### PR TITLE
fix(panel-rdo): agregar Bandeja Precios al sidebar v4

### DIFF
--- a/public/panel-rdo.html
+++ b/public/panel-rdo.html
@@ -369,6 +369,10 @@
           <svg class="ico" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
           Precios
         </a>
+        <a href="#" data-v4-tab="bandeja_precios" class="nav-item flex items-center gap-3 px-3 py-2 rounded-lg text-sm">
+          <svg class="ico" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>
+          Bandeja Precios
+        </a>
         <a href="#" data-v4-tab="cierres" class="nav-item flex items-center gap-3 px-3 py-2 rounded-lg text-sm">
           <svg class="ico" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"/></svg>
           Cierre


### PR DESCRIPTION
## Bug detectado por smoke headless con login real (Playwright)

La Ola 2.6 (PR #95) había agregado el tab \`📨 Bandeja Precios\` solo en el navbar horizontal viejo (que vive oculto desde v4-design F2). La UI real ahora es el sidebar lateral \`#v4-sidebar\` (líneas 313+ del HTML, hardcoded). **Sin entry en sidebar v4, los usuarios productivos no veían el tab.**

## Detección
Smoke con Playwright + login real con user de test \`smoke-pc2@gestionrepchile.cl\` (creado en \`panel.usuarios_autorizados\` + \`auth.users\` + \`panel.permisos\`) descubrió que el tab del navbar horizontal ya no es la UI visible.

## Fix
Agregar \`<a data-v4-tab="bandeja_precios">\` en sección **Gestión** entre Precios y Cierre, con icono SVG de bandeja/inbox.

## Verificación post-fix (mismo smoke)
✅ Desktop: tab visible en sidebar, click navega, 4 KPIs renderizan, tabla muestra "Sin propuestas para este filtro." (query Supabase real ejecutada).
✅ Mobile: tab accesible vía hamburguesa, layout responsive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)