### PR TITLE
feat(panel): R-AUD-042 tab Estado vivo 4 PCs (polling 10s)

### DIFF
--- a/public/panel-rdo.html
+++ b/public/panel-rdo.html
@@ -580,6 +580,7 @@
         <button data-tab="bandeja_dieg"   class="tab-btn py-3 px-3 text-stone-600"     role="tab" aria-selected="false" aria-controls="tabBandejaDiego">📥 Bandeja Diego</button>
         <button data-tab="ops_diarias"    class="tab-btn py-3 px-3 text-stone-600"     role="tab" aria-selected="false" aria-controls="tabOpsDiarias">🌅 Operaciones Día</button>
         <button data-tab="comercial"      class="tab-btn py-3 px-3 text-stone-600"     role="tab" aria-selected="false" aria-controls="tabComercial">💼 Comercial</button>
+        <button data-tab="pcs_vivo"       class="tab-btn py-3 px-3 text-stone-600"     role="tab" aria-selected="false" aria-controls="tabPcsVivo">🟢 Estado vivo 4 PCs</button>
         <button data-tab="gantt"          class="tab-btn py-3 px-3 text-stone-600"     role="tab" aria-selected="false" aria-controls="tabGantt">📊 Gantt Viva</button>
         <button data-tab="admin" id="adminTab" class="tab-btn py-3 px-3 text-stone-600 hidden" role="tab" aria-selected="false" aria-controls="tabAdmin">⚙️ Admin</button>
       </div>
@@ -2871,6 +2872,55 @@
       </div>
     </section>
 
+    <!-- R-AUD-042 · Tab Estado vivo 4 PCs (PC2 Pablo 2026-05-29 PM) -->
+    <section id="tabPcsVivo" class="tab-content hidden">
+      <div class="flex items-center justify-between mb-3">
+        <h2 class="text-xl font-bold text-stone-800">🟢 Estado vivo de los 4 PCs</h2>
+        <div class="text-xs text-stone-500"><span id="pcsVivoLastUpdate">—</span> · polling 10s</div>
+      </div>
+
+      <div id="pcsVivoGrid" class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div class="bg-white p-6 rounded-lg shadow-sm text-stone-500 text-sm text-center col-span-full">Cargando estado de los 4 PCs…</div>
+      </div>
+
+      <!-- Modal mandar comando -->
+      <div id="pcsVivoCmdModal" class="hidden fixed inset-0 z-50 bg-black/50 flex items-center justify-center p-4">
+        <div class="bg-white rounded-lg shadow-xl max-w-md w-full p-5">
+          <div class="flex items-center justify-between mb-3">
+            <h3 class="font-bold text-stone-800">📨 Mandar comando a <span id="pcsVivoCmdTarget"></span></h3>
+            <button onclick="pcsVivoCloseModal()" class="text-stone-400 hover:text-stone-700 text-xl">×</button>
+          </div>
+          <label class="block text-xs text-stone-500 mb-1">Tipo de comando</label>
+          <select id="pcsVivoCmdTipo" class="w-full border border-stone-300 rounded px-2 py-1.5 text-sm mb-3">
+            <option value="cerrar">🛑 cerrar — pedir cierre limpio</option>
+            <option value="pausar">⏸️ pausar — detener tareas en curso</option>
+            <option value="reanudar">▶️ reanudar — retomar tras pausa</option>
+            <option value="redirigir_prioridad">🔀 redirigir_prioridad — reordenar cola</option>
+            <option value="reset_cola">♻️ reset_cola — limpiar cola y empezar de 0</option>
+            <option value="desbloquear">🔓 desbloquear — quitar sanción/bloqueo</option>
+          </select>
+          <label class="block text-xs text-stone-500 mb-1">Motivo (obligatorio)</label>
+          <textarea id="pcsVivoCmdMotivo" rows="3" class="w-full border border-stone-300 rounded px-2 py-1.5 text-sm mb-3" placeholder="Razón del comando para quedar en el log…"></textarea>
+          <div id="pcsVivoCmdError" class="hidden text-sm text-red-600 mb-2"></div>
+          <div class="flex justify-end gap-2">
+            <button onclick="pcsVivoCloseModal()" class="px-3 py-1.5 text-sm text-stone-600 hover:bg-stone-100 rounded">Cancelar</button>
+            <button onclick="pcsVivoSendCmd()" id="pcsVivoCmdSendBtn" class="bg-green-700 hover:bg-green-800 text-white px-4 py-1.5 rounded text-sm font-semibold">Enviar</button>
+          </div>
+        </div>
+      </div>
+
+      <style>
+        .pcs-card { background: #fff; border-radius: 12px; padding: 1.25rem; box-shadow: 0 1px 3px rgba(0,0,0,.05); border-top: 4px solid #059669; }
+        .pcs-card.modo-apagado { border-top-color: #9ca3af; }
+        .pcs-card.modo-interactivo { border-top-color: #d97706; }
+        .pcs-card.modo-sancionado { border-top-color: #dc2626; }
+        .pcs-card.modo-ventana { border-top-color: #6366f1; }
+        .pcs-badge { display: inline-block; padding: 2px 8px; border-radius: 999px; font-size: .7rem; font-weight: 600; }
+        .pcs-stat { font-size: 2.5rem; font-weight: 700; line-height: 1; }
+        .pcs-stat-label { font-size: .7rem; color: #78716c; text-transform: uppercase; letter-spacing: .03em; }
+      </style>
+    </section>
+
     <!-- D-GANTT-VIVA-001 · Tab Gantt Viva (PC2 Pablo 2026-05-29 PM) -->
     <section id="tabGantt" class="tab-content hidden">
       <div class="flex items-center justify-between mb-3">
@@ -3046,7 +3096,7 @@ let recordedUrl = null;
 //
 // FALLBACKS (defaults): si las consultas fallan (red/RLS/tabla vacía) el
 // HTML no se rompe — el navbar aparece como en versión hardcoded.
-const FALLBACK_TABS_GLOBALES   = ['portada', 'pesaje', 'facturacion', 'dieguito', 'comunicados', 'manual', 'mi_memoria', 'rdo', 'negocios', 'cotizador', 'cierres', 'precios', 'bandeja_precios', 'operativos', 'reconciliacion', 'cartera', 'oportunidades', 'entregables', 'bandeja_dieg', 'ops_diarias', 'gantt', 'admin'];
+const FALLBACK_TABS_GLOBALES   = ['portada', 'pesaje', 'facturacion', 'dieguito', 'comunicados', 'manual', 'mi_memoria', 'rdo', 'negocios', 'cotizador', 'cierres', 'precios', 'bandeja_precios', 'operativos', 'reconciliacion', 'cartera', 'oportunidades', 'entregables', 'bandeja_dieg', 'ops_diarias', 'pcs_vivo', 'gantt', 'admin'];
 const FALLBACK_TABS_TRANSVERSALES = ['portada', 'dieguito', 'comunicados', 'cierres', 'precios', 'operativos'];
 const FALLBACK_BYPASS_EMAILS = [
   'gerencia@gestionrepchile.cl',
@@ -10776,6 +10826,173 @@ document.addEventListener('DOMContentLoaded', () => {
 <!-- 📈 Plan 2026 · tab Evolución (Bloque C · firmado 2026-05-28) -->
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js" defer></script>
 <script src="/js/plan-evolucion.js" defer></script>
+
+<!-- R-AUD-042 · Bootstrap tab Estado vivo 4 PCs (PC2 Pablo 2026-05-29 PM) -->
+<script>
+(function () {
+  let pollTimer = null;
+  let cmdTargetPc = null;
+
+  const PC_LABELS = {
+    'PC1_dusan': { emoji: '🟦', titulo: 'PC1 Dusan', subtitulo: 'Comandante · interactivo con Dusan' },
+    'PC2_pablo': { emoji: '🟩', titulo: 'PC2 Pablo', subtitulo: 'Supervisor excepciones · DDL + prod' },
+    'PC3_camaras': { emoji: '🟨', titulo: 'PC3 Cámaras', subtitulo: 'Operador externo · scrapes + EFs' },
+    'PC4_desocupado': { emoji: '🟪', titulo: 'PC4 Desocupado', subtitulo: 'Ingeniero autónomo · DDL + merges' },
+  };
+
+  const MODO_BADGES = {
+    'produccion': { text: 'producción', cls: 'bg-emerald-100 text-emerald-800' },
+    'interactivo': { text: 'interactivo', cls: 'bg-amber-100 text-amber-800' },
+    'apagado': { text: 'apagado', cls: 'bg-stone-200 text-stone-600' },
+    'ventana_exclusiva': { text: 'ventana exclusiva', cls: 'bg-indigo-100 text-indigo-800' },
+    'sancionado': { text: 'sancionado', cls: 'bg-red-100 text-red-800' },
+  };
+
+  function timeAgo(ts) {
+    if (!ts) return '—';
+    const diffMs = Date.now() - new Date(ts).getTime();
+    const min = Math.floor(diffMs / 60000);
+    if (min < 1) return 'hace <1 min';
+    if (min < 60) return `hace ${min} min`;
+    const h = Math.floor(min / 60);
+    if (h < 24) return `hace ${h} h`;
+    return `hace ${Math.floor(h / 24)} d`;
+  }
+
+  function renderCard(row) {
+    const meta = PC_LABELS[row.pc_nombre] || { emoji: '⬜', titulo: row.pc_nombre, subtitulo: '' };
+    const modoBadge = MODO_BADGES[row.modo_actual] || { text: row.modo_actual, cls: 'bg-stone-100 text-stone-700' };
+    const modoCls = row.modo_actual === 'apagado' ? 'modo-apagado'
+                  : row.modo_actual === 'interactivo' ? 'modo-interactivo'
+                  : row.modo_actual === 'sancionado' ? 'modo-sancionado'
+                  : row.ventana_exclusiva_activa ? 'modo-ventana' : '';
+    const apagado = row.modo_actual === 'apagado';
+    const cmdsBadge = row.comandos_pendientes > 0 ? `<span class="pcs-badge bg-blue-100 text-blue-800 ml-1">${row.comandos_pendientes} cmd</span>` : '';
+    const sancBadge = row.sanciones_activas > 0 ? `<span class="pcs-badge bg-red-100 text-red-800 ml-1">${row.sanciones_activas} sanción</span>` : '';
+    const ventBadge = row.ventana_exclusiva_activa ? `<span class="pcs-badge bg-indigo-100 text-indigo-800 ml-1">ventana R-AUD-037</span>` : '';
+
+    return `<div class="pcs-card ${modoCls}">
+      <div class="flex items-start justify-between mb-2">
+        <div>
+          <div class="text-sm font-bold text-stone-800">${meta.emoji} ${meta.titulo}</div>
+          <div class="text-xs text-stone-500">${meta.subtitulo}</div>
+        </div>
+        <div class="text-right">
+          <span class="pcs-badge ${modoBadge.cls}">${modoBadge.text}</span>
+          ${cmdsBadge}${sancBadge}${ventBadge}
+        </div>
+      </div>
+      <div class="grid grid-cols-4 gap-2 my-3">
+        <div><div class="pcs-stat text-emerald-700">${row.cola_pendientes ?? 0}</div><div class="pcs-stat-label">pendientes</div></div>
+        <div><div class="pcs-stat text-amber-600">${row.cola_en_curso ?? 0}</div><div class="pcs-stat-label">en curso</div></div>
+        <div><div class="pcs-stat text-indigo-600">${row.cola_built ?? 0}</div><div class="pcs-stat-label">built</div></div>
+        <div><div class="pcs-stat text-stone-700">${row.cola_done_24h ?? 0}</div><div class="pcs-stat-label">done 24h</div></div>
+      </div>
+      <div class="text-xs text-stone-500 mb-3"><span class="font-semibold">Último latido:</span> ${timeAgo(row.ultimo_latido)}</div>
+      ${row.ultimo_resumen ? `<div class="text-sm text-stone-700 bg-stone-50 p-2 rounded mb-3">${row.ultimo_resumen}</div>` : ''}
+      ${row.tarea_actual_titulo ? `<div class="text-xs text-stone-600 mb-3"><span class="font-semibold">Tarea actual:</span> ${row.tarea_actual_titulo}</div>` : ''}
+      <div class="flex gap-2 flex-wrap">
+        <button onclick="pcsVivoOpenCmd('${row.pc_nombre}')" class="text-xs bg-stone-100 hover:bg-stone-200 text-stone-700 px-2 py-1 rounded">📨 Comando</button>
+        ${!apagado ? `<button onclick="pcsVivoCloseSession('${row.pc_nombre}')" class="text-xs bg-red-50 hover:bg-red-100 text-red-700 px-2 py-1 rounded">🛑 Cerrar</button>` : ''}
+        ${apagado ? `<button onclick="pcsVivoStartSession('${row.pc_nombre}')" class="text-xs bg-emerald-50 hover:bg-emerald-100 text-emerald-700 px-2 py-1 rounded">▶ Iniciar</button>` : ''}
+      </div>
+    </div>`;
+  }
+
+  async function refrescar() {
+    try {
+      const { data, error } = await sb.rpc('pcs_vivo_feed');
+      const grid = document.getElementById('pcsVivoGrid');
+      if (error) {
+        console.warn('[PcsVivo] rpc error:', error);
+        if (grid) grid.innerHTML = `<div class="bg-amber-50 p-4 rounded col-span-full text-sm text-amber-800">No se pudo cargar el estado. ${error.message}</div>`;
+        return;
+      }
+      if (!data || data.length === 0) {
+        if (grid) grid.innerHTML = `<div class="bg-stone-50 p-4 rounded col-span-full text-sm text-stone-600 text-center">Sin acceso a este tablero (solo Dusan y Pablo).</div>`;
+        return;
+      }
+      const order = ['PC1_dusan', 'PC2_pablo', 'PC3_camaras', 'PC4_desocupado'];
+      const sorted = data.slice().sort((a, b) => order.indexOf(a.pc_nombre) - order.indexOf(b.pc_nombre));
+      if (grid) grid.innerHTML = sorted.map(renderCard).join('');
+      const el = document.getElementById('pcsVivoLastUpdate');
+      if (el) el.textContent = `actualizado ${new Date().toLocaleTimeString('es-CL')}`;
+    } catch (e) {
+      console.warn('[PcsVivo] exception:', e);
+    }
+  }
+
+  function isTabActive() {
+    const sec = document.getElementById('tabPcsVivo');
+    return sec && !sec.classList.contains('hidden');
+  }
+
+  function startPolling() {
+    stopPolling();
+    pollTimer = setInterval(() => { if (isTabActive()) refrescar(); }, 10_000);
+  }
+  function stopPolling() { if (pollTimer) { clearInterval(pollTimer); pollTimer = null; } }
+
+  window.pcsVivoOpenCmd = function (pcNombre) {
+    cmdTargetPc = pcNombre;
+    const tgt = document.getElementById('pcsVivoCmdTarget');
+    if (tgt) tgt.textContent = pcNombre;
+    document.getElementById('pcsVivoCmdMotivo').value = '';
+    document.getElementById('pcsVivoCmdTipo').value = 'cerrar';
+    document.getElementById('pcsVivoCmdError').classList.add('hidden');
+    document.getElementById('pcsVivoCmdModal').classList.remove('hidden');
+  };
+  window.pcsVivoCloseModal = function () {
+    document.getElementById('pcsVivoCmdModal').classList.add('hidden');
+    cmdTargetPc = null;
+  };
+  window.pcsVivoSendCmd = async function () {
+    const tipo = document.getElementById('pcsVivoCmdTipo').value;
+    const motivo = document.getElementById('pcsVivoCmdMotivo').value.trim();
+    const errEl = document.getElementById('pcsVivoCmdError');
+    if (!motivo) { errEl.textContent = 'El motivo es obligatorio.'; errEl.classList.remove('hidden'); return; }
+    if (!cmdTargetPc) return;
+    const btn = document.getElementById('pcsVivoCmdSendBtn');
+    btn.disabled = true; btn.textContent = 'Enviando…';
+    try {
+      const { data, error } = await sb.rpc('enviar_comando_panel', { p_pc_destino: cmdTargetPc, p_tipo: tipo, p_motivo: motivo });
+      if (error || (data && !data.ok)) {
+        errEl.textContent = (data && data.razon) || error?.message || 'Error desconocido.';
+        errEl.classList.remove('hidden');
+      } else {
+        pcsVivoCloseModal();
+        refrescar();
+      }
+    } catch (e) {
+      errEl.textContent = String(e); errEl.classList.remove('hidden');
+    } finally {
+      btn.disabled = false; btn.textContent = 'Enviar';
+    }
+  };
+  window.pcsVivoCloseSession = async function (pcNombre) {
+    if (!confirm(`¿Cerrar sesión de ${pcNombre}? Esto inserta un comando 'cerrar' con tu firma.`)) return;
+    const motivo = prompt('Motivo del cierre:', 'Cierre solicitado desde panel');
+    if (!motivo) return;
+    const { data, error } = await sb.rpc('enviar_comando_panel', { p_pc_destino: pcNombre, p_tipo: 'cerrar', p_motivo: motivo });
+    if (error || (data && !data.ok)) alert('Error: ' + ((data && data.razon) || error?.message)); else refrescar();
+  };
+  window.pcsVivoStartSession = async function (pcNombre) {
+    const motivo = prompt(`Iniciar ${pcNombre}. Motivo / mensaje al humano de esa PC:`, 'Solicitud de inicio desde panel');
+    if (!motivo) return;
+    const { data, error } = await sb.rpc('enviar_comando_panel', { p_pc_destino: pcNombre, p_tipo: 'reanudar', p_motivo: motivo });
+    if (error || (data && !data.ok)) alert('Error: ' + ((data && data.razon) || error?.message)); else { alert('Comando enviado. Avisar al humano de ' + pcNombre + ' por WhatsApp/email.'); refrescar(); }
+  };
+
+  function init() {
+    document.querySelector('button[data-tab="pcs_vivo"]')?.addEventListener('click', () => {
+      setTimeout(() => { refrescar(); startPolling(); }, 100);
+    });
+    document.querySelectorAll('button[data-tab]:not([data-tab="pcs_vivo"])').forEach(b => b.addEventListener('click', stopPolling));
+  }
+
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init); else init();
+})();
+</script>
 
 <!-- D-GANTT-VIVA-001 · Bootstrap tab Gantt Viva (PC2 Pablo 2026-05-29 PM) -->
 <script>


### PR DESCRIPTION
## Summary

Tab nuevo \"🟢 Estado vivo de los 4 PCs\" en \`panel-rdo.html\` para R-AUD-042 firmada Dusan 2026-05-29 PM-6+4 (\"1 + si\"). 4 tarjetas KPI corporativas con polling 10s.

**Backend en PR aparte** en \`reciclean-rdo\` branch \`replit/plan-pablo\` (mig 140 + 5 funciones + seed 4 PCs). Esta PR depende del merge del backend.

### Cambios en \`public/panel-rdo.html\` (4 lugares · R-AUD-034 OK)

1. button-tab \`data-tab=\"pcs_vivo\"\` antes de gantt.
2. \`'pcs_vivo'\` en \`FALLBACK_TABS_GLOBALES\`.
3. \`<section id=\"tabPcsVivo\">\` con grid 2x2 de 4 tarjetas KPI:
   - **Header**: emoji + título + subtítulo + badge modo (verde producción · gris apagado · ámbar interactivo · rojo sancionado · índigo ventana).
   - **Stats**: pendientes / en_curso / built / done_24h con font 2.5rem.
   - **Último latido** (timeAgo) + **último resumen** + **tarea actual**.
   - **3 botones**: 📨 Comando · 🛑 Cerrar · ▶ Iniciar (este solo en PC apagados).
4. **Modal mandar comando**: dropdown 6 tipos (cerrar/pausar/reanudar/redirigir_prioridad/reset_cola/desbloquear) + textarea motivo + envío vía RPC \`public.enviar_comando_panel\`.
5. IIFE bootstrap antes de \`</body>\`: polling 10s mientras tab activo, pause al cambiar tab, listeners change filtros.

Sidebar v4 muestra automáticamente para silos 06+10 vía \`panel.silo_pestanas\`.

### Test plan

- [ ] Smoke visual con login Dusan o Pablo → tab visible + 4 tarjetas renderizan.
- [ ] Probar polling 10s en Network devtools (debería ver request cada 10s a \`pcs_vivo_feed\` RPC).
- [ ] Probar enviar comando 'pausar' a PC3 desde el modal → debería crear fila en \`mayordomo.comandos_inter_pcs\`.
- [ ] Probar cerrar sesión (button rojo) → confirm + prompt + comando creado.
- [ ] Smoke con login Andrea o Ingrid → no debería ver el tab (silo_pestanas restringe a 06+10).

### Pareja con

D-GANTT-VIVA-001 (tab hermano, reusa \`is_gantt_admin\` + silos) · R-AUD-024 anti-mitomanía (badge sanciones_activas) · R-AUD-037 ventana exclusiva (badge en PC2 cuando aplica) · R-AUD-039+040 (visual oro + lenguaje fácil).

🤖 Generated with [Claude Code](https://claude.com/claude-code)