### PR TITLE
panel-rdo: FAB Diego conectado a panel.diego_bandeja

### DIFF
--- a/public/panel-rdo.html
+++ b/public/panel-rdo.html
@@ -3423,5 +3423,144 @@ document.getElementById('loginEmail').addEventListener('keypress', e => {
   if (e.key === 'Enter') login();
 });
 </script>
+
+<!-- ===== Diego FAB · chat conectado a panel.diego_bandeja ===== -->
+<style>
+  .diego-fab{position:fixed;right:24px;bottom:24px;width:60px;height:60px;background:linear-gradient(135deg,#059669,#047857);color:#fff;border-radius:50%;border:0;box-shadow:0 10px 25px -5px rgba(5,150,105,.45);display:flex;align-items:center;justify-content:center;cursor:pointer;transition:transform .2s ease;z-index:60}
+  .diego-fab:hover{transform:scale(1.08)}
+  .diego-fab-label{position:absolute;right:70px;top:50%;transform:translateY(-50%);background:#0f172a;color:#fff;padding:6px 12px;border-radius:8px;font-size:13px;white-space:nowrap;opacity:0;pointer-events:none;transition:opacity .2s ease}
+  .diego-fab:hover .diego-fab-label{opacity:1}
+  .diego-chat{position:fixed;right:24px;bottom:96px;width:340px;max-width:calc(100vw - 32px);background:#fff;border:1px solid #e2e8f0;border-radius:16px;box-shadow:0 16px 48px -12px rgba(15,23,42,.25);z-index:60;display:none;flex-direction:column;overflow:hidden}
+  .diego-chat.open{display:flex}
+  .diego-chat-h{background:linear-gradient(135deg,#059669,#047857);color:#fff;padding:10px 14px;display:flex;justify-content:space-between;align-items:center;font-size:13px;font-weight:600}
+  .diego-chat-h button{background:none;border:0;color:#fff;cursor:pointer;font-size:16px;line-height:1}
+  .diego-chat-body{background:#f8fafc;padding:12px;max-height:360px;min-height:200px;overflow-y:auto;display:flex;flex-direction:column;gap:8px}
+  .diego-msg{font-size:13px;padding:8px 12px;border-radius:12px;max-width:85%;line-height:1.35}
+  .diego-msg.mine{align-self:flex-end;background:#ecfdf5;color:#064e3b}
+  .diego-msg.theirs{align-self:flex-start;background:#fff;border:1px solid #e2e8f0;color:#0f172a}
+  .diego-msg-meta{font-size:10px;color:#94a3b8;margin-top:3px}
+  .diego-empty{color:#94a3b8;font-size:12px;text-align:center;padding:24px 8px}
+  .diego-chat-form{display:flex;gap:8px;padding:10px;border-top:1px solid #e2e8f0;background:#fff}
+  .diego-chat-form input{flex:1;border:1px solid #e2e8f0;border-radius:8px;padding:8px 10px;font-size:13px;outline:none}
+  .diego-chat-form input:focus{border-color:#059669;box-shadow:0 0 0 3px rgba(5,150,105,.15)}
+  .diego-chat-form button{background:#059669;color:#fff;border:0;border-radius:8px;padding:8px 14px;font-size:13px;font-weight:600;cursor:pointer}
+  .diego-chat-form button:disabled{opacity:.5;cursor:not-allowed}
+</style>
+
+<button class="diego-fab" id="diegoFab" type="button" aria-label="Abrir chat Diego">
+  <svg width="28" height="28" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z"/></svg>
+  <span class="diego-fab-label">Pregúntale a Diego</span>
+</button>
+
+<div class="diego-chat" id="diegoChat" role="dialog" aria-label="Chat con Diego">
+  <div class="diego-chat-h">
+    <span>🤖 Diego — Bandeja</span>
+    <button type="button" id="diegoChatClose" aria-label="Cerrar chat">✕</button>
+  </div>
+  <div class="diego-chat-body" id="diegoChatBody">
+    <div class="diego-empty">Cargando bandeja…</div>
+  </div>
+  <form class="diego-chat-form" id="diegoChatForm" autocomplete="off">
+    <input type="text" id="diegoChatInput" placeholder="Escribe un mensaje a Diego…" maxlength="500" aria-label="Mensaje a Diego" />
+    <button type="submit" id="diegoChatSend">Enviar</button>
+  </form>
+</div>
+
+<script>
+(function () {
+  // Reutiliza el cliente global `sb` ya creado en initSupabase() —> mismo JWT del usuario.
+  function ready() { return typeof sb !== 'undefined' && sb && sb.schema; }
+
+  const fab = document.getElementById('diegoFab');
+  const win = document.getElementById('diegoChat');
+  const closeBtn = document.getElementById('diegoChatClose');
+  const body = document.getElementById('diegoChatBody');
+  const form = document.getElementById('diegoChatForm');
+  const input = document.getElementById('diegoChatInput');
+  const sendBtn = document.getElementById('diegoChatSend');
+
+  let realtimeCh = null;
+
+  function getRemitente() {
+    try {
+      const s = JSON.parse(localStorage.getItem('rf_session') || 'null');
+      return (s && (s.email || s.nombre)) || 'Panel RDO';
+    } catch { return 'Panel RDO'; }
+  }
+  function esc(s) {
+    return String(s == null ? '' : s).replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+  }
+  function fmtHora(iso) {
+    if (!iso) return '';
+    try {
+      return new Date(iso).toLocaleString('es-CL', { day:'2-digit', month:'2-digit', hour:'2-digit', minute:'2-digit' });
+    } catch { return ''; }
+  }
+  function render(rows) {
+    if (!rows || rows.length === 0) {
+      body.innerHTML = '<div class="diego-empty">Sin mensajes todavía. Escribí abajo para empezar.</div>';
+      return;
+    }
+    const yo = getRemitente();
+    body.innerHTML = rows.slice().reverse().map(r => {
+      const mine = r.remitente === yo;
+      const cls = mine ? 'mine' : 'theirs';
+      const respLine = r.responsable ? ' · resp: ' + esc(r.responsable) : '';
+      const estLine = r.estado && r.estado !== 'pendiente' ? ' · ' + esc(r.estado) : '';
+      return '<div class="diego-msg ' + cls + '">' +
+               '<div>' + esc(r.mensaje) + '</div>' +
+               '<div class="diego-msg-meta">' + esc(r.remitente || 'anon') + ' · ' + fmtHora(r.creado_en) + respLine + estLine + '</div>' +
+             '</div>';
+    }).join('');
+    body.scrollTop = body.scrollHeight;
+  }
+  async function cargar() {
+    if (!ready()) {
+      body.innerHTML = '<div class="diego-empty">Cliente Supabase no disponible.</div>';
+      return;
+    }
+    const { data, error } = await sb.schema('panel').from('diego_bandeja')
+      .select('id,mensaje,remitente,responsable,estado,creado_en')
+      .order('creado_en', { ascending: false })
+      .limit(30);
+    if (error) {
+      body.innerHTML = '<div class="diego-empty">Error: ' + esc(error.message) + '</div>';
+      return;
+    }
+    render(data);
+  }
+  async function enviar(msg) {
+    if (!ready()) return { ok: false, err: 'sb no disponible' };
+    const { error } = await sb.schema('panel').from('diego_bandeja')
+      .insert({ mensaje: msg, remitente: getRemitente(), estado: 'pendiente' });
+    if (error) return { ok: false, err: error.message };
+    return { ok: true };
+  }
+  function suscribir() {
+    if (realtimeCh || !ready()) return;
+    realtimeCh = sb.channel('diego_bandeja_fab')
+      .on('postgres_changes', { event: '*', schema: 'panel', table: 'diego_bandeja' }, () => cargar())
+      .subscribe();
+  }
+
+  fab.addEventListener('click', () => {
+    win.classList.add('open');
+    cargar();
+    suscribir();
+    setTimeout(() => input.focus(), 50);
+  });
+  closeBtn.addEventListener('click', () => win.classList.remove('open'));
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const msg = input.value.trim();
+    if (!msg) return;
+    sendBtn.disabled = true;
+    const { ok, err } = await enviar(msg);
+    sendBtn.disabled = false;
+    if (ok) { input.value = ''; cargar(); }
+    else { alert('No pude enviar: ' + err + (String(err).includes('401') || String(err).toLowerCase().includes('jwt') ? '\n(¿iniciaste sesión en el panel?)' : '')); }
+  });
+})();
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Resumen

Agrega un FAB flotante (botón verde abajo-derecha) + ventana de chat en `public/panel-rdo.html`, conectado directo a `panel.diego_bandeja` en Supabase.

**Sin tocar nada existente:** la pestaña 📎 Dieguito (uploader audio/foto/PDF + Edge Function `dieguito-process`) queda idéntica. El cambio son +139 líneas insertadas antes de `</body>`.

## Qué hace

- **FAB visual** replica del mockup `Panel-rdo-deepseek-v4.html` (Dusan aprobó el diseño).
- **Insert**: `sb.schema('panel').from('diego_bandeja').insert({mensaje, remitente, estado:'pendiente'})`. Usa el cliente `sb` ya inicializado en `initSupabase()` → JWT del usuario logueado.
- **Lectura**: SELECT últimas 30 entradas, orden DESC.
- **Realtime**: `postgres_changes` sobre `panel.diego_bandeja` → el chat se refresca solo cuando alguien responde (cambia `estado`/`responsable`/`nota_resolucion`).
- **Sin sesión**: el alert detecta 401/JWT y dice "¿iniciaste sesión en el panel?".

## Checklist de cambios a panel-rdo.html

| Item | Estado |
|---|---|
| Bypass 4 lugares (config_kv + RLS + v_panel_silos_visibles + fallback HTML) | N/A — no toqué bypass |
| GRANTs cesar_readonly a tablas nuevas en curated.* | N/A — no agregué tabla, `panel.diego_bandeja` ya existía con RLS + GRANTs (`authenticated` SELECT+INSERT+UPDATE) |
| Mobile responsive verificado en preview | ⏳ pendiente — verificar en este preview deploy |
| Tab Dieguito existente intacta | ✅ 0 deletions, solo inserciones |

## Cómo testear

1. Login al preview con cuenta válida.
2. Clic en FAB verde abajo-derecha → debe abrir ventana con 4 entradas existentes (Andrea, Cony, Sistema, test).
3. Escribir "TEST FAB" + Enviar → debe aparecer arriba con tu email como remitente.
4. Verificar en Supabase: `SELECT id, remitente, mensaje, creado_en FROM panel.diego_bandeja ORDER BY creado_en DESC LIMIT 5;`
5. Cambiar `estado='resuelto'` desde Supabase studio → el chat abierto debe refrescar solo (Realtime).
6. Mobile: verificar que el FAB no tape contenido en pantallas chicas.
7. Logout + intento de envío → debe mostrar alert con mensaje "¿iniciaste sesión en el panel?".

## Plan completo

Ver `C:\Users\dusan\.claude\plans\precious-wiggling-babbage.md` (aprobado por Dusan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)