### PR TITLE
panel-rdo: D-OP-12 Tab Oportunidades Kanban (pipeline visual)

### DIFF
--- a/public/panel-rdo.html
+++ b/public/panel-rdo.html
@@ -205,6 +205,7 @@
         <button data-tab="operativos" class="tab-btn py-3 px-3 text-stone-600"         role="tab" aria-selected="false" aria-controls="tabOperativos">📑 OPERATIVOS</button>
         <button data-tab="reconciliacion" class="tab-btn py-3 px-3 text-stone-600"     role="tab" aria-selected="false" aria-controls="tabReconciliacion">🔗 Reconciliación</button>
         <button data-tab="cartera"        class="tab-btn py-3 px-3 text-stone-600"     role="tab" aria-selected="false" aria-controls="tabCartera">👥 Cartera</button>
+        <button data-tab="oportunidades" class="tab-btn py-3 px-3 text-stone-600"      role="tab" aria-selected="false" aria-controls="tabOportunidades">🎯 Oportunidades</button>
         <button data-tab="admin" id="adminTab" class="tab-btn py-3 px-3 text-stone-600 hidden" role="tab" aria-selected="false" aria-controls="tabAdmin">⚙️ Admin</button>
       </div>
       <span class="chevron-more" aria-hidden="true">›</span>
@@ -887,6 +888,65 @@
     </section>
 
     <!-- ═══════════════════════════════════════════════════════════
+         PESTAÑA OPORTUNIDADES KANBAN (D-OP-12)
+    ═══════════════════════════════════════════════════════════ -->
+    <section id="tabOportunidades" class="tab-content hidden">
+      <div class="flex justify-between items-center mb-4">
+        <h2 class="text-xl font-bold text-stone-800">🎯 Oportunidades — Pipeline Kanban</h2>
+        <button onclick="loadOportunidadesKanban()" class="text-sm text-green-700 hover:underline">↺ Recargar</button>
+      </div>
+
+      <div id="oppKanban" class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-3">
+        <div class="text-stone-400 col-span-full text-center py-6">Cargando…</div>
+      </div>
+
+      <!-- Drawer oportunidad -->
+      <div id="oppDrawer" class="hidden fixed inset-0 bg-black bg-opacity-50 z-50 flex justify-end">
+        <div class="bg-white w-full max-w-md h-full overflow-y-auto p-5">
+          <div class="flex justify-between items-start mb-3">
+            <div>
+              <h3 id="oppDrawerTitulo" class="text-lg font-bold text-stone-800">—</h3>
+              <p id="oppDrawerCliente" class="text-sm text-stone-600">—</p>
+            </div>
+            <button onclick="oppCerrarDrawer()" class="text-stone-500 hover:text-stone-800 text-2xl leading-none" aria-label="Cerrar">×</button>
+          </div>
+
+          <div id="oppDrawerTags" class="flex flex-wrap gap-2 mb-4"></div>
+
+          <div class="bg-stone-50 rounded p-3 mb-4">
+            <div class="text-xs text-stone-500 mb-1">Estado actual</div>
+            <div id="oppDrawerEstadoActual" class="font-medium text-stone-800 mb-2">—</div>
+            <label for="oppDrawerEstadoSelect" class="block text-xs text-stone-500 mb-1">Cambiar a:</label>
+            <select id="oppDrawerEstadoSelect"
+                    class="w-full border border-stone-300 rounded px-2 py-1.5 text-sm focus:border-green-700 focus:outline-none mb-2">
+              <option value="recibida">Recibida</option>
+              <option value="en_evaluacion">En evaluación</option>
+              <option value="ganada">Ganada</option>
+              <option value="perdida">Perdida</option>
+            </select>
+            <button id="oppDrawerMoverBtn" onclick="oppMoverEstado()"
+                    class="w-full bg-green-700 hover:bg-green-800 text-white text-sm py-1.5 rounded">
+              Mover
+            </button>
+            <div id="oppDrawerMsg" class="hidden mt-2 text-xs p-2 rounded"></div>
+          </div>
+
+          <dl class="text-sm space-y-2">
+            <div><dt class="text-xs text-stone-500">Monto estimado</dt><dd id="oppDrawerMonto" class="font-medium">—</dd></div>
+            <div><dt class="text-xs text-stone-500">Probabilidad</dt><dd id="oppDrawerProb">—</dd></div>
+            <div><dt class="text-xs text-stone-500">Tipo / Origen</dt><dd id="oppDrawerTipo">—</dd></div>
+            <div><dt class="text-xs text-stone-500">Responsable</dt><dd id="oppDrawerResp">—</dd></div>
+            <div><dt class="text-xs text-stone-500">Sucursal</dt><dd id="oppDrawerSucursal">—</dd></div>
+            <div><dt class="text-xs text-stone-500">Fecha recepción</dt><dd id="oppDrawerFechaRec">—</dd></div>
+            <div><dt class="text-xs text-stone-500">Fecha cierre</dt><dd id="oppDrawerFechaCierre">—</dd></div>
+            <div><dt class="text-xs text-stone-500">Viabilidad</dt><dd id="oppDrawerViabilidad">—</dd></div>
+            <div><dt class="text-xs text-stone-500">Descripción</dt><dd id="oppDrawerDesc" class="whitespace-pre-line text-stone-700">—</dd></div>
+          </dl>
+        </div>
+      </div>
+    </section>
+
+    <!-- ═══════════════════════════════════════════════════════════
          PESTAÑA COTIZADOR
     ═══════════════════════════════════════════════════════════ -->
     <section id="tabCotizador" class="tab-content hidden">
@@ -1051,7 +1111,7 @@ let recordedUrl = null;
 //
 // FALLBACKS (defaults): si las consultas fallan (red/RLS/tabla vacía) el
 // HTML no se rompe — el navbar aparece como en versión hardcoded.
-const FALLBACK_TABS_GLOBALES   = ['portada', 'pesaje', 'facturacion', 'dieguito', 'comunicados', 'rdo', 'negocios', 'cotizador', 'cierres', 'precios', 'operativos', 'reconciliacion', 'cartera', 'admin'];
+const FALLBACK_TABS_GLOBALES   = ['portada', 'pesaje', 'facturacion', 'dieguito', 'comunicados', 'rdo', 'negocios', 'cotizador', 'cierres', 'precios', 'operativos', 'reconciliacion', 'cartera', 'oportunidades', 'admin'];
 const FALLBACK_TABS_TRANSVERSALES = ['portada', 'dieguito', 'comunicados', 'cierres', 'precios', 'operativos'];
 const FALLBACK_BYPASS_EMAILS = [
   'gerencia@gestionrepchile.cl',
@@ -1617,6 +1677,7 @@ function setupTabs() {
       if (tabId === 'operativos') initOperativos();
       if (tabId === 'reconciliacion') initReconciliacion();
       if (tabId === 'cartera')   initCartera();
+      if (tabId === 'oportunidades') initOportunidadesKanban();
       if (tabId === 'dieguito')  initDieguito();
     });
   });
@@ -4307,6 +4368,139 @@ window.carAplicarCategoria = async function() {
   await loadCartera();
   // Refrescar drawer
   if (_cartDrawerClienteId) await carAbrirDrawer(_cartDrawerClienteId);
+};
+
+// ============================================================
+// TAB OPORTUNIDADES KANBAN (D-OP-12)
+// ============================================================
+const OPP_ESTADOS = [
+  { id: 'recibida',      nombre: 'Recibida',      color: 'bg-stone-100' },
+  { id: 'en_evaluacion', nombre: 'En evaluación', color: 'bg-amber-50' },
+  { id: 'ganada',        nombre: 'Ganada',        color: 'bg-green-50' },
+  { id: 'perdida',       nombre: 'Perdida',       color: 'bg-red-50' },
+];
+let _oppDrawerId = null;
+let _oppSucursalesMap = null;
+
+async function initOportunidadesKanban() {
+  if (!_oppSucursalesMap) {
+    const sucs = await ensureSucursalesCache();
+    _oppSucursalesMap = new Map((sucs || []).map(s => [s.sucursal_id, s.nombre]));
+  }
+  await loadOportunidadesKanban();
+}
+
+async function loadOportunidadesKanban() {
+  const cont = document.getElementById('oppKanban');
+  cont.innerHTML = '<div class="text-stone-400 col-span-full text-center py-6">Cargando…</div>';
+
+  const [{ data: opps, error }, { data: kpis, error: e2 }] = await Promise.all([
+    sb.schema('curated').from('vw_oportunidades_kanban').select('*').order('fecha_recepcion', { ascending: false }),
+    sb.schema('curated').rpc('oportunidades_kanban_kpis')
+  ]);
+  if (error) { cont.innerHTML = `<div class="text-red-600 col-span-full">Error: ${escapeHtml(error.message)}</div>`; return; }
+
+  const porEstado = {};
+  OPP_ESTADOS.forEach(e => porEstado[e.id] = []);
+  (opps || []).forEach(o => {
+    if (!porEstado[o.estado]) porEstado[o.estado] = [];
+    porEstado[o.estado].push(o);
+  });
+  const kpisMap = new Map((kpis || []).map(k => [k.estado, k]));
+
+  cont.innerHTML = OPP_ESTADOS.map(e => {
+    const k = kpisMap.get(e.id);
+    const cant = k ? Number(k.cant) : 0;
+    const uf = k ? Number(k.uf_total) : 0;
+    const cards = (porEstado[e.id] || []).map(oppRenderCard).join('') || '<div class="text-xs text-stone-400 italic py-3 text-center">Sin oportunidades</div>';
+    return `
+      <div class="${e.color} rounded-lg p-3 min-h-[400px]">
+        <div class="flex justify-between items-baseline mb-2 pb-2 border-b border-stone-200">
+          <h3 class="font-semibold text-stone-800">${escapeHtml(e.nombre)}</h3>
+          <div class="text-xs text-stone-500">${cant} · ${uf.toLocaleString('es-CL', { maximumFractionDigits: 1 })} UF</div>
+        </div>
+        <div class="space-y-2">${cards}</div>
+      </div>`;
+  }).join('');
+}
+
+function oppRenderCard(o) {
+  const monto = o.valor_estimado_uf ? Number(o.valor_estimado_uf).toLocaleString('es-CL', { maximumFractionDigits: 1 }) + ' UF' : '';
+  const fechaRec = o.fecha_recepcion ? new Date(o.fecha_recepcion).toLocaleDateString('es-CL') : '';
+  return `
+    <div onclick="oppAbrirDrawer('${escapeHtml(o.oportunidad_id)}')"
+         class="bg-white rounded shadow-sm p-2 cursor-pointer hover:shadow-md transition">
+      <div class="font-medium text-sm text-stone-800 mb-1">${escapeHtml(o.titulo || '(sin título)')}</div>
+      <div class="text-xs text-stone-600 mb-1 truncate">${escapeHtml(o.cliente_nombre || '')}</div>
+      <div class="flex justify-between text-xs text-stone-500">
+        <span>${escapeHtml(monto)}</span>
+        <span>${escapeHtml(fechaRec)}</span>
+      </div>
+      ${o.responsable ? `<div class="text-xs text-stone-400 mt-1">👤 ${escapeHtml(o.responsable)}</div>` : ''}
+    </div>`;
+}
+
+window.oppAbrirDrawer = async function(oppId) {
+  _oppDrawerId = oppId;
+  document.getElementById('oppDrawer').classList.remove('hidden');
+  document.getElementById('oppDrawerMsg').classList.add('hidden');
+  ['oppDrawerTitulo','oppDrawerCliente','oppDrawerEstadoActual','oppDrawerMonto','oppDrawerProb','oppDrawerTipo','oppDrawerResp','oppDrawerSucursal','oppDrawerFechaRec','oppDrawerFechaCierre','oppDrawerViabilidad','oppDrawerDesc'].forEach(id => document.getElementById(id).textContent = '—');
+  document.getElementById('oppDrawerTags').innerHTML = '';
+
+  const { data: o, error } = await sb.schema('curated').from('vw_oportunidades_kanban').select('*').eq('oportunidad_id', oppId).maybeSingle();
+  if (error || !o) {
+    document.getElementById('oppDrawerTitulo').textContent = 'Error cargando oportunidad';
+    return;
+  }
+  document.getElementById('oppDrawerTitulo').textContent = o.titulo || '(sin título)';
+  document.getElementById('oppDrawerCliente').textContent = o.cliente_nombre + (o.cliente_rut ? ' · ' + o.cliente_rut : '');
+  document.getElementById('oppDrawerEstadoActual').textContent = (OPP_ESTADOS.find(e => e.id === o.estado) || {}).nombre || o.estado;
+  document.getElementById('oppDrawerEstadoSelect').value = o.estado;
+  document.getElementById('oppDrawerMonto').textContent = o.valor_estimado_uf ? Number(o.valor_estimado_uf).toLocaleString('es-CL', { maximumFractionDigits: 2 }) + ' UF' : '—';
+  document.getElementById('oppDrawerProb').textContent = o.probabilidad_pct != null ? o.probabilidad_pct + '%' : '—';
+  document.getElementById('oppDrawerTipo').textContent = [o.tipo, o.origen].filter(Boolean).join(' / ') || '—';
+  document.getElementById('oppDrawerResp').textContent = o.responsable || '—';
+  document.getElementById('oppDrawerSucursal').textContent = o.sucursal_id ? (_oppSucursalesMap.get(o.sucursal_id) || o.sucursal_id) : '—';
+  document.getElementById('oppDrawerFechaRec').textContent = o.fecha_recepcion ? new Date(o.fecha_recepcion).toLocaleDateString('es-CL') : '—';
+  document.getElementById('oppDrawerFechaCierre').textContent = o.fecha_cierre ? new Date(o.fecha_cierre).toLocaleDateString('es-CL') : '—';
+  document.getElementById('oppDrawerViabilidad').textContent = o.viabilidad_resultado || '—';
+  document.getElementById('oppDrawerDesc').textContent = o.descripcion || '—';
+
+  const tags = [];
+  if (o.viabilidad_resultado === 'viable') tags.push('<span class="text-xs px-2 py-0.5 bg-green-100 text-green-800 rounded">✓ viable</span>');
+  if (o.viabilidad_resultado === 'no_viable') tags.push('<span class="text-xs px-2 py-0.5 bg-red-100 text-red-800 rounded">✗ no viable</span>');
+  document.getElementById('oppDrawerTags').innerHTML = tags.join('');
+};
+
+window.oppCerrarDrawer = function() {
+  document.getElementById('oppDrawer').classList.add('hidden');
+  _oppDrawerId = null;
+};
+
+window.oppMoverEstado = async function() {
+  if (!_oppDrawerId) return;
+  const nuevoEstado = document.getElementById('oppDrawerEstadoSelect').value;
+  const msg = document.getElementById('oppDrawerMsg');
+  const btn = document.getElementById('oppDrawerMoverBtn');
+  msg.classList.add('hidden');
+  btn.disabled = true; btn.textContent = 'Moviendo…';
+
+  const { error } = await sb.schema('curated').from('oportunidades')
+    .update({ estado: nuevoEstado, updated_by: (currentUser || 'desconocido') })
+    .eq('oportunidad_id', _oppDrawerId);
+  btn.disabled = false; btn.textContent = 'Mover';
+
+  if (error) {
+    msg.className = 'mt-2 text-xs p-2 rounded bg-red-50 text-red-700';
+    msg.textContent = 'Error: ' + error.message;
+    msg.classList.remove('hidden');
+    return;
+  }
+  msg.className = 'mt-2 text-xs p-2 rounded bg-green-50 text-green-700';
+  msg.textContent = 'Estado actualizado.';
+  msg.classList.remove('hidden');
+  await loadOportunidadesKanban();
+  if (_oppDrawerId) await oppAbrirDrawer(_oppDrawerId);
 };
 
 // ---------- INIT ----------


### PR DESCRIPTION
## Resumen

Tab nuevo **Oportunidades** con vista Kanban 4 columnas (recibida → en_evaluacion → ganada / perdida). Andrea + Dusan pueden ver pipeline visual de las 36 oportunidades RDO + mover entre estados con un click.

> Nota: estas son las oportunidades RDO internas (`curated.oportunidades`), distintas de las 10.214 oportunidades CRM Impulsa que viven en el tab Reconciliación (PR #36).

## Backend (aplicado vía MCP esta sesión)

1. `curated.vw_oportunidades_kanban`: vista oportunidades + LEFT JOIN clientes (razón social + RUT).
2. `curated.oportunidades_kanban_kpis()`: RPC con counts + UF total por estado.
3. UPDATE policy + grant en `curated.oportunidades` para mover de estado desde el panel (anon + authenticated).
4. `UPDATE panel.pestanas SET activa=true` para `oportunidades`.

## Frontend (+195 líneas)

- Tab "Oportunidades" entre OPERATIVOS y Admin.
- **Kanban 4 columnas** responsive (1 col mobile, 2 tablet, 4 desktop):
  - Recibida (7 · 42 UF)
  - En evaluación (18 · 159 UF)
  - Ganada (6 · 61.5 UF)
  - Perdida (5 · 0 UF)
- **Card** por oportunidad: título, cliente, monto, fecha, responsable.
- **Drawer** al click de card:
  - Header título + cliente + RUT
  - Combo "Cambiar estado" + botón Mover (refresh automático del kanban)
  - Metadata: monto, probabilidad, tipo/origen, responsable, sucursal, fechas, viabilidad, descripción

## Test plan

- [ ] Tab visible para perfiles `comercial`, `dusan`, `admin` (silos 01, 07, 10).
- [ ] Kanban muestra 4 columnas con totales: 7/18/6/5 (total 36).
- [ ] Click en una card → drawer con datos.
- [ ] Cambiar estado de una card → la card desaparece de su columna y aparece en la nueva.
- [ ] KPIs (UF totales por columna) se recalculan post-mover.

## Out of scope MVP (v2)

- Drag-drop entre columnas (click-to-move suficiente para 36 cards).
- Filtros (sucursal, responsable, tipo).
- Mismatch etapas Reciclean vs Farex (mencionado payload, sprint 3).
- Edición de campos de la oportunidad.

## Spec

Escrita: `mayordomo/PLAN-2026/specs-tabs-faltantes/spec-tab-oportunidades.md` (commit en repo reciclean-rdo aparte).

Closes cola item `8357858c-b6b6-42f0-a09c-dfcf7144e134` (D-OP-12, signed Dusan 19-may).

🤖 Generated with [Claude Code](https://claude.com/claude-code)