### PR TITLE
fix(panel-rdo): BUG-FAB-001 — FAB toma email de sb.auth si rf_session esta vacio

### DIFF
--- a/public/panel-rdo.html
+++ b/public/panel-rdo.html
@@ -7816,14 +7816,15 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   async function callDiego(mensaje, attach) {
-    const email = getUserEmail();
-    if (!email) return { error: 'No hay sesión. ¿Iniciaste sesión en el panel?' };
+    let email = getUserEmail();
     const SUPABASE_URL_LOCAL = (typeof SUPABASE_URL !== 'undefined' && SUPABASE_URL) || 'https://eknmtsrtfkzroxnovfqn.supabase.co';
     let token = null;
     try {
       const s = await sb.auth.getSession();
       token = s?.data?.session?.access_token;
+      if (!email) email = s?.data?.session?.user?.email || null;
     } catch { /* noop */ }
+    if (!email) return { error: 'No hay sesión. ¿Iniciaste sesión en el panel?' };
     if (!token) return { error: 'No tengo token de sesión válido.' };
 
     const body = {


### PR DESCRIPTION
## Summary

- `callDiego()` solo miraba `localStorage.rf_session` y cortaba con "No hay sesión" si esa variable estaba vacía, aunque la sesión Supabase siguiera viva.
- Fix: al hacer la llamada que ya existía a `sb.auth.getSession()` (para sacar el token), también se toma el email del usuario como fallback.
- 3 líneas modificadas en `public/panel-rdo.html`. Cero cambios en otra lógica.

## ¿Cuándo se rompía?

Escenario: el usuario está logueado en Supabase pero `localStorage.rf_session` no está (cookies limpiadas, magic link sin pasar por login.html, expiración de la entrada vieja, etc.).

## Test plan

- [ ] Vercel preview carga sin errores
- [ ] Abrir panel-rdo con sesión válida → FAB Diego responde normalmente
- [ ] Borrar manualmente `localStorage.rf_session` (DevTools → Application → Storage), recargar la página → el FAB Diego sigue funcionando (toma email de Supabase)
- [ ] Sin sesión Supabase ni localStorage → FAB muestra "No hay sesión" (regresión esperada)

🤖 Generated with [Claude Code](https://claude.com/claude-code)