### PR TITLE
Promote main → prod: SW register + Bandeja Diego + Operaciones Día (#46 #47 #48)

### DIFF
--- a/public/panel-rdo.html
+++ b/public/panel-rdo.html
@@ -4789,5 +4789,18 @@ document.getElementById('resetPassword2').addEventListener('keypress', e => {
   });
 })();
 </script>
+
+<!-- Service Worker registration (v2: skipWaiting + clients.claim + navigate)
+     Sin esto el archivo /sw.js queda muerto: existe en el servidor pero
+     ningun cliente lo carga ni recibe auto-updates. -->
+<script>
+  if ('serviceWorker' in navigator) {
+    window.addEventListener('load', () => {
+      navigator.serviceWorker.register('/sw.js').catch(err => {
+        console.warn('SW register failed:', err);
+      });
+    });
+  }
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Promoción main → prod

Bundle de 3 PRs ya mergeados a `main` desde el último promote a prod (PR #45, 20-may 22:11 Chile).

### PRs incluidos

#### #48 — fix: registrar Service Worker en panel-rdo.html (BLQ-001)
Snippet de 9 líneas antes de `</body>` que finalmente instala el SW v2 en clientes.
- `public/sw.js` existía desde PR #44 con patrón correcto (skipWaiting + clients.claim + navigate) pero **nada lo registraba** → era letra muerta.
- Post-deploy: primera visita instala SW silencioso, segunda visita el SW v2 toma control via `clients.claim()`. Futuros deploys con bump de `CACHE_NAME` se propagan automático sin hard refresh.
- Detalle del bloqueo: `reciclean-rdo/mayordomo/BLOQUEOS.md § BLQ-001`.

#### #47 — D-OP-16 Tab Operaciones Día (Pablo)
Tab transversal para Dusan/Ingrid/Juan: panorama del día en una pantalla con date picker.
- Backend: RPC `public.f_operaciones_dia(p_fecha date)` aplicada vía MCP, retorna JSONB con pesajes + cierres + alertas + comparativa vs día anterior.
- Frontend (+130 líneas): tab entre Oportunidades y Admin, date picker + botones Ayer/Hoy, KPI bar, bloques pesajes por sucursal, cierres Dyana, alertas precio/contraparte.

#### #46 — D-OP-15 Tab Bandeja Diego (Pablo)
Tab transversal para gestionar mensajes pendientes que el FAB Diego (PR #42) y bots externos guardan en `panel.diego_bandeja`.
- Backend: vista `panel.vw_diego_bandeja_detalle` (5W2H + urgencia_color) + RPC `panel.diego_bandeja_kpis()` aplicadas vía MCP.
- Frontend (+200 líneas): tab con KPI bar (pendientes/resueltos/sin responsable/vencidos>48h) + filtros estado/responsable/buscar + tabla con asignación inline + drawer detalle 5W2H + acciones resolver/reasignar.

### Riesgos

- **PR #48**: bajo. 9 líneas de JS standard. Si falla `navigator.serviceWorker.register('/sw.js')`, el catch lo loguea y no rompe nada del panel.
- **PR #47 + #46**: tabs nuevos aislados, no tocan flows existentes. Backend ya aplicado en prod Supabase (RPCs + vistas), idempotente.

### Test plan post-merge

- [ ] Vercel auto-deploy a prod genera nuevo `dpl_*` con `target=production` en READY.
- [ ] `https://reciclean-sistema.vercel.app/panel-rdo.html` → DevTools Application → Service Workers → `sw.js` aparece registrado + "activated and running".
- [ ] Tab "🤖 Bandeja Diego" (o equivalente) visible para perfil dusan/admin → carga KPIs + lista pendientes.
- [ ] Tab "📊 Operaciones Día" (o equivalente) visible para perfiles transversales → date picker default ayer + KPIs renderean.

### Rollback

Vercel UI → Deployments → último deploy con `target=production` anterior (PR #45 `a40991f0`) → "Promote to Production". ~30 segundos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)