### PR TITLE
fix(precios): %E (comisión ejecutivo) default 0.25% en Tab C

### DIFF
--- a/public/js/utils.js
+++ b/public/js/utils.js
@@ -82,7 +82,8 @@ function calc(m, factor=1, suc=null) {
     if(pmax<plista) pmax=plista;
     pejec = Math.floor((plista+pmax)/2/10)*10;
   }
-  var pctE = (suc && COMISION_EJEC_POR_SUC[m.id] && COMISION_EJEC_POR_SUC[m.id][suc]!==undefined) ? COMISION_EJEC_POR_SUC[m.id][suc] : 0;
+  // v91: default 0.0025 (= 0.25%) — antes era 0; el valor sigue editable por celda en Tab C
+  var pctE = (suc && COMISION_EJEC_POR_SUC[m.id] && COMISION_EJEC_POR_SUC[m.id][suc]!==undefined) ? COMISION_EJEC_POR_SUC[m.id][suc] : 0.0025;
   var utilidadLista = plista>0 ? plista - compra : 0;
   var comisionEjec = Math.round(utilidadLista * pctE);
   return {lista:plista, ejec:pejec, max:pmax, compra:compra, neto:neto, sinMargen:sinMargen, flete:flete, margen:margen, mcSpread:mcSpread, pctE:pctE, comisionEjec:comisionEjec};


### PR DESCRIPTION
Antes el fallback de pctE en calc() era 0, así todos los materiales mostraban "0.00%" en la columna %E del Tab C - Precios & Márgenes. Ahora el default es 0.0025 (= 0.25%), aplicado vía fallback en calc(), así no se sobrescriben valores explícitos: cualquier celda que el usuario haya editado mantiene su valor; el resto muestra 0.25%.

La celda sigue siendo editable como antes (startEdSuc en precios.js:134).