### PR TITLE
panel-rdo: D-OP-04-v2 Ola 1.2 — tab Precios vigentes (material x sucursal)

### DIFF
--- a/public/panel-rdo.html
+++ b/public/panel-rdo.html
@@ -110,6 +110,7 @@
       <button data-tab="negocios"   class="tab-btn py-3 px-3 text-stone-600">💼 Negocios</button>
       <button data-tab="cotizador"  class="tab-btn py-3 px-3 text-stone-600">📋 Cotizador</button>
       <button data-tab="cierres"    class="tab-btn py-3 px-3 text-stone-600">📅 Cierres</button>
+      <button data-tab="precios"    class="tab-btn py-3 px-3 text-stone-600">💲 Precios</button>
       <button data-tab="admin" id="adminTab" class="tab-btn py-3 px-3 text-stone-600 hidden">⚙️ Admin</button>
     </div>
   </nav>
@@ -386,6 +387,76 @@
     </section>
 
     <!-- ═══════════════════════════════════════════════════════════
+         PESTAÑA PRECIOS (D-OP-04-v2 Ola 1.2 · lectura curated.vw_materiales_sucursal_precios_vigente)
+         Andrea ve qué precio defender antes de negociar.
+    ═══════════════════════════════════════════════════════════ -->
+    <section id="tabPrecios" class="tab-content hidden">
+      <div class="flex justify-between items-center mb-4">
+        <h2 class="text-xl font-bold text-stone-800">💲 Precios vigentes</h2>
+        <button onclick="loadPrecios()" class="text-sm text-green-700 hover:underline">↺ Recargar</button>
+      </div>
+
+      <!-- Filtros -->
+      <div class="bg-white p-4 rounded-lg shadow-sm mb-4 flex flex-wrap gap-3 items-end">
+        <div>
+          <label class="block text-xs text-stone-500 mb-1">Material</label>
+          <select id="precFiltroMaterial" onchange="loadPrecios()"
+                  class="border border-stone-300 rounded px-2 py-1.5 text-sm focus:border-green-700 focus:outline-none min-w-[12rem]">
+            <option value="">Todos</option>
+          </select>
+        </div>
+        <div>
+          <label class="block text-xs text-stone-500 mb-1">Sucursal</label>
+          <select id="precFiltroSucursal" onchange="loadPrecios()"
+                  class="border border-stone-300 rounded px-2 py-1.5 text-sm focus:border-green-700 focus:outline-none">
+            <option value="">Todas</option>
+          </select>
+        </div>
+        <div>
+          <label class="block text-xs text-stone-500 mb-1">Buscar material</label>
+          <input type="text" id="precBuscar" placeholder="Nombre…"
+                 oninput="loadPreciosBuscar(this.value)"
+                 class="border border-stone-300 rounded px-2 py-1.5 text-sm focus:border-green-700 focus:outline-none w-48">
+        </div>
+        <label class="flex items-center gap-1.5 text-xs text-stone-600 cursor-pointer pb-1.5">
+          <input type="checkbox" id="precMargenBajo" onchange="loadPrecios()" class="accent-green-700">
+          Solo margen &lt; 30%
+        </label>
+      </div>
+
+      <!-- KPI bar (resumen del filtro activo) -->
+      <div class="grid grid-cols-2 md:grid-cols-4 gap-3 mb-4">
+        <div class="bg-white p-4 rounded-lg shadow-sm">
+          <p class="text-xs text-stone-500">Combinaciones</p>
+          <p class="text-xl font-bold text-stone-700" id="precKpiTotal">—</p>
+        </div>
+        <div class="bg-white p-4 rounded-lg shadow-sm">
+          <p class="text-xs text-stone-500">Materiales únicos</p>
+          <p class="text-xl font-bold text-stone-700" id="precKpiMateriales">—</p>
+        </div>
+        <div class="bg-white p-4 rounded-lg shadow-sm">
+          <p class="text-xs text-stone-500">Margen promedio</p>
+          <p class="text-xl font-bold text-stone-700" id="precKpiMargenProm">—</p>
+        </div>
+        <div class="bg-white p-4 rounded-lg shadow-sm">
+          <p class="text-xs text-stone-500">Margen &lt; 30%</p>
+          <p class="text-xl font-bold text-red-600" id="precKpiMargenBajo">—</p>
+        </div>
+      </div>
+
+      <!-- Tabla precios -->
+      <div class="bg-white rounded-lg shadow-sm overflow-x-auto">
+        <div id="preciosTabla" class="text-sm text-stone-500 p-5">Cargando…</div>
+      </div>
+
+      <p class="text-xs text-stone-400 mt-3">
+        Fuente: <code>curated.vw_materiales_sucursal_precios_vigente</code> (precios vigentes con <code>vigencia_hasta IS NULL</code>).
+        Margen calculado como <code>(precio_venta − precio_compra) / precio_venta</code>.
+        Filtro por cliente: pendiente Ola 2 (requiere <code>staging.precios_propuestos</code>).
+      </p>
+    </section>
+
+    <!-- ═══════════════════════════════════════════════════════════
          PESTAÑA COTIZADOR
     ═══════════════════════════════════════════════════════════ -->
     <section id="tabCotizador" class="tab-content hidden">
@@ -548,8 +619,8 @@ let recordedUrl = null;
 //
 // FALLBACKS (defaults): si las consultas fallan (red/RLS/tabla vacía) el
 // HTML no se rompe — el navbar aparece como en versión hardcoded.
-const FALLBACK_TABS_GLOBALES   = ['portada', 'pesaje', 'facturacion', 'dieguito', 'comunicados', 'rdo', 'negocios', 'cotizador', 'cierres', 'admin'];
-const FALLBACK_TABS_TRANSVERSALES = ['portada', 'dieguito', 'comunicados', 'cierres'];
+const FALLBACK_TABS_GLOBALES   = ['portada', 'pesaje', 'facturacion', 'dieguito', 'comunicados', 'rdo', 'negocios', 'cotizador', 'cierres', 'precios', 'admin'];
+const FALLBACK_TABS_TRANSVERSALES = ['portada', 'dieguito', 'comunicados', 'cierres', 'precios'];
 const FALLBACK_BYPASS_EMAILS = [
   'gerencia@gestionrepchile.cl',
   'Dusan.arancibia@gmail.com',
@@ -947,6 +1018,7 @@ function setupTabs() {
       if (tabId === 'negocios')  loadNegocios();
       if (tabId === 'cotizador') initCotizador();
       if (tabId === 'cierres')   loadCierres();
+      if (tabId === 'precios')   initPrecios();
       if (tabId === 'dieguito')  initDieguito();
     });
   });
@@ -2351,6 +2423,158 @@ async function verCierresDetalle(empresaId, sucursalId, empNom, sucNom) {
 
 function cerrarCierresDetalle() {
   document.getElementById('cierresDetalle').classList.add('hidden');
+}
+
+// ============================================================
+// PESTAÑA PRECIOS (D-OP-04-v2 Ola 1.2)
+// Lectura curated.vw_materiales_sucursal_precios_vigente.
+// Andrea consulta antes de negociar (qué precio defender).
+// ============================================================
+
+let _preciosIniciado = false;
+let _preciosCache = [];        // resultado crudo de la vista
+let _preciosBuscarTimer = null;
+
+async function initPrecios() {
+  if (_preciosIniciado) {
+    // re-render con cache si ya está montado
+    loadPrecios();
+    return;
+  }
+  _preciosIniciado = true;
+
+  // Cargar catálogos de filtros en paralelo
+  const [matRes, sucRes] = await Promise.all([
+    sb.schema('curated').from('materiales').select('material_id, nombre').eq('activo', true).order('nombre'),
+    sb.schema('curated').from('sucursales').select('sucursal_id, nombre').eq('activa', true).order('nombre'),
+  ]);
+
+  const selMat = document.getElementById('precFiltroMaterial');
+  (matRes.data || []).forEach(m => {
+    const o = document.createElement('option');
+    o.value = m.material_id; o.textContent = m.nombre;
+    selMat.appendChild(o);
+  });
+
+  const selSuc = document.getElementById('precFiltroSucursal');
+  (sucRes.data || []).forEach(s => {
+    const o = document.createElement('option');
+    o.value = s.sucursal_id; o.textContent = s.nombre;
+    selSuc.appendChild(o);
+  });
+
+  await loadPrecios();
+}
+
+function loadPreciosBuscar(val) {
+  clearTimeout(_preciosBuscarTimer);
+  _preciosBuscarTimer = setTimeout(() => loadPrecios(), 300);
+}
+
+async function loadPrecios() {
+  const div = document.getElementById('preciosTabla');
+  div.innerHTML = '<p class="text-stone-400">Cargando…</p>';
+
+  const fmat = document.getElementById('precFiltroMaterial')?.value || '';
+  const fsuc = document.getElementById('precFiltroSucursal')?.value || '';
+  const buscar = (document.getElementById('precBuscar')?.value || '').trim().toLowerCase();
+  const margenBajoOnly = document.getElementById('precMargenBajo')?.checked === true;
+
+  // Cache de nombres material+sucursal en paralelo con la query principal
+  const matCacheP = sb.schema('curated').from('materiales').select('material_id, nombre');
+  const sucCacheP = sb.schema('curated').from('sucursales').select('sucursal_id, nombre');
+
+  let q = sb.schema('curated').from('vw_materiales_sucursal_precios_vigente')
+    .select('material_id, sucursal_id, vigencia_desde, vigencia_hasta, precio_compra_clp, precio_venta_clp, moneda, notas')
+    .is('vigencia_hasta', null);   // solo vigentes (sin cierre de vigencia)
+  if (fmat) q = q.eq('material_id', fmat);
+  if (fsuc) q = q.eq('sucursal_id', fsuc);
+
+  const { data, error } = await q.order('material_id').order('sucursal_id');
+
+  if (error) {
+    console.error('[D-OP-04-v2 1.2] loadPrecios error:', error);
+    div.innerHTML = `<div class="p-5"><p class="text-red-600 mb-2">No se pudo cargar los precios vigentes.</p>
+      <p class="text-xs text-stone-500">${escapeHtml(humanizeSupabaseError(error))}</p></div>`;
+    if (typeof showToast === 'function') showToast(humanizeSupabaseError(error), 'error');
+    return;
+  }
+
+  const [matCacheRes, sucCacheRes] = await Promise.all([matCacheP, sucCacheP]);
+  const matMap = new Map(((matCacheRes && matCacheRes.data) || []).map(m => [m.material_id, m.nombre || m.material_id]));
+  const sucMap = new Map(((sucCacheRes && sucCacheRes.data) || []).map(s => [s.sucursal_id, s.nombre || s.sucursal_id]));
+
+  // Enriquecer con nombre + margen calculado, aplicar filtros frontend.
+  let rows = (data || []).map(r => {
+    const matNom = matMap.get(r.material_id) || r.material_id;
+    const sucNom = sucMap.get(r.sucursal_id) || r.sucursal_id;
+    const compra = Number(r.precio_compra_clp);
+    const venta  = Number(r.precio_venta_clp);
+    const margenPct = (Number.isFinite(venta) && venta > 0) ? ((venta - compra) / venta) * 100 : null;
+    return { ...r, matNom, sucNom, margenPct };
+  });
+
+  if (buscar) rows = rows.filter(r => r.matNom.toLowerCase().includes(buscar));
+  if (margenBajoOnly) rows = rows.filter(r => r.margenPct !== null && r.margenPct < 30);
+
+  _preciosCache = rows;
+
+  // KPIs
+  document.getElementById('precKpiTotal').textContent = rows.length.toLocaleString('es-CL');
+  document.getElementById('precKpiMateriales').textContent = new Set(rows.map(r => r.material_id)).size.toLocaleString('es-CL');
+  const margenes = rows.map(r => r.margenPct).filter(m => m !== null);
+  document.getElementById('precKpiMargenProm').textContent = margenes.length
+    ? (margenes.reduce((a, b) => a + b, 0) / margenes.length).toFixed(1) + '%'
+    : '—';
+  document.getElementById('precKpiMargenBajo').textContent = rows.filter(r => r.margenPct !== null && r.margenPct < 30).length.toLocaleString('es-CL');
+
+  if (rows.length === 0) {
+    div.innerHTML = `<div class="p-8 text-center">
+      <p class="text-stone-400 text-base mb-1">Sin precios para este filtro.</p>
+      <p class="text-xs text-stone-400">Probá quitar filtros o revisá que la vista <code>vw_materiales_sucursal_precios_vigente</code> tenga datos vigentes.</p>
+    </div>`;
+    return;
+  }
+
+  const fmtCLP_n = n => (n === null || n === undefined || Number.isNaN(Number(n)))
+    ? '—'
+    : '$' + Math.round(Number(n)).toLocaleString('es-CL');
+
+  const rowsHtml = rows.map(r => {
+    const margenCls = r.margenPct === null
+      ? 'text-stone-400'
+      : r.margenPct < 30
+        ? 'text-red-600 font-bold'
+        : r.margenPct < 50
+          ? 'text-amber-700 font-semibold'
+          : 'text-green-700 font-semibold';
+    return `<tr class="border-b border-stone-100 hover:bg-stone-50">
+      <td class="py-2 px-3 font-medium text-stone-700">${escapeHtml(r.matNom)}</td>
+      <td class="py-2 px-3 text-stone-600">${escapeHtml(r.sucNom)}</td>
+      <td class="py-2 px-3 text-right text-stone-700">${fmtCLP_n(r.precio_compra_clp)}</td>
+      <td class="py-2 px-3 text-right text-stone-700">${fmtCLP_n(r.precio_venta_clp)}</td>
+      <td class="py-2 px-3 text-right ${margenCls}">${r.margenPct !== null ? r.margenPct.toFixed(1) + '%' : '—'}</td>
+      <td class="py-2 px-3 text-right text-stone-400 text-xs">${r.vigencia_desde ? new Date(r.vigencia_desde).toLocaleDateString('es-CL') : '—'}</td>
+      <td class="py-2 px-3 text-stone-500 text-xs">${escapeHtml(r.notas || '')}</td>
+    </tr>`;
+  }).join('');
+
+  div.innerHTML = `
+    <table class="min-w-full text-sm">
+      <thead class="bg-stone-50 text-stone-500 text-xs uppercase tracking-wide">
+        <tr>
+          <th class="py-2 px-3 text-left">Material</th>
+          <th class="py-2 px-3 text-left">Sucursal</th>
+          <th class="py-2 px-3 text-right">Compra (CLP)</th>
+          <th class="py-2 px-3 text-right">Venta (CLP)</th>
+          <th class="py-2 px-3 text-right">Margen</th>
+          <th class="py-2 px-3 text-right">Vigencia desde</th>
+          <th class="py-2 px-3 text-left">Notas</th>
+        </tr>
+      </thead>
+      <tbody>${rowsHtml}</tbody>
+    </table>
+    <p class="text-xs text-stone-400 p-3">${rows.length} fila(s) · margen rojo &lt;30% · ámbar 30-50% · verde ≥50%</p>`;
 }
 
 // ============================================================


### PR DESCRIPTION
## Summary
Nueva pestaña **💲 Precios** para que Andrea vea qué precio defender antes de negociar.
- Lectura \`curated.vw_materiales_sucursal_precios_vigente\` (14 vigentes hoy).
- Filtros: material · sucursal · buscar nombre · checkbox \"margen <30%\".
- KPI bar (4 cards): total · materiales únicos · margen promedio · cuántos con margen bajo.
- Tabla con margen coloreado: rojo <30% / ámbar 30-50% / verde ≥50%.

Refs: ítem cola D-OP-04-v2 Ola 1.2 \`416917de\`. Parte 2 del bundle Ola 1 (parte 1 = PR #30 con 1.1+1.3+1.4).

## Cambios

### Frontend (\`public/panel-rdo.html\`, +226/-2)
- Botón nav \`<button data-tab=\"precios\">💲 Precios</button>\`.
- \`<section id=\"tabPrecios\">\` con filtros + KPI bar + tabla + nota al pie.
- Hook \`setupTabs\`: \`if (tabId === 'precios') initPrecios();\`
- Funciones nuevas: \`initPrecios()\` (carga catálogos), \`loadPrecios()\` (query + render), \`loadPreciosBuscar()\` (debounce input).
- Bypass HTML: \`precios\` añadido a \`FALLBACK_TABS_GLOBALES\` + \`FALLBACK_TABS_TRANSVERSALES\`.

### BD (migración aplicada vía MCP)
- \`d_op_04_v2_ola_1_2_seed_pestana_precios\` — INSERT en \`panel.pestanas\` (codigo='precios', es_transversal=true, requiere_perfil=NULL, orden=58). \`ON CONFLICT DO NOTHING\`.

## Limitación conocida
La vista fuente \`vw_materiales_sucursal_precios_vigente\` **NO incluye cliente** — sólo material × sucursal × vigencia. El item pedía \"× cliente × material × sucursal\". El filtro por cliente queda como TODO Ola 2 cuando exista \`staging.precios_propuestos\` (item 2.1). Nota visible al pie del tab.

## Test plan
- [ ] Smoke en Vercel preview: abrir panel → ver tab \"💲 Precios\" entre Cierres y Admin.
- [ ] Click en tab → tabla con 14 filas + KPIs poblados.
- [ ] Filtro por material → tabla se reduce.
- [ ] Filtro por sucursal → tabla se reduce.
- [ ] Buscar \"fierro\" → filtro por nombre material (300ms debounce).
- [ ] Checkbox \"margen <30%\" → solo filas margen bajo, KPI cambia.
- [ ] Verificar coloreado margen: <30% rojo, 30-50% ámbar, ≥50% verde.
- [ ] Mobile: KPIs colapsan 2 cols, tabla scroll horizontal.
- [ ] Pestaña visible en todos los silos (es_transversal=true).

## Checklist \`public/panel-rdo.html\` (CLAUDE.md)
- [x] No toca \`package.json\` / \`vercel.json\` / \`vite.config.js\`
- [x] No toca \`index.html\` / \`asistente.html\` / \`login.html\` ni \`public/js/*.js\`
- [x] Mobile responsive (grid \`grid-cols-2 md:grid-cols-4\`, tabla \`overflow-x-auto\`)
- [x] Bypass 4 lugares: \`config_kv\` N/A · RLS heredada (vista vigente ya con grant a anon/authenticated) · \`v_panel_silos_visibles\` N/A (transversal sin filtro silo) · fallback HTML actualizado ✓
- [x] GRANTs \`cesar_readonly\`: la vista \`vw_materiales_sucursal_precios_vigente\` y catálogos \`materiales\`/\`sucursales\` ya tienen GRANT SELECT a roles públicos

🤖 Generated with [Claude Code](https://claude.com/claude-code)