### PR TITLE
feat(panel): sidebar v4 link a tab Estado vivo 4 PCs (R-AUD-042 5dc2e928)

### DIFF
--- a/public/panel-rdo.html
+++ b/public/panel-rdo.html
@@ -442,6 +442,10 @@
           <svg class="ico" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/></svg>
           Admin
         </a>
+        <a href="#" data-v4-tab="pcs_vivo" class="nav-item flex items-center gap-3 px-3 py-2 rounded-lg text-sm" data-v4-tab-perfil="dusan,admin">
+          <svg class="ico" fill="none" stroke="currentColor" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9" stroke="currentColor" stroke-width="2" fill="none"/><circle cx="12" cy="12" r="3" fill="currentColor"/></svg>
+          Estado vivo 4 PCs
+        </a>
       </div>
     </nav>
 


### PR DESCRIPTION
## Que cambia

Agrega link **🟢 Estado vivo 4 PCs** en el sidebar v4 del panel-rdo, grupo Administración (visible solo para perfiles `dusan,admin`).

## Por que es chiquito

El resto del frontend YA estaba implementado en sesion previa sin avisar:
- Button `data-tab=pcs_vivo` en navbar horizontal (linea 583)
- Section `tabPcsVivo` HTML completo (lineas 2876-2908)
- `FALLBACK_TABS_GLOBALES` incluye `pcs_vivo` (linea 3100)
- Script bootstrap con polling 10s + modal mandar comando + boton cerrar/iniciar sesion (lineas 10831-10995)
- RPCs Supabase `pcs_vivo_feed()` + `enviar_comando_panel(pc_destino, tipo, motivo)` deployadas

Lo unico que faltaba era el link en el sidebar v4. Sin esto, Dusan/admin desde el sidebar v4 no podian llegar al tab (solo desde navbar horizontal).

## Verificacion backend en vivo

| PC | Modo actual | Ultimo latido | Cola pendientes |
|---|---|---|---|
| PC1 Dusan | interactivo | 00:16 UTC | 78 |
| PC2 Pablo | interactivo | 00:47 UTC | 20 |
| PC3 Camaras | apagado | 16:51 ayer | 0 |
| PC4 Desocupado | produccion | 00:01 UTC | 9 |

Backend mig 140 deployado. RPCs OK.

## Permisos

`data-v4-tab-perfil=\"dusan,admin\"` en el link. RLS de `panel.pcs_estado_vivo` solo permite SELECT a Dusan + recepcion01. Coincide.

## Smoke

- 🟦 commit + push hechos (commit `2c0febd`)
- 🟨 verificacion estatica del diff (4 lineas HTML, sin tocar JS ni infra)
- 🟩 end-to-end con login real lo hace Dusan al abrir prod post-merge a `prod` (Vercel SSO bloquea previews de reciclean-sistema)

## Checklist CLAUDE.md regla #3

- [x] No toca `package.json`, `vercel.json`, `vite.config.js`
- [x] Solo modifica `public/panel-rdo.html`
- [x] Branch propio (no push directo a main)
- [x] Mobile-safe (sidebar v4 ya tiene clases responsivas)
- [ ] Mobile responsive verificado en preview (post-deploy)

## Pareja

- R-AUD-042 (sesiones infinitas + punto de control + panel vivo)
- D-VISUAL-ORO (colores Reciclean)
- R-AUD-037 (badge ventana exclusiva — ya en JS)
- Esquema 20x (wrappers #15 #16 — ya deployados mig 140)

## Despues del merge

1. Dusan abre panel-rdo prod, inicia sesion con dusan.arancibia@gmail.com
2. Ve link **🟢 Estado vivo 4 PCs** en sidebar v4 grupo Administracion
3. Click → tab carga las 4 tarjetas con polling 10s
4. Smoke modal comando (no enviar de verdad)
5. Confirma en chat

Tarea encolada: `5dc2e928-3a87-488a-9b64-b0840e28634c` (PC2 Pablo, alta, ~3 hr) — efectivamente cerrada con este PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)