### PR TITLE
docs(diagrama): firma Dusan D-DIAGRAMA-FLUJO-V2-FINAL

### DIFF
--- a/public/DECISIONES-DIAGRAMA-FLUJO.md
+++ b/public/DECISIONES-DIAGRAMA-FLUJO.md
@@ -99,3 +99,24 @@ Cotización arriendo → Contrato firmado → Facturación recurrente mensual
 ---
 
 **Firmado:** PC Dusan, 2026-05-24 madrugada (pendiente firma Dusan).
+
+---
+
+## ✅ FIRMA DUSAN — 2026-05-25 AM
+
+**Los 5 defaults quedan vinculantes** + complemento Punto 5:
+
+> "Los 5 defaults OK, pero si el #7 [punto 5] hay que complementar por envío WhatsApp." — Dusan, 25-may-2026 AM
+
+### Complemento Punto 5
+
+El nuevo diagrama "Servicios consultoría/comerciales" tiene que incluir paso obligatorio de **entrega vía WhatsApp** al cliente:
+
+- **Capacitación:** terminada la capacitación → WhatsApp con resumen PDF + foto asistencia + grabación si hubo.
+- **Imágenes/respaldos Ley REP:** fotos del retiro → WhatsApp inmediato al cliente como respaldo legal.
+
+Tool: `dieguito-whatsapp` v3.1 (ya en prod tras D-OP-04-v2 Ola 2). Sin infraestructura nueva.
+
+### Referencia cruzada
+
+`reciclean-rdo: mayordomo/DECISIONES.md § D-DIAGRAMA-FLUJO-V2-FINAL` (commit a generar).


### PR DESCRIPTION
## Summary

Dusan firma 25-may AM los 5 defaults propuestos del diagrama flujo material V2 + complemento Punto 5.

**Punto 5 complemento:** el nuevo diagrama "Servicios consultoría/comerciales" debe incluir paso obligatorio de entrega WhatsApp:
- Capacitación → resumen PDF + foto asistencia + grabación
- Imágenes/respaldos Ley REP → fotos del retiro al cliente como respaldo legal

Tool: `dieguito-whatsapp` v3.1 (ya en prod tras D-OP-04-v2 Ola 2). Sin infraestructura nueva.

## Referencia cruzada
- `reciclean-rdo: mayordomo/DECISIONES.md` § D-DIAGRAMA-FLUJO-V2-FINAL (commit 4b5227f)

## Test plan
- [x] Solo doc, no afecta código ni datos

🤖 Generated with [Claude Code](https://claude.com/claude-code)