### PR TITLE
Release prod 23-may PM #2 · fix BUG-FAB-001

### DIFF
--- a/public/panel-rdo.html
+++ b/public/panel-rdo.html
@@ -7816,14 +7816,15 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   async function callDiego(mensaje, attach) {
-    const email = getUserEmail();
-    if (!email) return { error: 'No hay sesión. ¿Iniciaste sesión en el panel?' };
+    let email = getUserEmail();
     const SUPABASE_URL_LOCAL = (typeof SUPABASE_URL !== 'undefined' && SUPABASE_URL) || 'https://eknmtsrtfkzroxnovfqn.supabase.co';
     let token = null;
     try {
       const s = await sb.auth.getSession();
       token = s?.data?.session?.access_token;
+      if (!email) email = s?.data?.session?.user?.email || null;
     } catch { /* noop */ }
+    if (!email) return { error: 'No hay sesión. ¿Iniciaste sesión en el panel?' };
     if (!token) return { error: 'No tengo token de sesión válido.' };
 
     const body = {


### PR DESCRIPTION
## Hotfix BUG-FAB-001 — fallback sb.auth.getSession()

Commit único (40986b4) de Pablo: `public/panel-rdo.html` ahora detecta cuando `localStorage.rf_session` está vacío y cae a `sb.auth.getSession()` para tomar el email autenticado.

### Por qué se necesita YA

Sin este fix, usuarios reales que loguean por la pantalla del panel **no pueden usar Diego** porque el FAB lee `rf_session` (que algunos flujos no setean) y responde "No hay sesión". Auditoría 23-may detectó este bloqueador.

### Cambio mínimo

- 5 líneas modificadas en `panel-rdo.html` función `callDiego()`.
- Sin migraciones, sin EF, sin tablas.

### Rollback

Revertir commit 40986b4. Vercel redeploya.

Mergeado en línea con precedente D-PROTEC-PROD-002 (admin bypass autorizado).

🤖 Generated with [Claude Code](https://claude.com/claude-code)