### PR TITLE
promote main → prod: BUG-IA-CONSENT-002 + BUG-IA-CONSENT-004 hotfix

### DIFF
--- a/public/panel-rdo.html
+++ b/public/panel-rdo.html
@@ -8465,10 +8465,9 @@ document.addEventListener('DOMContentLoaded', () => {
       if (win.classList.contains('open')) { win.classList.remove('open'); }
       else { fab.click(); }
     }
-    // ESC cierra
+    // ESC cierra (BUG-IA-CONSENT-004 fix: textarea autofocusea al abrir, antes ESC nunca cerraba)
     if (e.key === 'Escape' && win.classList.contains('open')) {
-      const tag2 = (e.target?.tagName || '').toLowerCase();
-      if (tag2 !== 'textarea' && tag2 !== 'input') win.classList.remove('open');
+      win.classList.remove('open');
     }
   });
 
@@ -9685,7 +9684,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (!email) { alert('No hay sesión activa.'); return; }
         const [perfilQ, histQ, memQ] = await Promise.all([
           sb.schema('panel').from('usuarios_autorizados').select('*').eq('email', email).maybeSingle(),
-          sb.schema('panel').from('diego_bandeja').select('*').eq('remitente', email).order('ts', { ascending: false }).limit(500),
+          sb.schema('panel').from('diego_bandeja').select('*').eq('remitente', email).order('creado_en', { ascending: false }).limit(500),
           sb.schema('panel').from('diego_memoria_sesion').select('*').eq('usuario_email', email).maybeSingle(),
         ]);
         const bundle = {


### PR DESCRIPTION
## Summary

Hotfix de 2 bugs detectados en E2E pasada de la promo D-PROMO-PROD-004 (hace ~45min).

Merge anterior dejó vivos en prod:
- **BUG-002** export JSON con historial vacío (column `ts` no existe en `diego_bandeja`)
- **BUG-004** ESC no cierra el chat de Diego (textarea autofocuseado bloqueaba el handler)

Ambos fixeados en PR #112 → main (commit `0244275`). Esta promo los lleva a prod.

Diff: 1 archivo (`public/panel-rdo.html`), +3/-4 líneas. Cero migraciones SQL.

## Bugs hermanos ya en prod (no requieren PR adicional)

- BUG-001 (RLS authenticated UPDATE) fixeado vía mig **086** aplicada hoy
- BUG-003 (GRANT diego_memoria_sesion) fixeado vía mig **087** aplicada hoy

## Test plan post-merge (Dusan en prod real)

- [ ] Login con cuenta normal, abrir chat con Ctrl+K, presionar ESC → chat cierra
- [ ] Tab "🧠 Mi memoria" → botón "📥 Exportar mis datos en JSON" → bundle descargado contiene `historial_diego` con conversaciones reales (no array vacío)

🤖 Generated with [Claude Code](https://claude.com/claude-code)