### PR TITLE
fix(panel-rdo): BUG-IA-CONSENT-002 export historial + BUG-IA-CONSENT-004 ESC chat

### DIFF
--- a/public/panel-rdo.html
+++ b/public/panel-rdo.html
@@ -8465,10 +8465,9 @@ document.addEventListener('DOMContentLoaded', () => {
       if (win.classList.contains('open')) { win.classList.remove('open'); }
       else { fab.click(); }
     }
-    // ESC cierra
+    // ESC cierra (BUG-IA-CONSENT-004 fix: textarea autofocusea al abrir, antes ESC nunca cerraba)
     if (e.key === 'Escape' && win.classList.contains('open')) {
-      const tag2 = (e.target?.tagName || '').toLowerCase();
-      if (tag2 !== 'textarea' && tag2 !== 'input') win.classList.remove('open');
+      win.classList.remove('open');
     }
   });
 
@@ -9685,7 +9684,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (!email) { alert('No hay sesión activa.'); return; }
         const [perfilQ, histQ, memQ] = await Promise.all([
           sb.schema('panel').from('usuarios_autorizados').select('*').eq('email', email).maybeSingle(),
-          sb.schema('panel').from('diego_bandeja').select('*').eq('remitente', email).order('ts', { ascending: false }).limit(500),
+          sb.schema('panel').from('diego_bandeja').select('*').eq('remitente', email).order('creado_en', { ascending: false }).limit(500),
           sb.schema('panel').from('diego_memoria_sesion').select('*').eq('usuario_email', email).maybeSingle(),
         ]);
         const bundle = {


### PR DESCRIPTION
## Summary

Hotfix 2 bugs detectados en E2E pasada post-promo D-PROMO-PROD-004 (1 archivo, +3/-4):

### BUG-IA-CONSENT-002 · Ley 21719 portabilidad
- Botón "📥 Exportar mis datos en JSON" usa `.order('ts')` pero `panel.diego_bandeja` no tiene esa columna (es `creado_en`).
- Resultado: `histQ.error` no se checkea, `histQ.data || []` silencia → bundle descargado con `historial_diego: []` aunque el user tenga conversaciones reales.
- **Fix**: `s/'ts'/'creado_en'/` en la query.

### BUG-IA-CONSENT-004 · UX CL-015 rota
- Ctrl+K abre chat y autofocusea `diegoChatInput` (textarea).
- Handler ESC tenía guarda `if (tag2 !== 'textarea' && tag2 !== 'input')` → como ESC siempre se dispara con el textarea enfocado, ESC nunca cerraba.
- **Fix**: remover el chequeo de tag, ESC siempre cierra cuando `win.open`.

## Test plan

- [x] BUG-002 verificado pre-fix con eval JS en prod: `histQ.error = "column diego_bandeja.ts does not exist"`
- [x] BUG-004 verificado pre-fix con agent-browser: Ctrl+K abrió chat, focus en textarea, ESC no cerró
- [ ] Smoke post-merge: re-correr E2E con user test (crear, Ctrl+K, ESC, export JSON, verificar bundle con historial poblado)

## Bugs relacionados

Hermano de BUG-IA-CONSENT-001 (RLS UPDATE) ya fixeado vía mig 086 y BUG-IA-CONSENT-003 (GRANT memoria_sesion) ya fixeado vía mig 087. Estos 4 bugs salieron de la pasada E2E del 2026-05-25 21:30 UTC documentada en `mayordomo/BITACORA-VIVA.md` + `mayordomo/DECISIONES.md` de rdo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)