### PR TITLE
chore: add .github/CODEOWNERS apuntando a @pablo-arancibia (D-PROTEC-PROD-003)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,23 @@
+# CODEOWNERS — reciclean-sistema
+# Ejecuta D-PROTEC-PROD-003 (Opción B) + D-PROTEC-PROD-003.1 (Camino 1),
+# firmadas por Dusan el 17-may-2026.
+# Detalle: reciclean-rdo/mayordomo/DECISIONES.md
+#
+# Régimen: todo PR cuyo destino sea `prod` requiere review aprobada por
+# Pablo (segundo par de ojos técnico). Dusan sigue siendo único firmante
+# de decisión Mayordomo; Pablo no decide producto, solo aprueba que el
+# diff técnico no rompe nada.
+#
+# Para que esto efectivamente bloquee merge a `prod`, la regla de branch
+# protection `prod` debe tener activado:
+#   - Require a pull request before merging
+#   - Require approvals: 1
+#   - Require review from Code Owners: TRUE   (crítico)
+#
+# Sin "Require review from Code Owners" GitHub ignora este archivo
+# para el gate.
+#
+# Sintaxis: <path> <@handle>
+# Más específico gana sobre más general.
+
+* @pablo-arancibia


### PR DESCRIPTION
﻿## Por qué

Ejecuta política firmada **D-PROTEC-PROD-003** del 17-may-2026 (`reciclean-rdo/mayordomo/DECISIONES.md`):

> Pablo se incorpora como collaborator del repo con `.github/CODEOWNERS` que lo nombra reviewer obligatorio para todo PR a `prod`. Dusan sigue siendo único firmante de decisión Mayordomo — Pablo aporta segundo par de ojos técnico.

Y **D-PROTEC-PROD-003.1** del mismo día (Camino 1): Pablo creó cuenta GitHub propia (`@pablo-arancibia`) para que el "review from Code Owners" no colapse a self-approve.

## Qué cambia

- **Crea:** `.github/CODEOWNERS` con `* @pablo-arancibia`.
- **No cambia código de la app.** Cero impacto runtime, cero impacto Vercel build.

## Mecánica futura de merge a `prod` tras este PR + activación branch protection

1. Dusan firma el PR en bandeja AM (gate decisión CEO Mayordomo).
2. Pablo pone "Approve" en GitHub (gate Code Owner técnico).
3. Check Vercel SUCCESS.
4. Merge automático.

Sin bypass admin salvo emergencia documentada.

## Pasos manuales pendientes post-merge (Dusan)

1. https://github.com/dusanarancibia-cpu/reciclean-sistema/settings/access → invitar `@pablo-arancibia` como collaborator (Triage o Write).
2. Esperar aceptación de Pablo (mail a `sistemas@gestionrepchile.cl`).
3. https://github.com/dusanarancibia-cpu/reciclean-sistema/settings/branches → regla `prod` → activar **Require review from Code Owners**.

## Test plan

- [ ] Branch creada `chore/codeowners-prod` desde `main`.
- [ ] Archivo `.github/CODEOWNERS` agregado, sintaxis válida.
- [ ] PR target `main`, MERGEABLE/CLEAN, sin conflictos.
- [ ] Tras merge + invitación + activación "Require review from Code Owners", el próximo PR a `prod` debe pedir aprobación de `@pablo-arancibia` y bloquear merge sin ella.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
