### PR TITLE
R-AUD-034: cerrar 8 FANTASMA + 3 MUERTA de sidebar v4 (post-Megapol)

### DIFF
--- a/public/panel-rdo.html
+++ b/public/panel-rdo.html
@@ -354,13 +354,33 @@
           <svg class="ico" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"/></svg>
           Facturación
         </a>
+        <a href="#" data-v4-tab="ops_diarias" class="nav-item flex items-center gap-3 px-3 py-2 rounded-lg text-sm">
+          <svg class="ico" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364-6.364l-.707.707M6.343 17.657l-.707.707m12.728 0l-.707-.707M6.343 6.343l-.707-.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
+          Operaciones Día
+        </a>
+        <a href="#" data-v4-tab="operativos" class="nav-item flex items-center gap-3 px-3 py-2 rounded-lg text-sm">
+          <svg class="ico" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg>
+          Operativos
+        </a>
         <a href="#" data-v4-tab="dieguito" class="nav-item flex items-center gap-3 px-3 py-2 rounded-lg text-sm">
           <svg class="ico" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"/></svg>
           Dieguito
         </a>
+        <a href="#" data-v4-tab="bandeja_dieg" class="nav-item flex items-center gap-3 px-3 py-2 rounded-lg text-sm">
+          <svg class="ico" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>
+          Bandeja Diego
+        </a>
       </div>
       <div>
         <h3 class="px-3 mb-1 text-[10px] font-semibold text-slate-400 uppercase tracking-wider">Gestión</h3>
+        <a href="#" data-v4-tab="negocios" class="nav-item flex items-center gap-3 px-3 py-2 rounded-lg text-sm">
+          <svg class="ico" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 13.255A23.931 23.931 0 0112 15c-3.183 0-6.22-.62-9-1.745M16 6V4a2 2 0 00-2-2h-4a2 2 0 00-2 2v2m4 6h.01M5 20h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>
+          Negocios
+        </a>
+        <a href="#" data-v4-tab="cotizador" class="nav-item flex items-center gap-3 px-3 py-2 rounded-lg text-sm">
+          <svg class="ico" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"/></svg>
+          Cotizador
+        </a>
         <a href="#" data-v4-tab="rdo" class="nav-item flex items-center gap-3 px-3 py-2 rounded-lg text-sm">
           <svg class="ico" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 17v-2m3 2v-4m3 4v-6m2 10H5a2 2 0 01-2-2V5a2 2 0 012-2h14a2 2 0 012 2v14a2 2 0 01-2 2z"/></svg>
           RDO
@@ -381,6 +401,18 @@
           <svg class="ico" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a4 4 0 00-3-3.87M9 20H4v-2a4 4 0 013-3.87m6-3a4 4 0 11-8 0 4 4 0 018 0zm6 0a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
           Cartera
         </a>
+        <a href="#" data-v4-tab="entregables" class="nav-item flex items-center gap-3 px-3 py-2 rounded-lg text-sm">
+          <svg class="ico" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 17v-2a4 4 0 014-4h4m-3-3l3 3m-3 3l3-3m0-9v6a2 2 0 002 2h6"/></svg>
+          Entregables
+        </a>
+        <a href="#" data-v4-tab="oportunidades" class="nav-item flex items-center gap-3 px-3 py-2 rounded-lg text-sm">
+          <svg class="ico" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6"/></svg>
+          Oportunidades
+        </a>
+        <a href="#" data-v4-tab="reconciliacion" class="nav-item flex items-center gap-3 px-3 py-2 rounded-lg text-sm" data-v4-tab-perfil="dusan,admin">
+          <svg class="ico" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4"/></svg>
+          Reconciliación
+        </a>
       </div>
       <div>
         <h3 class="px-3 mb-1 text-[10px] font-semibold text-slate-400 uppercase tracking-wider">Equipo</h3>
@@ -396,9 +428,12 @@
           <svg class="ico" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"/></svg>
           Mi memoria
         </a>
-        <a href="#" data-v4-tab="oportunidades" class="nav-item flex items-center gap-3 px-3 py-2 rounded-lg text-sm">
-          <svg class="ico" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"/></svg>
-          Oportunidades
+      </div>
+      <div data-v4-group-perfil="dusan,admin">
+        <h3 class="px-3 mb-1 text-[10px] font-semibold text-slate-400 uppercase tracking-wider">Administración</h3>
+        <a href="#" data-v4-tab="admin" class="nav-item flex items-center gap-3 px-3 py-2 rounded-lg text-sm" data-v4-tab-perfil="dusan,admin">
+          <svg class="ico" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/></svg>
+          Admin
         </a>
       </div>
     </nav>


### PR DESCRIPTION
## Origen

Incidente Megapol 27-may (5h 15min total · Andrea sola 4h). Andrea quedó bloqueada cotizando porque el sidebar v4 no incluía links a Negocios + Cotizador, aunque backend permitía. La auditoría automática `panel.audit_sidebar_v4()` (R-AUD-034, mig 125) detectó que el mismo bug afectaba 8 pestañas en total + 3 links muertos. **Severidad ROJA, 14 usuarios afectados**.

## Cambios (panel-rdo.html, sidebar v4)

| Acción | Slug | Grupo | Pestaña backend |
|---|---|---|---|
| Agregado | `negocios` | Gestión | ✅ activa |
| Agregado | `cotizador` | Gestión | ✅ activa |
| Agregado | `entregables` | Gestión | ✅ activa |
| Agregado | `reconciliacion` | Gestión (dusan+admin) | ✅ activa |
| Agregado | `bandeja_dieg` | Día a día | ✅ activa |
| Agregado | `ops_diarias` | Día a día | ✅ activa |
| Agregado | `operativos` | Día a día | ✅ activa |
| Agregado | `admin` | Administración (dusan+admin) | ✅ activa |
| Movido | `oportunidades` | Equipo → Gestión | — |

Las 3 MUERTAS (`bandeja_precios`, `manual`, `mi_memoria`) se cierran creando la pestaña correspondiente en backend (ver mig 126 en `reciclean-rdo` branch `replit/r-aud-034-fix-gaps-mig-126`).

## Pareja DB

PR mig 126 en `reciclean-rdo`: https://github.com/dusanarancibia-cpu/reciclean-rdo/pull/new/replit/r-aud-034-fix-gaps-mig-126

Hace 2 cosas:
1. INSERT 3 pestañas en `panel.pestanas` (bandeja_precios, manual, mi_memoria).
2. UPSERT 21 entradas en `panel.sidebar_v4_manifest` (era 13).

## Smoke post-fix

\`\`\`
curl -X POST https://eknmtsrtfkzroxnovfqn.supabase.co/functions/v1/auditoria-sidebar-v4
{
  \"ok\": true,
  \"severidad\": \"verde\",
  \"fantasmas_pestanas\": 0,
  \"muertas_pestanas\": 0,
  \"ocultas_pestanas\": 0,
  \"usuarios_afectados\": 0
}
\`\`\`

## Test plan

- [ ] Preview Vercel carga sin errores de consola.
- [ ] Andrea (perfil `comercial`) entra al preview, ve en sidebar: Negocios + Cotizador + Cartera + Oportunidades + Precios + Cierres + Bandeja Precios + Entregables.
- [ ] Click sidebar \"Negocios\" → abre tab con buscador.
- [ ] Buscar Megapol → asignar sucursal → click 📋 → cotizador abre con pre-carga.
- [ ] Click sidebar \"Cotizador\" directo también funciona.
- [ ] Cony (perfil `externo`) NO ve Negocios / Cotizador / Cartera (no tiene el perfil).
- [ ] Dusan ve grupo \"Administración\" con link Admin. Andrea no lo ve.
- [ ] Mobile <768px: sidebar accesible (overflow scroll).

## Impacto post-merge

- Andrea desbloqueada cotizando Megapol + 146 oportunidades sin sucursal.
- 14 usuarios dejan de tener pestañas invisibles.
- La auditoría diaria queda en verde y la regla R-AUD-034 entra en régimen estable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)