### PR TITLE
fix(cotizador): desbloquear inputs cantidad/precio + multi-servicio (Andrea)

### DIFF
--- a/public/panel-rdo.html
+++ b/public/panel-rdo.html
@@ -2572,8 +2572,8 @@
                 <thead>
                   <tr class="border-b text-stone-500 text-xs">
                     <th class="text-left py-2 pr-2">Material / Descripción</th>
-                    <th class="text-right py-2 px-2 w-24">Cantidad <span class="text-stone-400">(en kg)</span></th>
-                    <th class="text-right py-2 px-2 w-28">Precio <span class="text-stone-400">(UF / u)</span></th>
+                    <th class="text-right py-2 px-2 w-32">Cantidad <span class="text-stone-400">(en kg)</span></th>
+                    <th class="text-right py-2 px-2 w-36">Precio <span class="text-stone-400">(UF / u)</span></th>
                     <th class="text-right py-2 px-2 w-20">Desc. %</th>
                     <th class="text-right py-2 px-2 w-24">Subtotal UF</th>
                     <th class="py-2 w-8"></th>
@@ -2582,7 +2582,8 @@
                 <tbody id="cotLineas"></tbody>
               </table>
               <p class="mt-2 text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded p-2">
-                💡 <strong>Cantidad:</strong> escribí en kg (5 toneladas = 5000 kg). <strong>Precio:</strong> es en UF por unidad. Para compra de material a $30 CLP/kg con UF $40.543 → poné ~0.00074 UF/kg.
+                💡 <strong>Cantidad:</strong> escribí en kg (5 toneladas = 5000 kg). <strong>Precio:</strong> es en UF por unidad. Para compra de material a $30 CLP/kg con UF $40.543 → poné ~0.00074 UF/kg.<br>
+                <strong>Múltiples servicios:</strong> agregá una línea por cada servicio con <em>+ Agregar línea</em> (ej. notario + destrucción + transporte = 3 líneas).
               </p>
             </div>
           </div>
@@ -5917,13 +5918,13 @@ function renderLineasCot() {
                class="w-full border border-stone-200 rounded px-2 py-1 text-sm focus:border-green-700 focus:outline-none">
       </td>
       <td class="py-1 px-2">
-        <input type="number" value="${l.qty}" min="0.01" step="0.01"
+        <input type="number" value="${l.qty}" min="0" step="any" inputmode="decimal"
                aria-label="Cantidad de la línea ${i + 1}"
                oninput="_cotLineas[${i}].qty = parseFloat(this.value)||0; cotRecalcular()"
                class="w-full border border-stone-200 rounded px-2 py-1 text-sm text-right focus:border-green-700 focus:outline-none">
       </td>
       <td class="py-1 px-2">
-        <input type="number" value="${l.precioUF}" min="0" step="0.0001"
+        <input type="number" value="${l.precioUF}" min="0" step="any" inputmode="decimal"
                aria-label="Precio UF de la línea ${i + 1}"
                oninput="_cotLineas[${i}].precioUF = parseFloat(this.value)||0; cotRecalcular()"
                class="w-full border border-stone-200 rounded px-2 py-1 text-sm text-right focus:border-green-700 focus:outline-none">


### PR DESCRIPTION
## Contexto
Andrea (T11 Comercial) bloqueada hoy 28-may PM con 4 problemas en el Cotizador. Origen: pedido Dusan MODO AUTONOMO para reparar urgente sin esperar Pablo. Bloqueaba cotizacion **Green Cup 5 toneladas a 0.00074 UF/kg** + **Emerson servicio notario 350.000**.

## Cambios en este PR
| Problema | Fix | Linea |
|---|---|---|
| P1 input cantidad no aceptaba 5000 | `step="any"` + `inputmode="decimal"` + columna `w-32` | 2575 + 5920 |
| P2 input precio no aceptaba 0.00074 ni 350000 | `step="any"` + `inputmode="decimal"` + columna `w-36` | 2576 + 5926 |
| P4 UX multiples servicios | Tip amarillo aclara que cada servicio va como linea via `+ Agregar linea` | 2585 |

**P3 Diego procesa imagenes**: queda **FUERA** de este PR — toca Edge Function. Documentado para Pablo en `reciclean-rdo/mayordomo/BANDEJA-PABLO-DIEGO-IMAGE-OCR.md`.

## Justificacion tecnica
Los inputs YA eran `type="number"` sin `maxlength`. El problema real era:
- `step="0.01"` (cantidad) y `step="0.0001"` (precio) hacian que el browser rebotara valores fuera del step (ej. `0.00074` no es multiplo de `0.0001` desde `0`).
- Columnas `w-24` / `w-28` clipaban visualmente y daban la sensacion de "limite 4,99".

`step="any"` desbloquea cualquier flotante. `inputmode="decimal"` mejora teclado movil.

## Validacion E2E (a hacer una vez Vercel deploye preview)
- [ ] Login `comercial.prueba@reciclean.cl`
- [ ] Cantidad acepta `5000` (Green Cup) — screenshot
- [ ] Precio acepta `0.00074` (compra material) — screenshot
- [ ] Precio acepta `350000` (servicio notario Emerson) — screenshot
- [ ] `+ Agregar linea` con 3 servicios distintos (notario + destruccion + transporte) — screenshot
- [ ] Total UF suma las 3 lineas correctamente

## Checklist obligatorio (CLAUDE.md reciclean-sistema regla #3)
- [x] No toca `package.json`, `vercel.json`, `vite.config.js`
- [x] Solo modifica `public/panel-rdo.html`
- [x] Branch propio (no push directo a `main`)
- [x] Cambio mobile-safe (`inputmode="decimal"` ayuda en mobile)
- [ ] Mobile responsive verificado en preview (post-deploy)

## Riesgos
- `min="0"` permite qty=0. La logica `guardarCotizacion()` ya filtra `precioUF === 0`, asi que no se guarda nada vacio. Aceptable.

## Despues del merge
1. Pablo revisa + mergea a `main`.
2. Dusan firma promocion `main -> prod` aparte.
3. PC1 registra afirmacion R-AUD-024 en `panel.afirmaciones_pc` con N=3 M=4 P=1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)