### PR TITLE
docs(claude): declarar panel-rdo fuente de verdad única + reglas oper…

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+## Qué cambia
+<!-- resumen 1-3 líneas: qué problema resolvés / qué feature agregás -->
+
+## Tipo de cambio (label)
+- [ ] `risk:low` — texto, color, label, traducción, fix de typo
+- [ ] `risk:med` — lógica JS, nueva pestaña, query Supabase, CSS estructural
+- [ ] `risk:high` — auth/RLS, schema `curated.*`, deploys, secrets, `vercel.json`, `package.json`, `vite.config.js`
+
+## Checklist técnico
+<!-- marcá los que aplican; tachá los que no -->
+
+- [ ] Si toqué `public/panel-rdo.html`: probé login + cambio de silo + responsive mobile (<768px) en el preview Vercel de esta rama
+- [ ] Si creé tabla en `curated.*`: ejecuté `GRANT SELECT ON ... TO cesar_readonly` (sin esto, César/PowerBI rompe con `42501`)
+- [ ] Si toqué visibilidad por silo o usuario: sincronicé los 4 lugares:
+  - [ ] `panel.config_kv`
+  - [ ] política RLS
+  - [ ] vista `v_panel_silos_visibles`
+  - [ ] fallback HTML del panel (constantes `FALLBACK_*`)
+- [ ] Si toqué CSS: usé build local `/tailwind.css`, NO `cdn.tailwindcss.com`
+- [ ] Si toqué Edge Functions: bumpié versión + corrí `supabase functions deploy <nombre>`
+- [ ] Si tocaste schema curated: agregaste migración en `reciclean-rdo/supabase/migrations/` con nombre `YYYY-MM-DD_NNN_descripcion.sql`
+
+## Preview Vercel
+<!-- URL del deploy preview de esta rama -->
+<URL>
+
+## Riesgo de rollback
+<!-- bajo / medio / alto + cómo revertir si rompe -->
+
+## Bitácora paralela
+- [ ] Entrada agregada en `reciclean-manifiesto-diego/docs/BITACORA-PARALELO-MAYO-2026.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,19 @@
 # Sistema Comercial Reciclean-Farex
 
+## ⚠️ Este repo aloja DOS sistemas (leer antes de tocar nada)
+
+1. **Sistema Comercial** (descrito abajo) — gestión de precios materiales reciclables. Archivos: `index.html`, `asistente.html`, `login.html`, `public/js/*.js`.
+2. **Panel RDO** — desde 7-may-2026. **`public/panel-rdo.html` es la fuente de verdad ÚNICA**. El "espejo" en `reciclean-rdo/panel-html/` quedó archivado el 14-may-2026 tras desactualizarse en 1025 líneas. Ver sección "Panel RDO" más abajo.
+
+## ⚠️ Reglas operativas — TODOS los agentes IA leer primero
+
+1. **NUNCA pushear directo a `main` ni a `prod`** desde un agente IA. La rama `prod` está protegida y conectada a Vercel productivo; `main` es integración.
+2. **Toda sesión Replit** trabaja en su rama propia (`replit/<descripcion>`). Si no existe, crearla: `git checkout -b replit/<sprint>`. Vercel auto-genera preview deploy por rama.
+3. **Cambios a `public/panel-rdo.html`** requieren PR con checklist: bypass 4 lugares (`config_kv` + RLS + `v_panel_silos_visibles` + fallback HTML)? GRANTs `cesar_readonly` aplicados a tablas nuevas en `curated.*`? Mobile responsive verificado en preview?
+4. **El espejo a `reciclean-rdo` está MUERTO** desde 14-may-2026. NO copies `panel-rdo.html` a otro lugar. Fuente de verdad única: `public/panel-rdo.html`.
+5. **No tocar `package.json`, `vercel.json`, `vite.config.js`** sin aviso explícito a Pablo (sistemas@gestionrepchile.cl).
+6. **Bitácora diaria obligatoria** al cerrar el día: `reciclean-manifiesto-diego/docs/BITACORA-PARALELO-MAYO-2026.md`.
+
 ## ⭐ DOCUMENTO MAESTRO — leer antes que nada
 
 **Diagnóstico Organizacional Grupo Arancibia-Pinto v2** (05-may-2026 · 2da sesión)


### PR DESCRIPTION
…ativas para agentes IA

- Sección "Este repo aloja DOS sistemas" al inicio del CLAUDE.md
- Bloque "Reglas operativas — TODOS los agentes IA leer primero" con 6 reglas (no push directo a main/prod, ramas replit/*, checklist panel-rdo, espejo MUERTO, protección vercel.json/package.json, bitácora obligatoria)
- .github/pull_request_template.md con checklist técnico + labels risk:low/med/high

Parte de la decisión P1.0 — ver bitácora paralela 14-may.