### PR TITLE
promote(main→prod): D-GANTT-VIVA-001 tab Gantt Viva + docs silos BLOQ

### DIFF
--- a/public/BLOQUEOS.md
+++ b/public/BLOQUEOS.md
@@ -1,0 +1,53 @@
+# Bloqueos abiertos · Panel RDO
+
+> Lista viva. Cada bloqueo se cierra con un commit que lo referencia: `cierra BLOQ-XXX`.
+> Generado: 2026-05-28 a partir de `DIAGNOSTICO-HERRAMIENTAS-POR-SILO.md`.
+> Actualizado: 2026-05-28 PM — cirugía silos cerró BLOQ-010 a BLOQ-018.
+
+---
+
+## ⏳ Esperando otro PC (no tocar)
+
+| ID | Tema | Bloqueado por | Owner que destrabará |
+|---|---|---|---|
+| BLOQ-001 | KPI por silo dentro de `public/panel-rdo.html` | PR #119 abierto (Pablo · ola1-data-source-footer) | PC1 después del merge |
+| BLOQ-002 | Hook nuevo en `data-v4-tab` para KPIs silo | PR #119 (Pablo usa el mismo dispatcher) | PC1 después del merge |
+| BLOQ-003 | Modificar zona ~línea 8587 (CRM Impulsa drawer) | PR #119 cambió esa query hoy | PC1 después del merge |
+| BLOQ-004 | Agregar nuevos `#dataSourceFooter*` o `#dsTooltipModal*` | PR #119 los crea | PC1 después del merge |
+| **BLOQ-019** | **Sincronizar sidebar v4 con 5 pestañas backend nuevas** (cumplimiento, dotacion, campanas, rutas, inventario) | PR #119 abierto (panel-rdo.html) | PC1 después del merge — auditoria-sidebar-v4 ya detecta los 5 fantasmas. Acción: agregar `<a data-v4-tab="…">` por cada una. |
+
+## ✅ Cerrado en esta sesión (sin colisión con Pablo)
+
+| ID | Tema | Migración / cambio | Verificación |
+|---|---|---|---|
+| BLOQ-010 | `panel.documentos.silo_negocio` etiquetado 01-11 | mig `bloq_010_etiquetar_documentos_silo_negocio` | 235/276 docs con silo; 41 NULL (legacy public/) |
+| BLOQ-011 | Pestaña `cumplimiento` silo 05 | mig `bloq_011_015_pestanas_silo_05_08_09_02_03` | Visible en `v_silo_pestanas_visibles` |
+| BLOQ-012 | Pestaña `dotacion` silo 08 | idem | Visible |
+| BLOQ-013 | Pestaña `campanas` silo 09 | idem | Visible |
+| BLOQ-014 | Pestaña `rutas` silo 02 | idem | Silo 02 pasa de 1 → 2 asignadas |
+| BLOQ-015 | Pestaña `inventario` silo 03 | idem | Silo 03 pasa de 1 → 2 asignadas |
+| BLOQ-016 | `estado_proyectos.ultima_verificacion` + trigger touch | mig `bloq_016_verificacion_proyectos` | 10/10 verificados + trigger `panel.trg_estado_proyectos_touch()` |
+| BLOQ-017 | `bandeja_precios` asignada a silos 01/07/10 | mig `bloq_017_asignar_bandeja_precios_silos` | Andrea (silo 01) la ve en su sidebar |
+| BLOQ-018 | EF `gap-notify` — verificada | (sin cambio, sólo diagnóstico) | ~14 invocaciones/h en 24h, todas HTTP 200. No hay gaps reales hoy → 0 alertas. EF sana. |
+
+## Reglas
+
+- **Antes de comenzar:** marcar el bloqueo como `in_progress` con commit `BLOQ-XXX: arranque` (no obligatorio, pero recomendado).
+- **Al cerrar:** el commit del merge debe incluir `cierra BLOQ-XXX` para que la próxima sesión lo elimine de esta lista.
+- **Cualquier ítem `⏳`** queda en lista de espera; no se asciende a `🔧` hasta que el PR bloqueante haya sido merged.
+- **BLOQ-019** es resultado natural de BLOQ-011..015: la BD está sana, falta sólo enganchar los links del sidebar (responsabilidad PC1 post-#119).
+
+---
+
+## Resumen para Dusan (CEO)
+
+| Antes (mañana 28-may) | Después (tarde 28-may) |
+|---|---|
+| 3 silos sin pestaña propia (05, 08, 09) | Los 3 ya tienen su pestaña backend |
+| 2 silos delgados (02, 03 sólo `pesaje`) | Ambos pasan a 2 pestañas |
+| 276 docs sin silo de negocio | 235 etiquetados, 41 legacy NULL |
+| `estado_proyectos.verificado_por = NULL` en los 10 | 10/10 con verificación + fuente + trigger automático |
+| `bandeja_precios` huérfana | Asignada a silos 01, 07, 10 |
+| EF `gap-notify` con 0 alertas | Confirmada sana (corre cada ~5 min) |
+
+Frontend (sidebar v4) ya las verá cuando Pablo cierre PR #119 y PC1 agregue los 5 `data-v4-tab=` correspondientes.

--- a/public/DIAGNOSTICO-HERRAMIENTAS-POR-SILO.md
+++ b/public/DIAGNOSTICO-HERRAMIENTAS-POR-SILO.md
@@ -1,0 +1,243 @@
+# Diagnóstico de Herramientas por Silo — Panel RDO
+
+**Generado:** 2026-05-28 · **Autor:** PC Dusan (diagnóstico, no reparación) · **Modo:** lectura + lectura + documentación.
+
+> ⚠️ Este informe sólo lee, no toca código. Reparaciones sugeridas se derivan a PC1 con etiqueta `🔧` o esperan a Pablo con `⏳`.
+
+---
+
+## Resumen ejecutivo
+
+| Métrica | Valor | Notas |
+|---|---:|---|
+| Silos definidos en `panel.silos` | **11** | El prompt menciona 8; estos cubren los 8 + 3 extra (Manifiestos, Cumplimiento, Tecnología, Personales) |
+| Pestañas definidas en `panel.pestanas` | 21 | 1 está activa pero NO asignada a ningún silo: `bandeja_precios` |
+| Pestañas visibles en `v_silo_pestanas_visibles` | 20 | 10 transversales + 10 asignadas |
+| Edge Functions activas | **41** | Todas en estado `ACTIVE` |
+| Migraciones aplicadas hoy | 10 | Más reciente: `20260528130129` |
+| Documentos indexados en `panel.documentos` | **276** | 205 `mayordomo` + 71 `public` — **NINGUNO etiquetado al código de silo real (01-11)** ⬜ |
+| Alertas UI abiertas (`v_alertas_ui_abiertas`) | **0** | Sistema existe; está vacío. No hay alertas por silo. |
+| KPIs por silo en BD | 1 tabla (`tesoreria_kpis`) | Sólo cubre silo 07 Finanzas. No hay `kpis_por_silo` ni `widget_portada_silo`. |
+| `panel.estado_proyectos` con `verificado_por=NULL` | **10 / 10** | Ningún proyecto tiene última verificación registrada |
+| PRs abiertos relevantes | **#119** (Pablo) | Toca `public/panel-rdo.html` (+94/-2) |
+
+**Lectura corta:** las pestañas existen y el control de acceso está sano. Lo que falla es la capa por silo de **KPIs**, **alertas**, **documentos** y **verificación de proyectos**. 4 silos no tienen ninguna pestaña asignada propia (sólo transversales).
+
+---
+
+## Mapeo silo solicitado por usuario → silo real BD
+
+| Solicitado en prompt | Código BD | Nombre en `panel.silos` | Acceso |
+|---|---|---|---|
+| Gerencia | 10 | Direccion-General | restringido |
+| Comercial | 01 | Comercial-Ventas | colaborativo |
+| Operaciones | 02 | Operaciones-Recoleccion | colaborativo |
+| Planta | 03 | Planta-Procesamiento | colaborativo |
+| Finanzas | 07 | Administracion-Finanzas | colaborativo |
+| RRHH | 08 | RRHH-Prevencion | colaborativo |
+| Logística | (no existe directo) | mapea a **02 Operaciones** + **04 Manifiestos** | — |
+| Marketing | 09 | Marketing-Comunicaciones | colaborativo |
+| _(extra)_ | 04 | Manifiestos-Trazabilidad | restringido |
+| _(extra)_ | 05 | Cumplimiento-Ambiental | colaborativo |
+| _(extra)_ | 06 | Tecnologia-Diego | técnico |
+| _(extra)_ | 11 | Temas-Personales | individual |
+
+---
+
+## Tabla consolidada — Cobertura por silo (✅/⚠️/❌/⬜)
+
+Leyenda: ✅ funciona · ⚠️ parcial · ❌ roto · ⬜ no existe · 🔧 PC1 puede reparar ya · ⏳ requiere Pablo.
+
+| Silo | Tabs asignadas | KPI portada | Tools Diego | Docs por silo | Alertas | Quién usa | 🔧 / ⏳ |
+|---|---:|---|---|---|---|---|---|
+| **10 Gerencia** | 10 ✅ | ⚠️ Card Diego Health + Bóveda; no hay KPI grupo dedicado | ✅ Diego usa identidad_diego_v1 | ⬜ todos los docs caen en `mayordomo/raiz` | ⬜ 0 abiertas | gerencia@ (owner), recepcion01@ | 🔧 KPIs grupo; ⬜ etiquetar docs |
+| **01 Comercial** | 7 ✅ (negocios, cotizador, cartera, oportunidades, reconciliacion, entregables, facturacion) | ⚠️ Diego sugiere · sin KPI ventas dedicado | ✅ "precio cartón X", "cotiza X tn de Y" | ⬜ docs `mayordomo/PLAN-2026` no atados al silo | ⬜ 0 | servicios@ (owner), comercial@, gestorcomercial@, Asistente@ | 🔧 KPI ventas portada |
+| **02 Operaciones** | 1 ⚠️ (sólo `pesaje`) | ⬜ sin KPI propio | ⚠️ Diego responde pero sin tool específica de rutas | ⬜ docs no atados | ⬜ 0 | gestorcomercial@ (owner), apoyo@, asistente.talca@, comercial@, operaciones.pm@, servicios@ | 🔧 agregar tab `rutas` o `flota`; KPI camiones-hoy |
+| **03 Planta** | 1 ⚠️ (sólo `pesaje`) | ⬜ sin KPI propio | ⚠️ sin tool inventario | ⬜ docs no atados | ⬜ 0 | gestorcomercial@ (owner), apoyo@, asistente.talca@, comercial@, operaciones.pm@, servicios@ | 🔧 agregar tab `inventario` o `materiales`; KPI stock hoy |
+| **04 Manifiestos** | 2 ⚠️ (`pesaje`, `rdo`) | ⬜ sin KPI propio (restringido a Dusan) | ⚠️ sin tool trazabilidad | ⬜ docs no atados | ⬜ 0 | gerencia@ (owner), dpinto@ (read) | 🔧 tab `trazabilidad` con vista de manifiestos por mes |
+| **05 Cumplimiento** | **0 ❌** sin pestañas propias | ⬜ sin KPI propio | ⚠️ sin tool SEREMI/REP | ⬜ docs no atados | ⬜ 0 | Asistente@ (owner) | 🔧 tab `cumplimiento` con `v_cumplimiento_legal` (R-AUD-029) |
+| **06 Tecnología** | 2 ✅ (`rdo`, `admin`) | ✅ Diego Health Card | ✅ tools admin (gestionar_permisos) | ⬜ docs no atados (skills sí en `mayordomo/skills`) | ⬜ 0 | recepcion01@ (owner), gerencia@, Asistente@, soporte@ | — |
+| **07 Finanzas** | 4 ✅ (`facturacion`, `negocios`, `rdo`, `reconciliacion`) | ✅ `panel.tesoreria_kpis` poblado | ⚠️ sin tool tesorería dedicada | ⬜ docs `analisis-facturacion-cl` no atados al silo | ⬜ 0 | dpinto@ (owner), gerencia@ (owner co), gestorcomercial@, Asistente@, recepcion01@, servicios@ | 🔧 conectar `tesoreria_kpis` a card de portada por silo |
+| **08 RRHH** | **0 ❌** sin pestañas propias | ⬜ sin KPI propio | ⚠️ sin tool dotación/asistencia | ⬜ docs no atados | ⬜ 0 | Asistente@ (owner), 6 más | 🔧 tab `dotacion` con `panel.dotacion`; KPI rotación |
+| **09 Marketing** | **0 ❌** sin pestañas propias | ⬜ sin KPI propio | ⚠️ sin tool campañas | ⬜ docs no atados | ⬜ 0 | gerencia@ (owner), recepcion01@ | 🔧 tab `campañas`; KPI alcance/leads |
+| **11 Personales** | **0 ✅ esperado** sólo transversales | n/a (individual) | n/a | n/a | n/a | dpinto@ (owner), gerencia@ (owner) | — (diseño correcto) |
+
+### Conteo por silo (origen pestañas)
+
+| Silo | Asignadas | Transversales | Total |
+|---|---:|---:|---:|
+| 01 Comercial | 7 | 10 | 17 |
+| 02 Operaciones | 1 | 10 | 11 |
+| 03 Planta | 1 | 10 | 11 |
+| 04 Manifiestos | 2 | 10 | 12 |
+| 05 Cumplimiento | **0** | 10 | 10 |
+| 06 Tecnología | 2 | 10 | 12 |
+| 07 Finanzas | 4 | 10 | 14 |
+| 08 RRHH | **0** | 10 | 10 |
+| 09 Marketing | **0** | 10 | 10 |
+| 10 Dirección | 10 | 10 | 20 |
+| 11 Personales | 0 | 10 | 10 |
+
+---
+
+## Herramientas declaradas y su estado real
+
+### A. Edge Functions activas (41 / 41) — todas ✅ deployed
+
+Las EF que sirven al panel y silos están todas activas. Última actualizada hoy: `comite-validacion` v4, `verificador-afirmaciones` v3, `auto-calcular-inputs` v2, `generar-pdf-cotizacion` v1.
+
+Distribución funcional declarada (no hay tabla de "EF↔silo", inferido por nombre):
+
+| Familia | EF | Estado | Silo principal |
+|---|---|---|---|
+| Diego | `diego-chat-process` v54, `diego-health-check` v7, `diego-followup-cron`, `diego-scoring-cron`, `diego-embeddings-generate`, `diego-buscar-semantico` | ✅ ACTIVE | Transversal / 06 |
+| RDO | `rdo-builder` v11, `serve-entregable-html`, `render-entregable-html`, `daily-digest` | ✅ ACTIVE | Transversal |
+| Comercial | `precio-aplicar`, `notif-precios`, `precios-competencia-scraper`, `generar-pdf-cotizacion` | ✅ ACTIVE | 01 / 07 |
+| Operaciones | `ingest-pesajes-csv`, `export-csv-pesajes`, `ocr-tablero`, `ocr-diesel`, `google-maps-distance` | ✅ ACTIVE | 02 / 03 |
+| Plan 2026 | `auto-calcular-inputs` v2, `kpi-auto-calcular` | ✅ ACTIVE | 10 |
+| Gobierno | `verificador-afirmaciones`, `comite-validacion`, `audit-ui-permisos`, `auditoria-sidebar-v4`, `gap-notify`, `gap-dispatch-whatsapp` | ✅ ACTIVE | 10 |
+| Bóveda 2026 | `canary-deploy-test`, `deploy-proxy`, `pc-status`, `pc-watchdog` | ✅ ACTIVE | 10 |
+| Auxiliares | `uf-diaria`, `f-uf-hoy`, `mockup-panel-rdo`, `upload-mockup-storage`, `binary-upload`, `upload-presentacion-handoff`, `audio-transcribe`, `dieguito-whatsapp`, `dieguito-process`, `papa-gotas` | ✅ ACTIVE | Transversales |
+
+### B. Tools Diego (vía `panel.config_ui.identidad_diego_v1` + `diego_chat_process_anti_mitomania`)
+
+Diego tiene tools declaradas, pero no hay tabla `panel.diego_tools_por_silo`. La herramienta es transversal: la misma identidad atiende a todos los silos.
+
+✅ Activas conocidas (inferido de la EF y prompt): `precio_consultar`, `cotizar`, `gestionar_permisos`, `buscar_semantico`. ⚠️ Sin tool dedicada para: rutas (silo 02), inventario (silo 03), cumplimiento legal (silo 05), dotación (silo 08), campañas (silo 09).
+
+### C. Widgets de portada
+
+Sólo dos widgets de portada declarados como vivos (verificados vía smoke):
+- `v4-diego-health` (✅ visto en panel) — silo 06
+- `Diego sugiere hoy` (✅ visto en panel) — transversal
+
+⬜ **Falta** widget por silo de: ventas (01), camiones/rutas (02), inventario (03), trazabilidad (04), cumplimiento (05), tesorería (07), dotación (08), campañas (09).
+
+### D. Documentos indexados
+
+| silo (literal) | proyectos | docs |
+|---|---|---:|
+| mayordomo | analisis-facturacion-cl, perfiles-draft, PLAN-2026, PLAN-2026-specs, PRESENTACION-SEREMI, raiz, skills | 205 |
+| public | audit-85, public | 71 |
+
+⬜ **Crítico:** Ningún documento usa `silo IN ('01','02',...,'11')`. La columna `silo` se usa como bucket de repositorio (mayordomo / public), no como silo de negocio. **El buscador por silo del panel no encuentra documentos del silo real.**
+
+### E. Alertas UI
+
+`panel.v_alertas_ui_abiertas` está vacío (0 filas). La vista existe (mig 067/ola sidebar). No hay alertas abiertas en ningún silo en este momento. Estado: ✅ vista funciona / ⚠️ no hay tráfico real → dudoso si la EF `gap-notify` está disparando bien.
+
+### F. Proyectos en estado_proyectos
+
+| Estado | Proyectos |
+|---|---|
+| vivo (✅) | Bóveda 2026 · Diego v21 · Impulsa CRM · Mayordomo v2 · Panel RDO v4 · WhatsApp Diego |
+| pendiente (⏸️) | Comité IAs · E360 · Tablero Trifásico · Ventana Profunda |
+
+⬜ Los 10 tienen `ultima_verificacion=NULL` y `verificado_por=NULL`. La tabla sirve como índice pero no hay ciclo de verificación que la mantenga viva (BÓVEDA 2026 cubre afirmaciones, no proyectos).
+
+---
+
+## Fase 3 — Riesgos de colisión con Pablo
+
+### PRs abiertos
+
+| PR | Repo | Título | Autor | Files | Actualizado |
+|---|---|---|---|---|---|
+| **#119** | reciclean-sistema | Ola 1 · F6 data-source-footer + switch v_cliente_360_full | dusanarancibia-cpu *(rama replit/Pablo)* | `public/panel-rdo.html` (+94/-2) | 2026-05-28 15:31 UTC |
+
+Reciclean-rdo: sin PRs abiertos.
+
+### Análisis del PR #119
+
+Pablo añade:
+- Línea 8587 — switch query CRM Impulsa drawer a `v_cliente_360_full` (afecta **silo 01 Comercial**)
+- `#dataSourceFooter` flotante + `#dsTooltipModal` + `window.actualizarFooterFuente(tabCodigo)`
+- Hooks en `data-v4-tab` y `button[data-tab]`
+
+### ⚠️ Riesgo de conflicto con mis merges de hoy
+
+Yo mergeé hoy (28-may) a main y prod **el mismo archivo** `public/panel-rdo.html`:
+- PR #128 (15:14 UTC) — añadió 3 líneas en `initSupabase()` (`window.sb = sb`).
+
+Pablo updateó #119 a las 15:31 UTC. `mergeable=UNKNOWN` al consultar. Sí hay riesgo de conflicto si Pablo no rebasó. **Recomendación al PC1:** antes de cualquier reparación que toque `public/panel-rdo.html`, esperar a que #119 esté merged a main. Cualquier cambio mío al mismo archivo después de hoy debe coordinarse.
+
+### Migraciones pendientes
+
+`supabase_migrations.schema_migrations` — 10 migraciones de hoy (28-may) aplicadas, ninguna pendiente. La más reciente: `20260528130129`. **Sin riesgo de DDL no aplicada.**
+
+### Edge Functions con deploy pendiente
+
+Ninguna EF marca `INACTIVE` ni `PENDING`. 41/41 ACTIVE.
+
+---
+
+## Fase 4 — Cola de reparaciones
+
+### 🔧 PC1 puede tomar YA (no toca archivos de Pablo)
+
+| # | Silo | Reparación | Tipo | Archivo / Tabla | Estimado |
+|---|---|---|---|---|---|
+| 1 | global | Etiquetar `panel.documentos.silo` con códigos 01–11 (hoy todos son `mayordomo`/`public`) | UPDATE | `panel.documentos` | DML reglas + 1 día revisión |
+| 2 | 05 Cumplimiento | Crear asignación `silo_pestanas` ('05', 'cumplimiento') + crear pestaña base `cumplimiento` apuntando a `v_cumplimiento_legal` (mig 067) | INSERT + 1 fila JS | `panel.silo_pestanas` · `panel.pestanas` · nuevo `cumplimiento-tab.js` | 1 sesión |
+| 3 | 08 RRHH | Crear pestaña `dotacion` apuntando a `panel.dotacion` | INSERT + 1 archivo JS | `panel.silo_pestanas` + nuevo `dotacion-tab.js` | 1 sesión |
+| 4 | 09 Marketing | Crear pestaña `campanas` (stub vacío inicialmente) | INSERT | `panel.silo_pestanas` | <30 min |
+| 5 | 02 Operaciones | Crear pestaña `rutas` apuntando a tablas `flota_*`/`recoleccion_*` | INSERT + JS | `panel.silo_pestanas` + tab nueva | 1 sesión |
+| 6 | 03 Planta | Crear pestaña `inventario` apuntando a `curated.materiales*` | INSERT + JS | `panel.silo_pestanas` + tab nueva | 1 sesión |
+| 7 | global | `panel.estado_proyectos` — poblar `verificado_por`/`ultima_verificacion` en los 10 registros + agregar trigger de revisión a Bóveda | DML + función | `panel.estado_proyectos` | 1 sesión |
+| 8 | global | `bandeja_precios` está en `panel.pestanas` pero NO en `silo_pestanas` — asignar a silos 01, 07, 10 (o desactivar si está obsoleta) | INSERT | `panel.silo_pestanas` | <15 min |
+| 9 | 06 Tecnología | Verificar que `gap-notify` esté generando alertas (hoy hay 0 abiertas — ¿la EF corre?) | Verificación logs EF | EF `gap-notify` | <30 min |
+
+Todas estas reparaciones requieren **DML/DDL en BD o crear scripts nuevos** — **no tocan `public/panel-rdo.html`**, por lo que no chocan con Pablo.
+
+### ⏳ Esperando a Pablo (NO tocar mientras #119 esté abierto)
+
+| # | Reparación | Razón |
+|---|---|---|
+| A | Cualquier KPI nuevo embebido directo en `public/panel-rdo.html` | Pablo está agregando footer + tooltip en ese archivo |
+| B | Cualquier hook nuevo a `data-v4-tab` o `button[data-tab]` | Pablo está usando esos dispatchers |
+| C | Modificar línea cercana a 8587 (CRM Impulsa drawer) | Pablo cambió esa query hoy |
+| D | Agregar nuevo `#dataSourceFooter*` o `#dsTooltipModal*` | Pablo lo está creando |
+
+Estos ítems se cargan en `BLOQUEOS.md` con dependencia "merge de #119".
+
+---
+
+## Acciones recomendadas (no ejecutadas)
+
+1. **Cargar BLOQUEOS.md** con los 4 ítems ⏳ esperando a Pablo (PR #119).
+2. **Cola PC1** con los 9 ítems 🔧 listos para reparar sin colisión.
+3. **Aviso a Dusan:** los silos 05, 08, 09 hoy son sólo "fachada" — sus usuarios ven pestañas transversales pero ninguna herramienta propia. Decisión necesaria: ¿priorizar uno?
+4. **R-AUD-007 + R-AUD-009** se reafirman: si Diego es preguntado por dotación / cumplimiento / marketing, **debe responder "no tengo herramienta dedicada para este silo"** antes de inventar.
+
+---
+
+## Anexo — Acceso por silo (`panel.silo_acceso`)
+
+| Silo | Owners | Editors | Readers |
+|---|---|---|---|
+| 01 Comercial | servicios@ | Asistente@, comercial@, gestorcomercial@ | — |
+| 02 Operaciones | gestorcomercial@ | apoyo@, asistente.talca@, comercial@, operaciones.pm@, servicios@ | — |
+| 03 Planta | gestorcomercial@ | apoyo@, asistente.talca@, comercial@, operaciones.pm@, servicios@ | — |
+| 04 Manifiestos | gerencia@ | — | dpinto@ |
+| 05 Cumplimiento | Asistente@ | — | — |
+| 06 Tecnología | recepcion01@ | Asistente@, gerencia@, soporte@ | — |
+| 07 Finanzas | dpinto@, gerencia@ | Asistente@, gestorcomercial@, recepcion01@, servicios@ | — |
+| 08 RRHH | Asistente@ | comercial@, gerencia@, gestorcomercial@, recepcion01@ | contador4@, dpinto@ |
+| 09 Marketing | gerencia@ | recepcion01@ | — |
+| 10 Gerencia | gerencia@ | recepcion01@ | — |
+| 11 Personales | dpinto@, gerencia@ | — | — |
+
+---
+
+## Bloqueos abiertos (referencia BLOQUEOS.md)
+
+```
+[2026-05-28]
+- BLOQ-001 — Reparar KPI silo en panel-rdo.html · Esperando PR #119 merge · Owner: PC1.
+- BLOQ-002 — Hook nuevo en data-v4-tab para KPIs silo · Esperando PR #119 merge · Owner: PC1.
+- BLOQ-003 — `panel.documentos.silo` etiquetado por silo real · Listo para PC1 ya · Owner: PC1.
+- BLOQ-004 — Tab `cumplimiento` silo 05 · Listo para PC1 ya · Owner: PC1.
+- BLOQ-005 — Tab `dotacion` silo 08 · Listo para PC1 ya · Owner: PC1.
+- BLOQ-006 — Pestaña `campanas` silo 09 · Listo para PC1 ya · Owner: PC1.
+- BLOQ-007 — Verificar EF `gap-notify` (0 alertas hoy) · Diagnóstico previo a fix · Owner: PC1.
+```

--- a/public/panel-rdo.html
+++ b/public/panel-rdo.html
@@ -20,6 +20,9 @@
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js" defer></script>
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" defer></script>
+  <!-- D-GANTT-VIVA-001 · Frappe Gantt CDN -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/frappe-gantt@0.6.1/dist/frappe-gantt.css">
+  <script src="https://cdn.jsdelivr.net/npm/frappe-gantt@0.6.1/dist/frappe-gantt.umd.js" defer></script>
   <style>
     .app-container { display: none; }
     .login-container { display: flex; }
@@ -577,6 +580,7 @@
         <button data-tab="bandeja_dieg"   class="tab-btn py-3 px-3 text-stone-600"     role="tab" aria-selected="false" aria-controls="tabBandejaDiego">📥 Bandeja Diego</button>
         <button data-tab="ops_diarias"    class="tab-btn py-3 px-3 text-stone-600"     role="tab" aria-selected="false" aria-controls="tabOpsDiarias">🌅 Operaciones Día</button>
         <button data-tab="comercial"      class="tab-btn py-3 px-3 text-stone-600"     role="tab" aria-selected="false" aria-controls="tabComercial">💼 Comercial</button>
+        <button data-tab="gantt"          class="tab-btn py-3 px-3 text-stone-600"     role="tab" aria-selected="false" aria-controls="tabGantt">📊 Gantt Viva</button>
         <button data-tab="admin" id="adminTab" class="tab-btn py-3 px-3 text-stone-600 hidden" role="tab" aria-selected="false" aria-controls="tabAdmin">⚙️ Admin</button>
       </div>
       <span class="chevron-more" aria-hidden="true">›</span>
@@ -2867,6 +2871,83 @@
       </div>
     </section>
 
+    <!-- D-GANTT-VIVA-001 · Tab Gantt Viva (PC2 Pablo 2026-05-29 PM) -->
+    <section id="tabGantt" class="tab-content hidden">
+      <div class="flex items-center justify-between mb-3">
+        <h2 class="text-xl font-bold text-stone-800">📊 Gantt Viva</h2>
+        <div id="ganttResumenBadge" class="text-sm text-stone-600">Cargando…</div>
+      </div>
+
+      <!-- Filtros -->
+      <div class="bg-white p-3 rounded-lg shadow-sm mb-3 flex flex-wrap items-end gap-3 text-sm">
+        <div>
+          <label for="ganttFiltroTipo" class="block text-xs text-stone-500 mb-1">Eje</label>
+          <select id="ganttFiltroTipo" class="border border-stone-300 rounded px-2 py-1 text-sm">
+            <option value="">Todos</option>
+            <option value="iniciativa">Iniciativas (D-NNN)</option>
+            <option value="tarea">Tareas en cola</option>
+            <option value="card">Cards portada</option>
+            <option value="silo">Silos</option>
+            <option value="pc">PCs</option>
+          </select>
+        </div>
+        <div>
+          <label for="ganttFiltroSilo" class="block text-xs text-stone-500 mb-1">Silo</label>
+          <select id="ganttFiltroSilo" class="border border-stone-300 rounded px-2 py-1 text-sm">
+            <option value="">Todos</option>
+            <option value="01">01 Comercial</option>
+            <option value="02">02 Operaciones</option>
+            <option value="03">03 Planta</option>
+            <option value="04">04 Manifiestos</option>
+            <option value="05">05 Cumplimiento</option>
+            <option value="06">06 Tecnología</option>
+            <option value="07">07 Admin/Finanzas</option>
+            <option value="08">08 RRHH</option>
+            <option value="09">09 Marketing</option>
+            <option value="10">10 Dirección</option>
+            <option value="11">11 Personales</option>
+          </select>
+        </div>
+        <div>
+          <label for="ganttFiltroColor" class="block text-xs text-stone-500 mb-1">Color</label>
+          <select id="ganttFiltroColor" class="border border-stone-300 rounded px-2 py-1 text-sm">
+            <option value="">Todos</option>
+            <option value="rojo">🔴 Solo rojo</option>
+            <option value="amarillo">🟡 Amarillo</option>
+            <option value="verde">🟢 Verde</option>
+          </select>
+        </div>
+        <button id="ganttRefreshBtn" type="button" class="bg-green-700 hover:bg-green-800 text-white px-3 py-1.5 rounded text-sm font-semibold">↻ Refrescar</button>
+        <span id="ganttLastUpdate" class="text-xs text-stone-400 ml-auto">—</span>
+      </div>
+
+      <!-- Container Frappe Gantt -->
+      <div class="bg-white rounded-lg shadow-sm p-3 overflow-x-auto">
+        <div id="ganttContainer" style="min-height: 480px;">
+          <div class="text-sm text-stone-500 p-6 text-center">Cargando carta gantt…</div>
+        </div>
+      </div>
+
+      <!-- Leyenda + nota -->
+      <div class="mt-3 text-xs text-stone-500 flex flex-wrap gap-4">
+        <span><span class="inline-block w-3 h-3 rounded mr-1" style="background:#059669"></span>Verde — al día</span>
+        <span><span class="inline-block w-3 h-3 rounded mr-1" style="background:#d97706"></span>Amarillo — atrasado &gt; SLA verde</span>
+        <span><span class="inline-block w-3 h-3 rounded mr-1" style="background:#dc2626"></span>Rojo — vencido / fantasma / sancionado</span>
+        <span class="ml-auto">D-GANTT-VIVA-001 · refresh auto cada 60s</span>
+      </div>
+
+      <style>
+        #ganttContainer .gantt .bar-verde rect.bar { fill: #059669; }
+        #ganttContainer .gantt .bar-verde rect.bar-progress { fill: #047857; }
+        #ganttContainer .gantt .bar-amarillo rect.bar { fill: #d97706; }
+        #ganttContainer .gantt .bar-amarillo rect.bar-progress { fill: #b45309; }
+        #ganttContainer .gantt .bar-rojo rect.bar { fill: #dc2626; }
+        #ganttContainer .gantt .bar-rojo rect.bar-progress { fill: #991b1b; }
+        #ganttContainer .gantt .bar-sindatos rect.bar { fill: #9ca3af; }
+        #ganttContainer .gantt .bar-sindatos rect.bar-progress { fill: #6b7280; }
+      </style>
+    </section>
+
     <section id="tabAdmin" class="tab-content hidden">
       <h2 class="text-xl font-bold mb-3 text-stone-800">Administración</h2>
       <div class="bg-white p-5 rounded-lg shadow-sm mb-4">
@@ -2965,7 +3046,7 @@ let recordedUrl = null;
 //
 // FALLBACKS (defaults): si las consultas fallan (red/RLS/tabla vacía) el
 // HTML no se rompe — el navbar aparece como en versión hardcoded.
-const FALLBACK_TABS_GLOBALES   = ['portada', 'pesaje', 'facturacion', 'dieguito', 'comunicados', 'manual', 'mi_memoria', 'rdo', 'negocios', 'cotizador', 'cierres', 'precios', 'bandeja_precios', 'operativos', 'reconciliacion', 'cartera', 'oportunidades', 'entregables', 'bandeja_dieg', 'ops_diarias', 'admin'];
+const FALLBACK_TABS_GLOBALES   = ['portada', 'pesaje', 'facturacion', 'dieguito', 'comunicados', 'manual', 'mi_memoria', 'rdo', 'negocios', 'cotizador', 'cierres', 'precios', 'bandeja_precios', 'operativos', 'reconciliacion', 'cartera', 'oportunidades', 'entregables', 'bandeja_dieg', 'ops_diarias', 'gantt', 'admin'];
 const FALLBACK_TABS_TRANSVERSALES = ['portada', 'dieguito', 'comunicados', 'cierres', 'precios', 'operativos'];
 const FALLBACK_BYPASS_EMAILS = [
   'gerencia@gestionrepchile.cl',
@@ -10695,5 +10776,125 @@ document.addEventListener('DOMContentLoaded', () => {
 <!-- 📈 Plan 2026 · tab Evolución (Bloque C · firmado 2026-05-28) -->
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js" defer></script>
 <script src="/js/plan-evolucion.js" defer></script>
+
+<!-- D-GANTT-VIVA-001 · Bootstrap tab Gantt Viva (PC2 Pablo 2026-05-29 PM) -->
+<script>
+(function () {
+  const EF_URL = '/functions/v1/gantt-viva-feed';
+  let ganttInstance = null;
+  let pollTimer = null;
+  let lastFetchAt = null;
+
+  function buildQS() {
+    const tipo  = document.getElementById('ganttFiltroTipo')?.value || '';
+    const silo  = document.getElementById('ganttFiltroSilo')?.value || '';
+    const color = document.getElementById('ganttFiltroColor')?.value || '';
+    const qs = new URLSearchParams();
+    if (tipo)  qs.set('tipo', tipo);
+    if (silo)  qs.set('silo', silo);
+    if (color) qs.set('color', color);
+    return qs.toString();
+  }
+
+  async function fetchFeed() {
+    try {
+      const session = await sb.auth.getSession();
+      const token = session?.data?.session?.access_token || SUPABASE_ANON_KEY;
+      const qs = buildQS();
+      const url = `${SUPABASE_URL}${EF_URL}${qs ? '?' + qs : ''}`;
+      const res = await fetch(url, { headers: { 'Authorization': `Bearer ${token}` } });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      return await res.json();
+    } catch (e) {
+      console.warn('[GanttViva] fetch error:', e);
+      return null;
+    }
+  }
+
+  function renderResumen(resumen) {
+    const el = document.getElementById('ganttResumenBadge');
+    if (!el || !resumen) return;
+    const r = resumen.rojo || 0, a = resumen.amarillo || 0, v = resumen.verde || 0, s = resumen.sin_datos || 0, t = resumen.total || 0;
+    el.innerHTML = `<span class="text-red-600 font-semibold">🔴 ${r}</span> · <span class="text-amber-600 font-semibold">🟡 ${a}</span> · <span class="text-emerald-700 font-semibold">🟢 ${v}</span> · <span class="text-stone-400">⬜ ${s}</span> · <span class="text-stone-500">Σ ${t}</span>`;
+  }
+
+  function renderGantt(rows) {
+    const container = document.getElementById('ganttContainer');
+    if (!container) return;
+    if (!rows || rows.length === 0) {
+      container.innerHTML = '<div class="text-sm text-stone-500 p-6 text-center">Sin elementos para los filtros actuales.</div>';
+      ganttInstance = null;
+      return;
+    }
+    if (typeof Gantt === 'undefined') {
+      container.innerHTML = '<div class="text-sm text-amber-700 p-6 text-center">Frappe Gantt no cargó. Verificá conexión CDN.</div>';
+      return;
+    }
+    const tasks = rows
+      .filter(r => r.start && r.end)
+      .map(r => ({ id: r.id, name: r.name, start: r.start, end: r.end, progress: r.progress, custom_class: r.custom_class, dependencies: '' }));
+    if (tasks.length === 0) {
+      container.innerHTML = '<div class="text-sm text-stone-500 p-6 text-center">Hay elementos pero sin fechas mapeables (silos / PCs agregados).</div>';
+      return;
+    }
+    container.innerHTML = '<svg id="ganttSvg" width="100%" height="480"></svg>';
+    try {
+      ganttInstance = new Gantt('#ganttSvg', tasks, {
+        view_mode: 'Week',
+        bar_height: 22,
+        bar_corner_radius: 4,
+        padding: 14,
+        date_format: 'YYYY-MM-DD',
+        custom_popup_html: (t) => `<div style="padding:6px 10px;background:#fff;border:1px solid #d6d3d1;border-radius:6px;font-size:13px;box-shadow:0 2px 8px rgba(0,0,0,.1)"><strong>${t.name}</strong><br><span style="color:#78716c">${t.start} → ${t.end}</span><br><span style="color:#78716c">${t.progress}%</span></div>`
+      });
+    } catch (e) {
+      console.error('[GanttViva] Gantt render error:', e);
+      container.innerHTML = `<div class="text-sm text-red-600 p-6 text-center">Error renderizando Gantt: ${e.message}</div>`;
+    }
+  }
+
+  function updateLastUpdate() {
+    const el = document.getElementById('ganttLastUpdate');
+    if (el) el.textContent = lastFetchAt ? `Última actualización: ${lastFetchAt.toLocaleTimeString('es-CL')}` : '—';
+  }
+
+  async function refrescar() {
+    const data = await fetchFeed();
+    if (!data || !data.ok) return;
+    lastFetchAt = new Date();
+    updateLastUpdate();
+    renderResumen(data.resumen);
+    renderGantt(data.rows);
+  }
+
+  function startPolling() {
+    stopPolling();
+    pollTimer = setInterval(() => { if (isTabActive()) refrescar(); }, 60_000);
+  }
+  function stopPolling() { if (pollTimer) { clearInterval(pollTimer); pollTimer = null; } }
+
+  function isTabActive() {
+    const sec = document.getElementById('tabGantt');
+    return sec && !sec.classList.contains('hidden');
+  }
+
+  function init() {
+    document.querySelector('button[data-tab="gantt"]')?.addEventListener('click', () => {
+      setTimeout(() => { refrescar(); startPolling(); }, 100);
+    });
+    document.getElementById('ganttRefreshBtn')?.addEventListener('click', refrescar);
+    ['ganttFiltroTipo','ganttFiltroSilo','ganttFiltroColor'].forEach(id => {
+      document.getElementById(id)?.addEventListener('change', refrescar);
+    });
+    document.querySelectorAll('button[data-tab]:not([data-tab="gantt"])').forEach(b => b.addEventListener('click', stopPolling));
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Promoción main → prod (Dusan autorizó acción Claude 2026-05-29 PM-late+3)

3 commits acumulados desde el último deploy prod (commit \`8a373b95\` 28-may 15:48 UTC):

### 1. \`b51cad3\` · Merge PR #133 — feat(panel): D-GANTT-VIVA-001 tab Gantt Viva con Frappe Gantt
- CDN Frappe Gantt v0.6.1 (CSS + UMD JS).
- button-tab \`data-tab="gantt"\` + sidebar v4 vía \`panel.silo_pestanas\` (silos 06 + 10).
- \`<section id="tabGantt">\` con badge resumen 🔴🟡🟢⬜Σ + filtros (eje, silo, color) + container Frappe Gantt + estilos custom_class.
- IIFE bootstrap: fetch EF \`/functions/v1/gantt-viva-feed\` con session token, polling 60s mientras tab activo.

### 2. \`bdd3b02\` · feat(panel): commit interno del PR #133

### 3. \`19ba6c1\` · docs(silos): cirugía BLOQ-010 a BLOQ-018 cerrados + BLOQ-019 abierto (PR #131)
- **NO autoría PC2 Pablo.** Trabajo de otro PC.

## Backend asociado (YA en prod Supabase, no en este PR)

- Mig 137 — tablas + matview + RPCs (29-may 14:00 UTC)
- Mig 138 — seguridad (G1 + silo_acceso) (29-may 14:33 UTC)
- Mig 139 — fix persona no-admin (29-may 14:40 UTC)
- EF \`gantt-viva-feed\` v2 ACTIVE (cliente JWT-aware)
- Pestaña \`gantt\` en \`panel.pestanas\` activa para silos 06+10

## Quién va a ver qué después del deploy

- **Dusan + Pablo** (admins, \`is_gantt_admin=true\`): tab "📊 Gantt Viva" visible · 115 filas · todos los silos.
- **Andrea, Ingrid, otros comerciales**: **NO ven el tab** porque \`silo_pestanas\` lo restringe a silos 06+10, los cuales no tienen. Sin riesgo de leak.
- **anon (sin login)**: 0 filas si llega al endpoint (REVOKE aplicado).

## Test plan post-merge

- [ ] Vercel deploy automático a \`prod\` branch → producción \`reciclean-sistema.vercel.app\`.
- [ ] Smoke visual Dusan o Pablo: tab Gantt Viva visible + renderiza barras de colores.
- [ ] Smoke visual Andrea: NO ve tab (silos restringidos correctamente).
- [ ] Curl con anon key → 0 filas.
- [ ] Verificar PR #131 (BLOQ-019) en runtime — pregunta a su autor original si dudás.

🤖 Generated with [Claude Code](https://claude.com/claude-code)