### PR TITLE
fix(panel-rdo): enlazar Comercial+Gantt al sidebar + guard pre-login Diego

### DIFF
--- a/public/panel-rdo.html
+++ b/public/panel-rdo.html
@@ -417,6 +417,10 @@
             <span class="v4-emoji" aria-hidden="true">🎯</span>
             Oportunidades
           </a>
+          <a href="#" data-v4-tab="comercial" class="nav-item flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm">
+            <span class="v4-emoji" aria-hidden="true">💼</span>
+            Comercial (CRM Impulsa)
+          </a>
           <a href="#" data-v4-tab="negocios" class="nav-item flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm">
             <span class="v4-emoji" aria-hidden="true">💼</span>
             Negocios
@@ -505,6 +509,10 @@
           <a href="#" data-v4-tab="plan_2026" class="nav-item flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm" data-v4-tab-perfil="dusan,admin">
             <span class="v4-emoji" aria-hidden="true">🗳️</span>
             Plan 2026
+          </a>
+          <a href="#" data-v4-tab="gantt" class="nav-item flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm" data-v4-tab-perfil="dusan,admin">
+            <span class="v4-emoji" aria-hidden="true">📊</span>
+            Gantt Viva
           </a>
         </div>
       </details>
@@ -4739,6 +4747,14 @@ window.loadDiegoAgenda = async function loadDiegoAgenda() {
 
   try {
     const { data: { session } } = await sb.auth.getSession();
+    // Guard pre-login (R-AUD-002): sin sesión, RLS sobre panel.diego_tareas devuelve 42501.
+    // Mostrar placeholder en vez de loguear error confuso en consola.
+    if (!session) {
+      lista.innerHTML = '<div class="text-xs text-slate-400 italic py-4 text-center">Esperando sesión…</div>';
+      if (total) total.textContent = '—';
+      if (sub) sub.textContent = 'Iniciá sesión para ver tu agenda';
+      return;
+    }
     const userEmail = (session?.user?.email || '').toLowerCase();
     const personMatch = _EMAIL_TO_NOMBRE[userEmail] || (userEmail.split('@')[0] || '');
 


### PR DESCRIPTION
## Resumen
Evidence Collector 31-may detectó 2 problemas en `public/panel-rdo.html`:

1. **2 tabs huérfanas** — `tabComercial` (CRM Impulsa) y `tabGantt` (Gantt Viva) existen como `<section>` con KPIs/handlers vivos pero NO tienen entrada en el sidebar v4 (`[data-v4-tab]`). Viola R-AUD-034 (incidente Megapol/Green Cup 27-may: Dusan perdió 6 hr buscando pestañas existentes pero no enlazadas).
2. **Error pre-login en consola** — `[loadDiegoAgenda] permission denied for table diego_tareas (code 42501)`. `panel.diego_tareas` tiene RLS estricta; sin sesión, anon recibe 42501.

## Decisiones tomadas
1. **tabComercial → agregada al sidebar en "👥 Gestión"** (label "Comercial (CRM Impulsa)", emoji 💼). VIVA: 4 KPIs (clientes, ops abiertas, cotizaciones, prospectos) + buscador + ficha modal con 6 sub-tabs.
2. **tabGantt → agregada al sidebar en "⚙️ Administración"** (label "Gantt Viva", emoji 📊, `data-v4-tab-perfil="dusan,admin"` porque solo CEO la usa). VIVA: Frappe Gantt + filtros tipo/silo/color + refresh 60s.
3. **loadDiegoAgenda → guard `if(!session)`** agregado tras `sb.auth.getSession()` (línea 4750). Devuelve placeholder "Esperando sesión…" sin hacer query. Cuando hay sesión sigue funcionando idéntico.

## Verificación
- Sidebar v4 dispara `button[data-tab="X"].click()` (línea 8137). Ambas tabs ya tenían `<button data-tab="comercial">` y `<button data-tab="gantt">` legacy (líneas 696/698), así que la cadena de click funciona end-to-end.
- `initTabComercial()` ya existe (línea 3937 dentro del handler `if (tabId === 'comercial')`).
- Gantt refresh polling listener ya existe (línea 11274).
- Guard valida `panel.diego_tareas.rowsecurity = true` (confirmado vía MCP Supabase).

## Diff
- `public/panel-rdo.html` (+16 / -0). Edit mínimo, sin renombres, sin dependencias nuevas.
- Commit: 2f14583

## Suposiciones PC sin validar
| Decisión | Razón PC | Pendiente Dusan validar |
|---|---|---|
| Gantt restringida a `dusan,admin` | Es herramienta de gestión interna, no operativa diaria. Solo Dusan necesita ver iniciativas/PCs/silos cruzados. | ¿Algún silo más debería verla? |
| Comercial sin restricción de perfil | CRM Impulsa con 15k registros = utilidad amplia (Andrea, comercial, prospectos). | ¿Restringir a `dusan,admin,comercial`? |
| Label "Comercial (CRM Impulsa)" | El nombre técnico ayuda a distinguir de "Oportunidades" y "Cartera". | ¿Preferís solo "Comercial"? |

## Extras de experto que agregué
Ninguno. Edit puramente quirúrgico.

## Next step humano
- Dusan: revisar preview Vercel del branch + mergear si OK.
- Próxima auditoría: validar runtime con creds reales (que el click del sidebar abre las 2 tabs y que el error 42501 desapareció en consola pre-login).

🤖 Generated with [Claude Code](https://claude.com/claude-code)