### PR TITLE
Promote main → prod: fix Service Worker auto-update (#44)

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'reciclean-v1';
+const CACHE_NAME = 'reciclean-v2';
 const ASSETS_TO_CACHE = [
   '/',
   '/asistente.html',
@@ -14,11 +14,17 @@ self.addEventListener('install', event => {
 
 self.addEventListener('activate', event => {
   event.waitUntil(
-    caches.keys().then(keys =>
-      Promise.all(keys.filter(k => k !== CACHE_NAME).map(k => caches.delete(k)))
-    )
+    Promise.all([
+      caches.keys().then(keys =>
+        Promise.all(keys.filter(k => k !== CACHE_NAME).map(k => caches.delete(k)))
+      ),
+      self.clients.claim().then(() =>
+        self.clients.matchAll({ type: 'window' }).then(clients => {
+          clients.forEach(client => client.navigate(client.url));
+        })
+      )
+    ])
   );
-  self.clients.claim();
 });
 
 self.addEventListener('fetch', event => {


### PR DESCRIPTION
## Promoción main → prod (segunda iteración del día)

**Solo 1 commit nuevo** desde el último deploy a prod (PR #43): `ea95879` — el fix del Service Worker para que se auto-actualice en navegadores con SW viejo cacheado.

## Contexto

Tras mergear PR #43 a prod (FAB Diego + 13 PRs) el deploy Vercel quedó READY desde 21:31 Chile pero los usuarios del equipo seguían viendo el panel viejo. Causa: SW `reciclean-v1` interceptando fetches y sirviendo HTML cacheado. Verificado con agent-browser que el FAB renderiza correctamente en localhost sobre el mismo HTML servido por prod.

## Cambios

Solo `public/sw.js` (+11/-5 líneas):
- CACHE_NAME bump v1 → v2 (dispara `activate`)
- `activate` extendido con `matchAll + navigate` para recarga automática de pestañas

Detalle completo en PR #44 (ya mergeado a main).

## Riesgo

- **Bajo**: el cambio es solo SW, no toca HTML/CSS/JS del panel ni backend.
- Si rompe: rollback Vercel UI → deploy anterior (sigue siendo `isRollbackCandidate: true`).

## Validación pre-merge

- ❌ No probado en localhost (orden directa Dusan 22:15)
- ✅ FAB verificado funcional en localhost via agent-browser (screenshot guardado: `C:\Users\dusan\claude-sandbox\fab-chat-abierto.png`)
- ✅ `sw.js` actual en main: `node --check` pasa (sintaxis JS válida)

🤖 Generated with [Claude Code](https://claude.com/claude-code)