### PR TITLE
feat(panel): limpiar jerga UI Bandeja Precios (d835edd7 bc44f5e2 ajuste 3 de 3)

### DIFF
--- a/public/panel-rdo.html
+++ b/public/panel-rdo.html
@@ -1323,8 +1323,7 @@
       </div>
 
       <p class="text-xs text-stone-400 mt-3">
-        Fuente: <code>staging.v_bandeja_precios</code> · Click una fila para ver detalle y aprobar/rechazar.
-        Aprobación atómica via <code>/functions/v1/precio-aplicar</code> (cierre vigencia anterior + INSERT nueva + log histórico).
+        Click una fila para ver el detalle y aprobar o rechazar la propuesta.
       </p>
 
       <!-- Drawer aprobar/rechazar -->
@@ -9981,7 +9980,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     tbody.innerHTML = rows.map(r => {
       const lockActive = r.lock_until && new Date(r.lock_until).getTime() > Date.now();
-      const lockTag = lockActive ? `<span class="ml-1 text-[10px] text-amber-700">🔒 ${esc(r.revisando_por ?? '?')}</span>` : '';
+      const lockTag = lockActive ? `<span class="ml-1 text-[10px] text-amber-700">🔒 Editando: ${esc(r.revisando_por ?? '?')}</span>` : '';
       const deltaCls = r.desviacion_pct == null ? 'text-stone-400'
                     : Math.abs(Number(r.desviacion_pct)) > 30 ? 'text-red-700'
                     : Math.abs(Number(r.desviacion_pct)) > 15 ? 'text-amber-700'
@@ -10027,7 +10026,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const lockActive = r.lock_until && new Date(r.lock_until).getTime() > Date.now();
     const lockWarn = document.getElementById('bpDrawerLockWarn');
     if (lockActive && r.revisando_por && r.revisando_por !== (currentUser ?? '')) {
-      lockWarn.textContent = `🔒 Esta propuesta la está revisando ${r.revisando_por} desde ${fmtEdad(r.lock_until)} (lock expira en breve).`;
+      lockWarn.textContent = `🔒 Esta propuesta la está editando ${r.revisando_por} desde hace ${fmtEdad(r.lock_until)}. Vas a poder editarla en unos minutos.`;
       lockWarn.classList.remove('hidden');
     } else {
       lockWarn.classList.add('hidden');


### PR DESCRIPTION
## Que cambia

3 strings visibles al usuario en tab Bandeja Precios cambian de jerga tecnica a lenguaje facil (cumple R-AUD-039).

| Linea | Antes | Despues |
|---|---|---|
| 1325-28 footer | `Fuente: staging.v_bandeja_precios · Click una fila... Aprobacion atomica via /functions/v1/precio-aplicar (cierre vigencia + INSERT + log historico).` | `Click una fila para ver el detalle y aprobar o rechazar la propuesta.` |
| 9984 lockTag tabla | `🔒 nombre` | `🔒 Editando: nombre` |
| 10030 lockWarn drawer | `revisando ... desde 15min (lock expira en breve).` | `la esta editando ... desde hace 15min. Vas a poder editarla en unos minutos.` |

## Diff total: 3 lineas + / 4 lineas -

## NO toca
- Comentarios JS (Andrea no los lee)
- Nombres columna SQL `revisando_por` / `lock_until` (schema, fuera scope UI)
- Variable JS `delta` (no aparece como string visible al usuario)
- Header tab ya estaba limpio (📨 Bandeja Precios — propuestas para aprobacion)

## Criterio aprobacion payload

"Andrea logueada lee la pantalla y entiende sin preguntar nada" → smoke FULL requiere Andrea humana. Verificacion estatica de mi parte:

- Toda mencion a `staging.*`, `/functions/*`, `INSERT`, `Lock`, `log historico` removida del UI visible.
- Lenguaje natural en lugar de tecnicismos.
- Mobile-safe (sin cambios estructura HTML).

## Cierre bc44f5e2 al 100%

Este PR cierra el tercer y ultimo ajuste de la tarea madre `bc44f5e2`:

- ajuste 1 (`2c7e2ab3`) audit visual D-VISUAL-ORO PC3 Camaras → done (29-may)
- ajuste 2 (`7ad07704`) puente Bandeja Precios → Diego Cerebro mig 150 → done HOY (commit `d11500b`)
- ajuste 3 (`d835edd7`) limpiar jerga UI → done ESTE PR

## Checklist CLAUDE.md regla #3

- [x] No toca `package.json`, `vercel.json`, `vite.config.js`
- [x] Solo modifica `public/panel-rdo.html`
- [x] Branch propio (no push directo a main)
- [x] Mobile-safe (solo cambios texto/strings)
- [ ] Mobile responsive verificado en preview (post-deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)