### PR TITLE
fix: Service Worker se actualiza solo (skipWaiting + clients.claim + navigate)

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'reciclean-v1';
+const CACHE_NAME = 'reciclean-v2';
 const ASSETS_TO_CACHE = [
   '/',
   '/asistente.html',
@@ -14,11 +14,17 @@ self.addEventListener('install', event => {
 
 self.addEventListener('activate', event => {
   event.waitUntil(
-    caches.keys().then(keys =>
-      Promise.all(keys.filter(k => k !== CACHE_NAME).map(k => caches.delete(k)))
-    )
+    Promise.all([
+      caches.keys().then(keys =>
+        Promise.all(keys.filter(k => k !== CACHE_NAME).map(k => caches.delete(k)))
+      ),
+      self.clients.claim().then(() =>
+        self.clients.matchAll({ type: 'window' }).then(clients => {
+          clients.forEach(client => client.navigate(client.url));
+        })
+      )
+    ])
   );
-  self.clients.claim();
 });
 
 self.addEventListener('fetch', event => {


### PR DESCRIPTION
## Problema

Tras mergear PR #42 (FAB Diego) + PR #43 (promoción 14 PRs a prod), los usuarios del equipo siguen viendo el panel viejo aunque el deploy Vercel está READY desde 21:31 Chile (verificado con `Invoke-WebRequest` y agent-browser). Causa raíz: el Service Worker viejo (`reciclean-v1`) está interceptando los fetch y sirviendo el HTML cacheado de versiones anteriores. Hard refresh manual destraba un usuario por vez; no escala.

## Cambios (`public/sw.js`)

1. **CACHE_NAME bumped `'reciclean-v1'` → `'reciclean-v2'`** — fuerza al SW del usuario a entrar en estado `installing` cuando descarga el nuevo `sw.js`, lo cual dispara el handler `activate` que limpia el cache viejo.

2. **`activate` extendido** — combina:
   - Limpieza de caches viejos (ya estaba).
   - `self.clients.claim()` (ya estaba) — el nuevo SW toma control inmediato de todas las pestañas existentes sin esperar que se cierren.
   - **NUEVO**: `self.clients.matchAll({type: 'window'}).then(clients => clients.forEach(c => c.navigate(c.url)))` — recarga programáticamente todas las pestañas que tengan el panel abierto, sin pedir al usuario que apriete F5.

3. **`install` intacto** — `skipWaiting()` ya estaba (no se necesita modificar). Pre-cache de `/`, `/asistente.html`, `/index.html` preservado para soporte offline.

4. **`fetch` intacto** — network-first con fallback a cache.

## Resultado esperado

Al deployar a prod:
1. Usuario abre el panel (incluso con tab vieja abierta).
2. Browser descarga el nuevo `sw.js` (sin cambios visibles).
3. SW nuevo entra en `installing` → pre-cachea assets.
4. SW nuevo activa, limpia `reciclean-v1`, hace `clients.claim`, recarga la pestaña.
5. Usuario ve el FAB Diego sin haber hecho nada.

## Riesgo

- **Bajo riesgo de loop de recarga**: el `navigate` se ejecuta una sola vez por activación del SW. La siguiente carga ya tiene el SW v2 activo, no se vuelve a invocar.
- **Hard refresh equivalente**: para usuarios con tab cerrada, la próxima apertura ya trae v2 directo. No hay regresión.

## Validación

- ❌ **No probado en localhost** — orden directa de Dusan a las 22:15 Chile saltea paso 3 de regla cirugía. Asumido riesgo según excepción explícita de la regla.
- Verificación post-deploy: abrir https://reciclean-sistema.vercel.app/panel-rdo.html, DevTools → Application → Service Workers, ver `reciclean-v2` activo. Si todavía hay v1: refresh página, esperar ~2 segundos, el navigate recarga sola.

🤖 Generated with [Claude Code](https://claude.com/claude-code)