### PR TITLE
E360: menú contextual + data-entity en tabs (D-MISMATCH Mig 035 frontend)

### DIFF
--- a/public/js/e360-context-menu.js
+++ b/public/js/e360-context-menu.js
@@ -1,0 +1,202 @@
+// ============================================================
+// public/js/e360-context-menu.js
+// Menu contextual E360 — D-MISMATCH Mig 035 frontend
+// Click-derecho sobre [data-entity-type][data-entity-id] dispara
+// un menú flotante con los ecosistemas / capas / objetivos
+// vinculados a esa entidad RDO via curated.rdo_e360_links.
+// ============================================================
+(function () {
+  'use strict';
+
+  if (typeof window === 'undefined') return;
+  if (window.__E360_MENU_LOADED__) return;
+  window.__E360_MENU_LOADED__ = true;
+
+  const CACHE = new Map();           // key: "tipo|id|nivel" -> slice JSON
+  const CACHE_MAX = 200;
+  let menuEl = null;
+  let closeListener = null;
+
+  function getSb() {
+    return window.sb || (typeof sb !== 'undefined' ? sb : null);
+  }
+
+  function detectarNivel(target) {
+    if (target.closest('[data-context-level="proceso"]')) return 'proceso';
+    if (target.closest('[data-context-level="vista"]'))    return 'vista';
+    return 'campo';
+  }
+
+  function esc(s) {
+    if (s == null) return '';
+    return String(s)
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+  }
+
+  function cacheTrim() {
+    if (CACHE.size <= CACHE_MAX) return;
+    const keys = Array.from(CACHE.keys()).slice(0, CACHE.size - CACHE_MAX);
+    keys.forEach(k => CACHE.delete(k));
+  }
+
+  async function fetchSlice(tipo, id, nivel) {
+    const key = `${tipo}|${id}|${nivel}`;
+    if (CACHE.has(key)) return CACHE.get(key);
+    const sb = getSb();
+    if (!sb) return { error: 'cliente Supabase no inicializado' };
+    const { data, error } = await sb
+      .schema('curated')
+      .rpc('f_e360_slice_for_entity', { p_tipo: tipo, p_id: id, p_nivel: nivel });
+    if (error) return { error: error.message };
+    CACHE.set(key, data);
+    cacheTrim();
+    return data;
+  }
+
+  function entityHeader(tipo) {
+    const map = {
+      oportunidad:  ['🎯', 'Oportunidad'],
+      cliente:      ['👥', 'Cliente'],
+      material:     ['📦', 'Material'],
+      trabajador:   ['👤', 'Trabajador'],
+      sucursal:     ['📍', 'Sucursal'],
+      empresa:      ['🏢', 'Empresa'],
+      servicio:     ['🛠️', 'Servicio'],
+      oferente:     ['💼', 'Oferente'],
+      factura:      ['🧾', 'Factura'],
+      cierre:       ['📅', 'Cierre'],
+      compra_diesel:['⛽', 'Diesel'],
+    };
+    return map[tipo] || ['•', tipo];
+  }
+
+  function renderMenu(slice, x, y, fallbackTitulo) {
+    closeMenu();
+    if (slice?.error) {
+      menuEl = document.createElement('div');
+      menuEl.className = 'fixed z-[9999] bg-white shadow-xl border border-red-300 rounded-lg p-3 text-sm text-red-700';
+      menuEl.style.left = x + 'px'; menuEl.style.top = y + 'px';
+      menuEl.textContent = 'Error E360: ' + slice.error;
+      document.body.appendChild(menuEl);
+      attachCloseListener();
+      return;
+    }
+
+    const entity = slice?.entity || {};
+    const [emoji, label] = entityHeader(entity.tipo);
+    const ecos = Array.isArray(slice?.ecosistemas_e360) ? slice.ecosistemas_e360 : [];
+    const capas = Array.isArray(slice?.capas_e360) ? slice.capas_e360 : [];
+    const objs = Array.isArray(slice?.objetivos_e360) ? slice.objetivos_e360 : [];
+    const kpis = Array.isArray(slice?.kpis) ? slice.kpis : [];
+    const decs = Array.isArray(slice?.decisiones) ? slice.decisiones : [];
+
+    const lines = [];
+    lines.push(`<div class="px-3 py-2 bg-stone-50 border-b border-stone-200 font-semibold text-stone-800">${emoji} ${esc(label)}: <span class="text-stone-600 font-normal">${esc(fallbackTitulo || entity.id || '')}</span></div>`);
+
+    function seccion(titulo, items, renderItem, vacioMsg) {
+      lines.push(`<div class="px-3 pt-2 pb-1 text-xs font-semibold text-stone-500 uppercase tracking-wide">${esc(titulo)} <span class="text-stone-400 font-normal">(${items.length})</span></div>`);
+      if (items.length === 0) {
+        lines.push(`<div class="px-3 pb-2 text-xs text-stone-400 italic">${esc(vacioMsg || 'Sin vínculos')}</div>`);
+        return;
+      }
+      lines.push('<div class="pb-1">');
+      items.slice(0, 6).forEach(it => lines.push(renderItem(it)));
+      if (items.length > 6) lines.push(`<div class="px-3 py-1 text-xs text-stone-400">+ ${items.length - 6} más</div>`);
+      lines.push('</div>');
+    }
+
+    seccion('🌐 Ecosistemas E360', ecos, (e) => `
+      <div class="px-3 py-1 hover:bg-stone-50 cursor-default flex items-center gap-2">
+        <span class="text-xs text-stone-400 font-mono w-14">${esc(e.id)}</span>
+        <span class="text-sm text-stone-700 flex-1">${esc(e.nombre)}</span>
+        <span class="text-xs text-stone-400">${esc(e.tipo_link)}</span>
+        <span class="text-xs px-1.5 py-0.5 rounded ${e.inferido ? 'bg-stone-100 text-stone-500' : 'bg-green-100 text-green-700'}">${e.inferido ? 'auto' : 'humano'} ${e.fuerza}</span>
+      </div>`,
+      'Sin ecosistemas vinculados');
+
+    seccion('📂 Capas', capas, (c) => `
+      <div class="px-3 py-1 hover:bg-stone-50 cursor-default flex items-center gap-2">
+        <span class="text-xs text-stone-400 font-mono w-10">${esc(c.numero)}</span>
+        <span class="text-sm text-stone-700 flex-1">${esc(c.nombre)} <span class="text-stone-400 text-xs">· ${esc(c.ecosistema_nombre)}</span></span>
+        <span class="text-xs text-stone-400">${esc(c.fuerza)}</span>
+      </div>`,
+      'Sin capas (etapa A solo agrega ecosistemas — capas curadas vienen etapa B)');
+
+    seccion('🎯 Objetivos', objs, (o) => `
+      <div class="px-3 py-1 hover:bg-stone-50 cursor-default">
+        <div class="text-sm text-stone-700">${esc(o.objetivo)}</div>
+        <div class="text-xs text-stone-400">${esc(o.ecosistema_nombre)}${o.meta_valor ? ' · meta ' + esc(o.meta_valor) + ' ' + esc(o.meta_unidad || '') : ''}</div>
+      </div>`,
+      'Sin objetivos vinculados');
+
+    if (kpis.length > 0) seccion('📊 KPIs', kpis, (k) => `<div class="px-3 py-1 text-sm text-stone-700">${esc(k.nombre || k)}</div>`, 'Sin KPIs');
+    if (decs.length > 0) seccion('📋 Decisiones', decs, (d) => `<div class="px-3 py-1 text-sm text-stone-700">${esc(d.id || d)}: ${esc(d.titulo || '')}</div>`, 'Sin decisiones');
+
+    lines.push(`<div class="px-3 py-2 border-t border-stone-100 flex justify-between text-xs text-stone-400"><span>Nivel: ${esc(entity.nivel || 'campo')}</span><span>${slice?.metadata?.count_links ?? 0} links</span></div>`);
+
+    menuEl = document.createElement('div');
+    menuEl.className = 'fixed z-[9999] bg-white shadow-xl border border-stone-200 rounded-lg overflow-hidden text-sm';
+    menuEl.style.minWidth = '320px';
+    menuEl.style.maxWidth = '460px';
+    menuEl.style.maxHeight = '70vh';
+    menuEl.style.overflowY = 'auto';
+    menuEl.style.left = Math.min(x, window.innerWidth - 480) + 'px';
+    menuEl.style.top  = Math.min(y, window.innerHeight - 200) + 'px';
+    menuEl.innerHTML = lines.join('');
+    document.body.appendChild(menuEl);
+    attachCloseListener();
+  }
+
+  function attachCloseListener() {
+    closeListener = (ev) => {
+      if (!menuEl) return;
+      if (ev.type === 'keydown' && ev.key !== 'Escape') return;
+      if (ev.type === 'click' && menuEl.contains(ev.target)) return;
+      closeMenu();
+    };
+    setTimeout(() => {
+      document.addEventListener('click', closeListener, true);
+      document.addEventListener('keydown', closeListener, true);
+      document.addEventListener('contextmenu', closeListener, true);
+    }, 0);
+  }
+
+  function closeMenu() {
+    if (menuEl) {
+      menuEl.remove();
+      menuEl = null;
+    }
+    if (closeListener) {
+      document.removeEventListener('click', closeListener, true);
+      document.removeEventListener('keydown', closeListener, true);
+      document.removeEventListener('contextmenu', closeListener, true);
+      closeListener = null;
+    }
+  }
+
+  document.addEventListener('contextmenu', async (e) => {
+    const target = e.target.closest('[data-entity-type][data-entity-id]');
+    if (!target) return;
+    const tipo = target.dataset.entityType;
+    const id   = target.dataset.entityId;
+    if (!tipo || !id) return;
+    e.preventDefault();
+    const nivel = detectarNivel(target);
+    const fallback = target.dataset.entityNombre || target.textContent?.trim().slice(0, 60);
+
+    // Mostrar placeholder mientras carga
+    renderMenu({ entity: { tipo, id, nivel }, ecosistemas_e360: [], capas_e360: [], objetivos_e360: [], metadata: { count_links: 0 } }, e.clientX, e.clientY, fallback);
+
+    const slice = await fetchSlice(tipo, id, nivel);
+    renderMenu(slice, e.clientX, e.clientY, fallback);
+  });
+
+  // API pública para debug
+  window.e360 = {
+    clearCache: () => CACHE.clear(),
+    cacheSize:  () => CACHE.size,
+    closeMenu,
+  };
+
+})();

--- a/public/panel-rdo.html
+++ b/public/panel-rdo.html
@@ -4084,8 +4084,12 @@ function renderRecFila(f) {
   }
 
   const montoFmt = f.monto_raw ? f.monto_raw : '—';
+  // Si la oportunidad CRM está matcheada a un cliente RDO, exponer el cliente para el menú E360 (click-derecho)
+  const e360Attrs = f.cliente_id_rdo
+    ? `data-entity-type="cliente" data-entity-id="${escapeHtml(f.cliente_id_rdo)}" data-entity-nombre="${escapeHtml(f.cliente_nombre_rdo || '')}" title="Click-derecho: vínculos E360 del cliente RDO"`
+    : '';
   return `
-    <tr class="border-t border-stone-100 hover:bg-stone-50">
+    <tr class="border-t border-stone-100 hover:bg-stone-50" ${e360Attrs}>
       <td class="px-3 py-2 font-mono text-xs">${escapeHtml(f.crm_id || '')}</td>
       <td class="px-3 py-2">${escapeHtml(f.cliente_crm || '')}</td>
       <td class="px-3 py-2 font-mono text-xs">${escapeHtml(f.rut_crm || '—')}</td>
@@ -4274,7 +4278,10 @@ async function loadCartera() {
     if (c.external_id_crm) flags.push('<span title="Cruzado con CRM Impulsa">🔗</span>');
     if (!c.activo) flags.push('<span title="Inactivo" class="text-red-600">⛔</span>');
     return `
-      <tr class="border-t border-stone-100 hover:bg-stone-50 cursor-pointer" onclick="carAbrirDrawer('${escapeHtml(c.cliente_id)}')">
+      <tr class="border-t border-stone-100 hover:bg-stone-50 cursor-pointer"
+          data-entity-type="cliente" data-entity-id="${escapeHtml(c.cliente_id)}" data-entity-nombre="${escapeHtml(c.razon_social || '')}"
+          title="Click: detalle · Click-derecho: vínculos E360"
+          onclick="carAbrirDrawer('${escapeHtml(c.cliente_id)}')">
         <td class="px-3 py-2"><span class="font-medium text-stone-800">${escapeHtml(c.razon_social || '—')}</span></td>
         <td class="px-3 py-2 font-mono text-xs">${escapeHtml(c.rut || '—')}</td>
         <td class="px-3 py-2">${escapeHtml(sucNombre)}</td>
@@ -4477,6 +4484,8 @@ function oppRenderCard(o) {
   const fechaRec = o.fecha_recepcion ? new Date(o.fecha_recepcion).toLocaleDateString('es-CL') : '';
   return `
     <div onclick="oppAbrirDrawer('${escapeHtml(o.oportunidad_id)}')"
+         data-entity-type="oportunidad" data-entity-id="${escapeHtml(o.oportunidad_id)}" data-entity-nombre="${escapeHtml(o.titulo || '')}"
+         title="Click: detalle · Click-derecho: vínculos E360"
          class="bg-white rounded shadow-sm p-2 cursor-pointer hover:shadow-md transition">
       <div class="font-medium text-sm text-stone-800 mb-1">${escapeHtml(o.titulo || '(sin título)')}</div>
       <div class="text-xs text-stone-600 mb-1 truncate">${escapeHtml(o.cliente_nombre || '')}</div>
@@ -4650,5 +4659,8 @@ document.getElementById('resetPassword2').addEventListener('keypress', e => {
   if (e.key === 'Enter') setNewPassword();
 });
 </script>
+
+<!-- E360 context menu (D-MISMATCH Mig 035 frontend) -->
+<script src="/js/e360-context-menu.js"></script>
 </body>
 </html>

--- a/public/panel-rdo.html
+++ b/public/panel-rdo.html
@@ -2944,6 +2944,8 @@ async function loadNegocios(buscarOverride) {
           ).join('');
           return `
           <tr class="border-b hover:bg-stone-50 cursor-pointer"
+              data-entity-type="oportunidad" data-entity-id="${escapeHtml(n.oportunidad_id)}" data-entity-nombre="${escapeHtml(n.titulo || '')}"
+              title="Click: timeline · Click-derecho: vínculos E360"
               onclick="verTimeline('${escapeHtml(n.oportunidad_id)}', '${escapeHtml(n.titulo.replace(/'/g,"&#39;"))}')">
             <td class="py-2 px-3 font-medium text-stone-800 max-w-xs truncate">${escapeHtml(n.titulo)}</td>
             <td class="py-2 px-2 text-center">${escapeHtml(tipoBadge[n.tipo] || n.tipo)}</td>
@@ -3403,7 +3405,9 @@ async function loadPrecios() {
         : r.margenPct < 50
           ? 'text-amber-700 font-semibold'
           : 'text-green-700 font-semibold';
-    return `<tr class="border-b border-stone-100 hover:bg-stone-50">
+    return `<tr class="border-b border-stone-100 hover:bg-stone-50"
+        data-entity-type="material" data-entity-id="${escapeHtml(r.material_id)}" data-entity-nombre="${escapeHtml(r.matNom)}"
+        title="Click-derecho: vínculos E360">
       <td class="py-2 px-3 font-medium text-stone-700">${escapeHtml(r.matNom)}</td>
       <td class="py-2 px-3 text-stone-600">${escapeHtml(r.sucNom)}</td>
       <td class="py-2 px-3 text-right text-stone-700">${fmtCLP_n(r.precio_compra_clp)}</td>


### PR DESCRIPTION
## Resumen

Frontend de la **Mig 035 D-MISMATCH** (backend aplicado vía MCP esta sesión). Menú contextual E360 que aparece con click-derecho sobre cualquier elemento con `data-entity-type` + `data-entity-id`, mostrando los ecosistemas, capas y objetivos vinculados.

PC1/Dusan/Claude ya puede consumir la RPC `curated.f_e360_slice_for_entity` desde el panel v4 sin esperar este PR.

## Backend (ya aplicado, no parte de este PR)

- `curated.rdo_e360_links` (tabla polimórfica) — 178 links etapa A
- `curated.f_e360_slice_for_entity(tipo, id, nivel)` (RPC principal)
- `f_kpis_for_entity` + `f_decisiones_for_entity` (stubs sprint 2)
- RLS + 6 policies + GRANTs ecosystem.* a anon/authenticated

## Frontend (este PR)

### `public/js/e360-context-menu.js` — nuevo archivo, ~190 líneas vanilla JS

- IIFE sin dependencias externas, auto-carga al final del body.
- Listener global `contextmenu` con detección de closest entity.
- Cache in-memory (`Map`) con TTL implícito (límite 200 entradas).
- Detección de nivel `campo` / `proceso` / `vista` via `data-context-level`.
- Menú flotante con:
  - Header (emoji + tipo + nombre).
  - Sección **Ecosistemas** con `tipo_link` + `fuerza` + flag `auto`/`humano`.
  - Sección **Capas** (vacía en etapa A — etapa B la llena).
  - Sección **Objetivos**.
  - Sub-secciones KPIs / Decisiones cuando los stubs devuelvan data.
  - Footer con `count_links` + nivel.
- Cierre con click fuera / Escape / nuevo click-derecho.
- `window.e360` helper para debug.

### `public/panel-rdo.html` — integración en 3 tabs

- `<script src="/js/e360-context-menu.js"></script>` al final.
- `data-entity-*` en:
  - **Tab Cartera**: `<tr>` cliente (36 filas).
  - **Tab Oportunidades Kanban**: card oportunidad (36 cards).
  - **Tab Reconciliación CRM**: si la oportunidad CRM tiene `cliente_id_rdo` matcheado, expone el cliente RDO (sin match → sin menú).
- Tooltip `title="Click-derecho: vínculos E360"` para discovery.

## Test plan

- [ ] Tab **Cartera** → click-derecho sobre fila `Reciklo Talca` → menú muestra `eco_023 Clientes y Mercado · pertenece_a · fuerza 10`.
- [ ] Tab **Oportunidades Kanban** → click-derecho sobre card cualquier oport → menú muestra `eco_033 Ventas (pertenece_a 10)` + `eco_023 (medido_por 7)`.
- [ ] Tab **Reconciliación CRM** → click-derecho sobre fila con `cliente_id_rdo` → menú muestra los vínculos del cliente cruzado.
- [ ] Esc cierra el menú. Click fuera cierra. Nuevo click-derecho reabre en posición nueva.
- [ ] Segundo click-derecho sobre la misma entidad: respuesta inmediata (cache hit).

## Out of scope MVP (sprint 2)

- Etapa B: links categóricos finos (`material categoria_*` → `eco_026 Economía Circular`, etc.).
- UI curaduría humana (INSERT/UPDATE/DELETE links desde menú).
- Pre-fetch en cambio de tab (warm cache).
- Mediciones P95 < 200ms con `page-logger.js`.

Closes D-MISMATCH G1..G8 (DECISIONES.md firmadas 17-may por PC Cámaras bajo REGLAS-FIRMA-V02).

🤖 Generated with [Claude Code](https://claude.com/claude-code)