### PR TITLE
fix(panel-rdo): exponer window.sb a scripts externos

### DIFF
--- a/public/panel-rdo.html
+++ b/public/panel-rdo.html
@@ -2973,6 +2973,9 @@ async function ensureSucursalesCache() {
 
 function initSupabase() {
   sb = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+  // Exponer cliente a scripts externos (plan-evolucion, e360-context-menu, mfa-enrollment, etc.)
+  // que viven en otro <script> scope y sólo pueden acceder via window.sb.
+  window.sb = sb;
 }
 
 // ---------- helpers ----------


### PR DESCRIPTION
Causa raiz Evolucion vacio: window.sb era undefined. Patch 3 lineas en initSupabase(). Sin esto el reintento del PR 126 nunca encontraba sb.