### PR TITLE
chore(codeowners): fix handle pablo-arancibia → arancibiapab01

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,4 +20,4 @@
 # Sintaxis: <path> <@handle>
 # Más específico gana sobre más general.
 
-* @pablo-arancibia
+* @arancibiapab01


### PR DESCRIPTION
## Summary

- Reemplaza `@pablo-arancibia` por `@arancibiapab01` en `.github/CODEOWNERS`.
- `@pablo-arancibia` quedó "decorativo" tras PR #26 (mergeado 17-may ~17:35): Pablo eligió ese handle el viernes pero NO completó la verificación de email → `gh api users/pablo-arancibia` devolvía 404.
- Esta semana Pablo creó su cuenta definitiva bajo `arancibia.pab01@gmail.com` con handle `arancibiapab01` (user id 284705882, verificado, collaborator Write aceptado 18-may ~10:30).

## Contexto

Ejecuta D-PROTEC-PROD-003 Opción B + D-PROTEC-PROD-003.1 Camino 1 (firmadas Dusan 17-may). Ver `reciclean-rdo/mayordomo/DECISIONES.md`.

## Test plan

- [x] `gh api users/arancibiapab01` devuelve 200 (user vivo, no 404)
- [x] `arancibiapab01` aparece como collaborator Write en https://github.com/dusanarancibia-cpu/reciclean-sistema/settings/access
- [ ] Post-merge: activar "Require review from Code Owners" en branch protection `prod` (Dusan, ~2 min)
- [ ] Post-merge: en PC Pablo `gh auth login` con cuenta `arancibiapab01` para que pushes locales salgan firmados como Pablo (ahora aún sale como `dusanarancibia-cpu`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)