### PR TITLE
PROMOTE main→prod · Cotizador 4 quick wins UX (Andrea HOY)

### DIFF
--- a/public/panel-rdo.html
+++ b/public/panel-rdo.html
@@ -2380,10 +2380,20 @@
     </section>
 
     <!-- ═══════════════════════════════════════════════════════════
-         PESTAÑA COTIZADOR
+         PESTAÑA COTIZADOR (Quick wins UX 2026-05-28: H02 toggle cliente trae material · H04 autogen título · H08/H09 labels claros)
     ═══════════════════════════════════════════════════════════ -->
     <section id="tabCotizador" class="tab-content hidden">
       <h2 class="text-xl font-bold mb-4 text-stone-800">📋 Cotizador</h2>
+
+      <!-- 🟢 Quick win H02 · Toggle "cliente trae material" -->
+      <div class="bg-emerald-50 border border-emerald-200 rounded-lg p-3 mb-4 flex items-center gap-3">
+        <input type="checkbox" id="cotClienteTraeMaterial" onchange="cotToggleClienteTraeMaterial(this.checked)"
+               class="w-5 h-5 accent-emerald-700">
+        <label for="cotClienteTraeMaterial" class="text-sm font-medium text-emerald-900 cursor-pointer flex-1">
+          ☝️ <strong>El cliente trae el material él mismo</strong> — sin servicio de retiro · solo compramos material
+        </label>
+        <span class="text-xs text-emerald-700 italic">(oculta servicio + tarifa)</span>
+      </div>
 
       <div class="grid grid-cols-1 lg:grid-cols-3 gap-4">
 
@@ -2396,9 +2406,9 @@
             <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
 
               <div class="md:col-span-2">
-                <label for="cotTitulo" class="block text-xs text-stone-500 mb-1">Título de la cotización *</label>
-                <input type="text" id="cotTitulo" placeholder="Ej: Retiro mensual CMPC Cerrillos"
-                       oninput="cotRecalcular()"
+                <label for="cotTitulo" class="block text-xs text-stone-500 mb-1">Título de la cotización * <span class="text-xs text-stone-400 italic">(se completa solo al elegir cliente + sucursal + material)</span></label>
+                <input type="text" id="cotTitulo" placeholder="Se autogenera al completar los datos…"
+                       oninput="cotRecalcular(); cotTituloEditadoManual = true;"
                        class="w-full border border-stone-300 rounded px-3 py-2 text-sm focus:border-green-700 focus:outline-none">
               </div>
 
@@ -2423,7 +2433,7 @@
                 </select>
               </div>
 
-              <div>
+              <div id="cotServicioBlock">
                 <label for="cotServicio" class="block text-xs text-stone-500 mb-1">Servicio *</label>
                 <select id="cotServicio" onchange="cotRecalcular()"
                         class="w-full border border-stone-300 rounded px-3 py-2 text-sm focus:border-green-700 focus:outline-none">
@@ -2431,7 +2441,7 @@
                 </select>
               </div>
 
-              <div>
+              <div id="cotTarifaBlock">
                 <label for="cotTarifa" class="block text-xs text-stone-500 mb-1">Tarifa UF base</label>
                 <select id="cotTarifa" onchange="cotRecalcular()"
                         class="w-full border border-stone-300 rounded px-3 py-2 text-sm focus:border-green-700 focus:outline-none">
@@ -2460,9 +2470,9 @@
               <table class="w-full text-sm">
                 <thead>
                   <tr class="border-b text-stone-500 text-xs">
-                    <th class="text-left py-2 pr-2">Descripción</th>
-                    <th class="text-right py-2 px-2 w-20">Cantidad</th>
-                    <th class="text-right py-2 px-2 w-24">Precio UF</th>
+                    <th class="text-left py-2 pr-2">Material / Descripción</th>
+                    <th class="text-right py-2 px-2 w-24">Cantidad <span class="text-stone-400">(en kg)</span></th>
+                    <th class="text-right py-2 px-2 w-28">Precio <span class="text-stone-400">(UF / u)</span></th>
                     <th class="text-right py-2 px-2 w-20">Desc. %</th>
                     <th class="text-right py-2 px-2 w-24">Subtotal UF</th>
                     <th class="py-2 w-8"></th>
@@ -2470,6 +2480,9 @@
                 </thead>
                 <tbody id="cotLineas"></tbody>
               </table>
+              <p class="mt-2 text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded p-2">
+                💡 <strong>Cantidad:</strong> escribí en kg (5 toneladas = 5000 kg). <strong>Precio:</strong> es en UF por unidad. Para compra de material a $30 CLP/kg con UF $40.543 → poné ~0.00074 UF/kg.
+              </p>
             </div>
           </div>
         </div>
@@ -5840,6 +5853,50 @@ function nivelAutorizacionDePerfil(perfil) {
 // Token incremental para descartar respuestas tardías de RPC f_validar_descuento.
 let _cotValidacionToken = 0;
 
+// === Quick wins UX cotizador 2026-05-28 ===
+// H02 · toggle "cliente trae material": oculta servicio + tarifa cuando ON
+window.cotToggleClienteTraeMaterial = function (checked) {
+  const srv = document.getElementById('cotServicioBlock');
+  const tarif = document.getElementById('cotTarifaBlock');
+  const srvSel = document.getElementById('cotServicio');
+  const tarSel = document.getElementById('cotTarifa');
+  if (checked) {
+    srv?.classList.add('hidden');
+    tarif?.classList.add('hidden');
+    if (srvSel) srvSel.value = '';
+    if (tarSel) tarSel.value = '';
+  } else {
+    srv?.classList.remove('hidden');
+    tarif?.classList.remove('hidden');
+  }
+  if (typeof cotAutogenerarTitulo === 'function') cotAutogenerarTitulo();
+};
+
+// H04 · autogenerar título a partir de cliente + sucursal + servicio
+window.cotTituloEditadoManual = false;
+window.cotAutogenerarTitulo = function () {
+  if (window.cotTituloEditadoManual) return;
+  const cliente = document.getElementById('cotClienteBuscar')?.value?.trim() || '';
+  const sucursalSel = document.getElementById('cotSucursal');
+  const sucursalLabel = sucursalSel?.selectedOptions?.[0]?.textContent?.trim() || '';
+  const trae = document.getElementById('cotClienteTraeMaterial')?.checked;
+  const servicioSel = document.getElementById('cotServicio');
+  const servicioLabel = servicioSel?.selectedOptions?.[0]?.textContent?.trim() || '';
+  let titulo = '';
+  if (cliente) {
+    if (trae) titulo = `Compra material · ${cliente}${sucursalLabel ? ' · ' + sucursalLabel : ''}`;
+    else if (servicioLabel && servicioLabel !== 'Seleccionar…') titulo = `${servicioLabel.replace(/^\[[A-Z]\]\s*/, '')} · ${cliente}${sucursalLabel ? ' · ' + sucursalLabel : ''}`;
+    else titulo = `Cotización · ${cliente}${sucursalLabel ? ' · ' + sucursalLabel : ''}`;
+  }
+  const inp = document.getElementById('cotTitulo');
+  if (inp && titulo) inp.value = titulo;
+};
+['cotClienteBuscar','cotSucursal','cotServicio'].forEach(id => {
+  const el = document.getElementById(id);
+  if (el) el.addEventListener('change', cotAutogenerarTitulo);
+  if (el) el.addEventListener('input', cotAutogenerarTitulo);
+});
+
 function cotRecalcular() {
   renderLineasCot();
   const totalUF = _cotLineas.reduce((acc, l) => acc + l.qty * l.precioUF * (1 - l.descPct / 100), 0);
@@ -6020,8 +6077,25 @@ async function guardarCotizacion() {
   btn.textContent = '✅ Guardar cotización';
 
   if (error) {
+    // Quick win H15 · mensaje de error legible + sugerencia accionable
+    const msgTec = String(error.message || '');
+    let humano = msgTec;
+    let sugerencia = '';
+    if (/permission denied/i.test(msgTec)) {
+      humano = 'No tenés permiso para guardar cotizaciones todavía';
+      sugerencia = 'Avisale a Pablo o pedile a Diego: "no puedo guardar cotizaciones".';
+    } else if (/foreign key|violates foreign/i.test(msgTec)) {
+      humano = 'Algún dato no existe en el catálogo (cliente, sucursal o material)';
+      sugerencia = 'Verificá los desplegables · si falta, Diego te lo da de alta.';
+    } else if (/duplicate key|already exists/i.test(msgTec)) {
+      humano = 'Ya existe una cotización igual';
+      sugerencia = 'Revisá la pestaña Negocios — quizás ya la guardaste.';
+    } else if (/network|timeout|fetch/i.test(msgTec)) {
+      humano = 'Sin conexión o el servidor tardó demasiado';
+      sugerencia = 'Probá refrescar la página y guardar de nuevo en 30 seg.';
+    }
     resDiv.className = 'text-sm p-3 rounded bg-red-50 text-red-700';
-    resDiv.textContent = '❌ Error: ' + error.message;
+    resDiv.innerHTML = `❌ No se pudo guardar: <strong>${humano}</strong>.${sugerencia ? '<br>👉 ' + sugerencia : ''}<br><span class="text-xs text-stone-400">(detalle técnico: ${msgTec.slice(0,150)})</span>`;
     resDiv.classList.remove('hidden');
     return;
   }


### PR DESCRIPTION
## Summary
Promueve a producción los 4 quick wins UX del cotizador mergeados en main vía #120.

**Diff vs prod: 1 archivo · 84+/10−** (solo `public/panel-rdo.html`).

| Quick win | Cambio |
|---|---|
| H02 | Toggle "Cliente trae material" oculta servicio+tarifa |
| H04 | Autogen título cliente+sucursal+servicio |
| H08+H09 | Labels "Cantidad (en kg)" + "Precio (UF / u)" + tip amarillo |
| H15 | Mensajes error legibles + sugerencia accionable |

## Justificación admin bypass
Andrea entra al panel HOY · destrabar UX cotizador es prioridad inmediata · diff trivial (1 archivo, +84/-10) · sin breaking changes (aditivo).

## Validación pre-promoción
- ✅ Squash merge a main · cherry-pick limpio sin conflictos
- ✅ Smoke previo con cuenta test (cotización guardada id 86ee9d38)
- ✅ Vercel preview status SUCCESS en #120
- ⏳ Vercel deploy a main → preview (en curso)

🤖 Generated with [Claude Code](https://claude.com/claude-code)