### PR TITLE
fix: registrar Service Worker en panel-rdo.html (BLQ-001)

### DIFF
--- a/public/panel-rdo.html
+++ b/public/panel-rdo.html
@@ -4789,5 +4789,18 @@ document.getElementById('resetPassword2').addEventListener('keypress', e => {
   });
 })();
 </script>
+
+<!-- Service Worker registration (v2: skipWaiting + clients.claim + navigate)
+     Sin esto el archivo /sw.js queda muerto: existe en el servidor pero
+     ningun cliente lo carga ni recibe auto-updates. -->
+<script>
+  if ('serviceWorker' in navigator) {
+    window.addEventListener('load', () => {
+      navigator.serviceWorker.register('/sw.js').catch(err => {
+        console.warn('SW register failed:', err);
+      });
+    });
+  }
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Contexto

Diagnóstico autónomo de PC Dusan 20-may PM detectó que `public/sw.js` está en prod con el patrón v2 correcto (`skipWaiting` + `clients.claim` + `client.navigate`), pero **ningún HTML del repo lo registra**. Verificación con agent-browser:

| Path | swMentions | registerCalls |
|---|---:|---|
| `/` | 0 | `[]` |
| `/index.html` | 0 | `[]` |
| `/login.html` | 0 | `[]` |
| `/asistente.html` | 0 | `[]` |
| `/panel-rdo.html` | 0 | `[]` |

Resultado: el SW está muerto. Browser fresh post-PR45 reporta `navigator.serviceWorker.controller = null`, `caches.keys() = []`. PR #44 + PR #45 (mergeados anoche) escribieron el archivo correcto pero el snippet de registro nunca se agregó al HTML.

## Cambio

Inserta 9 líneas antes de `</body>` en `public/panel-rdo.html`:

```html
<script>
  if ('serviceWorker' in navigator) {
    window.addEventListener('load', () => {
      navigator.serviceWorker.register('/sw.js').catch(err => {
        console.warn('SW register failed:', err);
      });
    });
  }
</script>
```

`window.addEventListener('load', ...)` evita penalizar el TTI: el registro arranca después de que el resto del panel ya cargó.

## Efecto esperado post-deploy a prod

- **Primera visita** post-deploy: el SW se instala silenciosamente (no controla esa pestaña aún).
- **Segunda visita / reload**: el SW v2 toma control via `clients.claim()` (ya está activate handler en `sw.js`).
- **Futuros deploys**: cuando `CACHE_NAME` cambie en `sw.js`, los users reciben el update automático + reload sin hard refresh manual.

## Lo que este PR NO hace

- ❌ NO arregla el problema de "veo diseño viejo en mi Chrome ahora mismo" — porque no hay SW cacheando hoy, lo que Vercel sirve YA es el HTML nuevo. Si Dusan ve viejo, la causa está en otro lado (extensión Chrome, otra URL como `plataforma-virtual.com`, proxy/CDN intermedio en su red).
- ❌ NO arregla el bug del login "queda pegado en Ingresando…" (BLQ-002, pendiente de reproducir con password real).
- ❌ NO agrega registro a `index.html`, `login.html`, `asistente.html` — esos son del sistema comercial viejo, no necesitan SW v2 para el panel RDO. Se puede hacer en PR aparte si se quiere.

## Test plan

- [ ] Vercel preview deploy del PR genera URL `reciclean-sistema-git-feature-sw-register-...` exitosa.
- [ ] Abrir la URL preview en Chrome con DevTools → Application → Service Workers → verificar que `sw.js` aparece registrado + status "activated and is running".
- [ ] DevTools → Cache Storage → verificar que existe entry `reciclean-v2` con los assets pre-cached (`/`, `/asistente.html`, `/index.html`).
- [ ] Recargar pestaña una vez → DevTools → Network → verificar que algunas requests dicen "(from ServiceWorker)" en la columna Size.

## Referencia

Detalle completo del bloqueo + evidencias: `reciclean-rdo/mayordomo/BLOQUEOS.md § BLQ-001`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)