### PR TITLE
chore: ignorar carpeta .local/ para archivos locales no versionables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 .env.local
 .env
 *.local
+.local/


### PR DESCRIPTION
Carpeta usada para artefactos de trabajo (PDFs, briefs, exports) que no deben publicarse en el repo público.

https://claude.ai/code/session_011MrAsWr7mLsZ2pFefRQCAa