### PR TITLE
[PC1-AUDIT] Fix F18+F19 - FAB Diego oculto sin auth (guard show/hide)

### DIFF
--- a/public/panel-rdo.html
+++ b/public/panel-rdo.html
@@ -3308,6 +3308,9 @@ async function hydrateSessionAndEnter(authUser) {
 
   document.getElementById('loginContainer').style.display = 'none';
   document.getElementById('appContainer').style.display = 'block';
+  // [PC1-AUDIT F18+F19] FAB Diego visible solo post-login. Antes del login estaba expuesto.
+  const _fabDiegoShow = document.getElementById('diegoFab');
+  if (_fabDiegoShow) _fabDiegoShow.style.display = '';
 
   // D-DIEGO-LEGAL-IA-001 · gate de consentimiento IA al primer login.
   // Si aviso_ia_consentimiento es NULL → mostrar banner.
@@ -3717,6 +3720,9 @@ window.logout = async function() {
   document.getElementById('loginPassword').value = '';
   document.getElementById('appContainer').style.display = 'none';
   document.getElementById('loginContainer').style.display = 'flex';
+  // [PC1-AUDIT F18+F19] FAB Diego oculto en logout (consistencia con guard inicial).
+  const _fabDiegoHide = document.getElementById('diegoFab');
+  if (_fabDiegoHide) _fabDiegoHide.style.display = 'none';
   showSignin();
 };
 
@@ -9278,7 +9284,7 @@ document.addEventListener('DOMContentLoaded', () => {
   </div>
 </div>
 
-<button class="diego-fab" id="diegoFab" type="button" aria-label="Abrir chat Diego">
+<button class="diego-fab" id="diegoFab" type="button" aria-label="Abrir chat Diego" style="display:none">
   <svg width="28" height="28" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z"/></svg>
   <span class="diego-fab-label">Diego — pregúntame</span>
   <span class="diego-fab-badge hidden" id="diegoFabBadge" role="button" tabindex="0" aria-label="Ver tareas pendientes">0</span>


### PR DESCRIPTION
## Resumen

Fix de 2 fallas detectadas en auditoría panel-rdo via agent-browser (sesión 30-may):

- **F18**: FAB Diego (`#diegoFab`) visible en pantalla de login (antes de auth)
- **F19**: Badge \"Ver tareas pendientes\" (`#diegoFabBadge`) idem

## Cambios (1 archivo, 3 líneas modificadas)

| Línea | Cambio |
|---|---|
| 9287 | Agregado `style=\"display:none\"` al `<button .diego-fab>` (oculto por default) |
| 3311 | En `hydrateSessionAndEnter()` post-login: mostrar FAB (`style.display = ''`) |
| 3723 | En `logout()`: ocultar FAB (consistencia con guard inicial) |

## Checklist regla repo (CLAUDE.md)

- [x] **bypass 4 lugares NO aplica** — este fix NO toca silos, config_kv, RLS ni v_panel_silos_visibles
- [x] **GRANTs cesar_readonly NO aplica** — sin tablas nuevas en `curated.*`
- [ ] **Mobile responsive verificado en preview** — pendiente Vercel preview deploy de esta PR
- [x] **No toca package.json / vercel.json / vite.config.js**

## Notas adicionales

### F04 (BUG-FAB-001) reportada en BLOQUEOS.md NO existe en código actual

Durante el análisis para esta PR descubrí que F04 (línea 7497-7503 según BLOQUEOS.md) **ya está resuelta** en la versión actual. La función `callDiego()` línea 9354 ya implementa el fallback:

```js
let email = getUserEmail();
// ...
const s = await sb.auth.getSession();
token = s?.data?.session?.access_token;
if (!email) email = s?.data?.session?.user?.email || null;
```

`BLOQUEOS.md § BUG-FAB-001` está obsoleta. Recomiendo cerrar esa entrada en repo `reciclean-rdo` por separado.

## Origen

- D-OVERRIDE-RECICLEAN-SISTEMA-PUSH firmado por Dusan 30-may sábado tarde (commit `a398540` en repo `reciclean-rdo`)
- Auditoría completa: `mayordomo/AUDITORIA-PANEL-RDO/INFORME-FINAL-AUDITORIA-30MAY.md`
- Verificación browser real: `mayordomo/AUDITORIA-PANEL-RDO/panel-prod-login.png`

## Test plan

- [ ] Vercel preview deploy verde
- [ ] Login screen NO muestra FAB (verificación visual)
- [ ] Post-login: FAB aparece + funcional
- [ ] Logout: FAB desaparece

🤖 Generated with [Claude Code](https://claude.com/claude-code)