### PR TITLE
Ola 1 · F6 data-source-footer + switch v_cliente_360_full

### DIFF
--- a/public/panel-rdo.html
+++ b/public/panel-rdo.html
@@ -521,6 +521,33 @@
     <a href="#" onclick="document.querySelector('button[data-tab=comunicados]').click(); return false;" class="underline text-amber-800 ml-2">Escuchar ahora</a>
   </div>
 
+  <!-- F6 Transparencia Datos · pie fijo con metadata de la tab activa (R-AUD-frescura) -->
+  <div id="dataSourceFooter" class="hidden fixed bottom-3 right-3 z-40 max-w-md bg-white/95 backdrop-blur border border-stone-200 shadow-md rounded-lg px-3 py-2 text-xs text-stone-600 flex items-center gap-2">
+    <span id="dsFreshIndicator" class="w-2 h-2 rounded-full bg-emerald-500" title="Datos frescos" aria-label="Indicador de frescura"></span>
+    <span class="font-medium text-stone-700"><span id="dsFuente">—</span></span>
+    <span class="text-stone-400">·</span>
+    <span><span id="dsFrecuencia">—</span></span>
+    <span class="text-stone-400">·</span>
+    <span>Hace <span id="dsHace">—</span></span>
+    <button type="button" id="dsTooltipBtn" class="ml-1 text-emerald-700 hover:underline" aria-haspopup="dialog">¿Cómo?</button>
+    <button type="button" id="dsCloseBtn" class="ml-1 text-stone-400 hover:text-stone-700" aria-label="Cerrar pie de transparencia">×</button>
+  </div>
+  <div id="dsTooltipModal" class="hidden fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4">
+    <div class="bg-white rounded-xl shadow-xl max-w-md w-full p-5">
+      <div class="flex items-start justify-between mb-3">
+        <h3 class="text-base font-semibold text-stone-800">¿Cómo se actualiza este dato?</h3>
+        <button type="button" id="dsTooltipClose" class="text-stone-400 hover:text-stone-700" aria-label="Cerrar">×</button>
+      </div>
+      <dl class="text-sm text-stone-700 space-y-2">
+        <div><dt class="text-stone-500 text-xs uppercase tracking-wide">Fuente</dt><dd id="dsModalFuente">—</dd></div>
+        <div><dt class="text-stone-500 text-xs uppercase tracking-wide">Frecuencia</dt><dd id="dsModalFrecuencia">—</dd></div>
+        <div><dt class="text-stone-500 text-xs uppercase tracking-wide">Responsable</dt><dd id="dsModalResponsable">—</dd></div>
+        <div><dt class="text-stone-500 text-xs uppercase tracking-wide">Cómo</dt><dd id="dsModalComo">—</dd></div>
+        <div><dt class="text-stone-500 text-xs uppercase tracking-wide">Última actualización</dt><dd id="dsModalUltima">—</dd></div>
+      </dl>
+    </div>
+  </div>
+
   <nav class="border-b border-stone-200 px-6 bg-white md:hidden" aria-label="Pestañas del panel (mobile)">
     <div class="nav-tabs-wrapper">
       <div class="flex gap-2 overflow-x-auto" role="tablist" aria-label="Pestañas del panel">
@@ -2651,7 +2678,7 @@
 
     <!-- ===================================================== -->
     <!-- TAB COMERCIAL · CRM Impulsa (mig 046 · 22-may-2026)    -->
-    <!-- Datos: panel.v_crm_impulsa_*  +  panel.v_crm_cliente_360 -->
+    <!-- Datos: panel.v_crm_impulsa_*  +  panel.v_cliente_360_full -->
     <!-- ===================================================== -->
     <section id="tabComercial" class="tab-content hidden">
       <header class="mb-4">
@@ -7597,8 +7624,73 @@ document.getElementById('resetPassword2').addEventListener('keypress', e => {
       // Marca activo el item del sidebar
       document.querySelectorAll('[data-v4-tab]').forEach(x => x.classList.remove('active'));
       a.classList.add('active');
+      // F6 transparencia datos · actualizar pie con metadata
+      if (typeof window.actualizarFooterFuente === 'function') {
+        window.actualizarFooterFuente(target);
+      }
       // En mobile, cerrar sidebar tras navegar
       if (window.innerWidth < 768) closeSidebar();
+    });
+  });
+})();
+
+// F6 Transparencia Datos · actualiza el pie fijo con metadata de la tab activa
+(function initDataSourceFooter() {
+  const fmtHace = (mins) => {
+    if (mins == null || isNaN(mins)) return '—';
+    if (mins < 60) return Math.round(mins) + ' min';
+    if (mins < 60 * 24) return Math.round(mins / 60) + ' h';
+    return Math.round(mins / (60 * 24)) + ' d';
+  };
+  const colorMap = { verde: 'bg-emerald-500', ambar: 'bg-amber-500', rojo: 'bg-red-500' };
+
+  window.actualizarFooterFuente = async function actualizarFooterFuente(tabCodigo) {
+    if (!tabCodigo || !window.sb) return;
+    try {
+      const { data, error } = await window.sb.schema('panel')
+        .from('v_frescura_datos')
+        .select('*')
+        .eq('codigo_tab', tabCodigo)
+        .maybeSingle();
+      const footer = document.getElementById('dataSourceFooter');
+      if (error || !data) { if (footer) footer.classList.add('hidden'); return; }
+      const ult = data.ultima_actualizacion ? new Date(data.ultima_actualizacion) : null;
+      const minsAgo = ult ? Math.round((Date.now() - ult.getTime()) / 60000) : null;
+      const setText = (id, v) => { const el = document.getElementById(id); if (el) el.textContent = v ?? '—'; };
+      setText('dsFuente', data.fuente_origen);
+      setText('dsFrecuencia', data.frecuencia_actualizacion);
+      setText('dsHace', fmtHace(minsAgo));
+      setText('dsModalFuente', data.fuente_origen);
+      setText('dsModalFrecuencia', data.frecuencia_actualizacion);
+      setText('dsModalResponsable', data.responsable);
+      setText('dsModalComo', data.como_se_actualiza);
+      setText('dsModalUltima', ult ? ult.toLocaleString('es-CL') : '—');
+      const ind = document.getElementById('dsFreshIndicator');
+      if (ind) {
+        ind.className = 'w-2 h-2 rounded-full ' + (colorMap[data.indicador_frescura] || 'bg-stone-400');
+        ind.title = 'Frescura: ' + (data.indicador_frescura || 'desconocida');
+      }
+      if (footer) footer.classList.remove('hidden');
+    } catch (e) { /* silencioso, no rompe UI */ }
+  };
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const btn = document.getElementById('dsTooltipBtn');
+    const modal = document.getElementById('dsTooltipModal');
+    const close = document.getElementById('dsTooltipClose');
+    const closeFooter = document.getElementById('dsCloseBtn');
+    if (btn && modal) btn.addEventListener('click', () => modal.classList.remove('hidden'));
+    if (close && modal) close.addEventListener('click', () => modal.classList.add('hidden'));
+    if (modal) modal.addEventListener('click', (e) => { if (e.target === modal) modal.classList.add('hidden'); });
+    if (closeFooter) closeFooter.addEventListener('click', () => {
+      const f = document.getElementById('dataSourceFooter'); if (f) f.classList.add('hidden');
+    });
+    // Hook adicional: cualquier click en button[data-tab] también actualiza el footer
+    document.querySelectorAll('button[data-tab]').forEach(b => {
+      b.addEventListener('click', () => {
+        const t = b.getAttribute('data-tab');
+        if (t) window.actualizarFooterFuente(t);
+      });
     });
   });
 })();
@@ -8584,7 +8676,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     try {
       const [cli360, cliFull] = await Promise.all([
-        sb.schema('panel').from('v_crm_cliente_360').select('*').eq('id_impulsa', idImpulsa).maybeSingle(),
+        sb.schema('panel').from('v_cliente_360_full').select('*').eq('id_impulsa', idImpulsa).maybeSingle(),
         sb.schema('panel').from('v_crm_impulsa_clientes').select('*').eq('id_impulsa', idImpulsa).maybeSingle()
       ]);
       if (cli360.error) throw cli360.error;


### PR DESCRIPTION
## Ola 1 ítems 15 + 25

### 15 · Switch query a v_cliente_360_full (10 min)

Línea 8587 (PC3 indicaba 7896, ubicación real es 8587). El call era:
\`\`\`js
sb.schema('panel').from('v_crm_cliente_360').select('*').eq('id_impulsa', idImpulsa).maybeSingle()
\`\`\`

Cambia a \`v_cliente_360_full\`. Ambas vistas existen en schema panel (verificado en information_schema). Comentario línea 2654 actualizado.

### 25 · F6 data-source-footer (30 min)

Pie fijo bottom-right (max-w-md, z-40) con metadata de la tab activa. SPEC original en public/F6-TRANSPARENCIA-DATOS.md.

Componentes agregados:
- \`#dataSourceFooter\` — chip flotante con indicador semáforo + fuente + frecuencia + \"Hace X min\" + botón \"¿Cómo?\".
- \`#dsTooltipModal\` — overlay con fuente/frecuencia/responsable/como/ultima_actualizacion.
- \`window.actualizarFooterFuente(tabCodigo)\` — fetch a \`panel.v_frescura_datos\` por codigo_tab, pinta semáforo + textos.
- Hook en dispatcher \`data-v4-tab\` (sidebar v4) + \`button[data-tab]\` (nav real).
- Cierre del footer con × por si molesta visualmente.

### Test plan
- [ ] Preview Vercel carga sin errores de consola.
- [ ] Hacer click en sidebar \"Cierres\" → footer aparece con semáforo verde (Ola 1 ítem 10 ya aplicado: cron actualiza frescura).
- [ ] Hacer click en \"¿Cómo?\" → abre modal con responsable + descripción.
- [ ] Cambiar a tab con fuente desconocida → footer se oculta (no rompe).
- [ ] Mobile <768px: footer no tapa nav.
- [ ] CRM Impulsa drawer (línea 8587) carga datos del cliente desde v_cliente_360_full.

🤖 Generated with [Claude Code](https://claude.com/claude-code)