### PR TITLE
fix(precios): publicar snapshot antes de borrar PRECIO_OVERRIDE

### DIFF
--- a/public/js/estado.js
+++ b/public/js/estado.js
@@ -302,6 +302,10 @@ document.getElementById('json-pre').textContent = FULL_JSON.slice(0,800)+'...';
     } catch(sbEx){
       toast('⚠ Error Supabase: '+sbEx.message,'warn');
     }
+  } else {
+    // v91: antes este caso fallaba en silencio y el usuario creía que había publicado
+    console.error('_supabase es null al intentar publicar snapshot — el Asistente NO se actualizó');
+    toast('⚠ Supabase no inicializado — snapshot NO publicado. Recarga el panel.','err');
   }
 
   // Also offer direct V24 patch — generate the full updated HTML

--- a/public/js/precios.js
+++ b/public/js/precios.js
@@ -749,7 +749,25 @@ async function publicarVersion(){
     cambios={};
     _aprobaciones={};
 
-    // Limpiar overrides de materiales aceptados (ya absorbidos en precio publicado)
+    renderPrecios();
+    renderHistorial();
+    renderPreview();
+    toast(res?.ok
+      ? `✓ Versión "${label}" publicada en BD`
+      : `✓ Versión "${label}" guardada localmente (${items.length} materiales)`,'ok');
+
+    // v91 FIX: publicar snapshot al Asistente ANTES de borrar PRECIO_OVERRIDE.
+    // Antes se borraba primero y el snapshot quedaba con precios recalculados
+    // por calc() sin el override, dejando v_precios_activos y el snapshot desincronizados.
+    renderPublico();
+    try {
+      await generarAsistente(true);
+    } catch(e) {
+      console.error('generarAsistente falló:', e);
+      toast('⚠ Error publicando al Asistente: ' + (e.message||e), 'err');
+    }
+
+    // Ahora sí limpiar overrides de materiales aceptados (ya usados para el snapshot)
     aceptados.forEach(id=>{
       const matId = parseInt(id);
       if(PRECIO_OVERRIDE[matId]) delete PRECIO_OVERRIDE[matId];
@@ -758,18 +776,8 @@ async function publicarVersion(){
     if(_db) try{ await idbSaveConfig('precio_override', JSON.stringify(PRECIO_OVERRIDE)); }catch(e){}
     safeLS('rf_precio_override', JSON.stringify(PRECIO_OVERRIDE));
 
-    renderPrecios();
-    renderHistorial();
-    renderPreview();
-    toast(res?.ok
-      ? `✓ Versión "${label}" publicada en BD`
-      : `✓ Versión "${label}" guardada localmente (${items.length} materiales)`,'ok');
-
     // Auto-generar ficha de despacho al publicar
     setTimeout(()=> generarFichaDespacho(), 500);
-    // v84: auto-alimentar Tab E y generar Asistente Comercial
-    renderPublico();
-    setTimeout(function(){ generarAsistente(true); }, 1000);
 
   }catch(err){
     console.error('Error en publicarVersion:', err);


### PR DESCRIPTION
publicarVersion() borraba PRECIO_OVERRIDE inmediatamente después del apiPost, pero el snapshot al Asistente se armaba 1s después via setTimeout. Para entonces calc() ya no tenía el override y recalculaba el precio desde compra/margen/spread, dejando v_precios_activos con el valor correcto y asistente_snapshot con el valor recalculado.

Reordena publicarVersion() para que generarAsistente(true) se ejecute con await ANTES de borrar los overrides, y añade try/catch con toast de error explícito. También elimina el setTimeout(1000) innecesario.

Adicionalmente, generarAsistente() ya no falla en silencio si _supabase es null — ahora muestra toast de error y log en consola.