### PR TITLE
fix(panel-rdo): guard pre-login Portada (audio + alertas)

### DIFF
--- a/public/panel-rdo.html
+++ b/public/panel-rdo.html
@@ -4072,12 +4072,20 @@ async function loadAudios() {
 }
 
 async function loadPortadaAudio() {
+  const container = document.getElementById('portadaAudioPlayer');
+  if (!container) return;
+  // Guard pre-login (R-AUD-002): sin sesión, RLS sobre panel.mensajes_audio devuelve 42501.
+  // Mostrar placeholder en vez de loguear error confuso en consola.
+  const { data: { session } } = await sb.auth.getSession();
+  if (!session) {
+    container.innerHTML = '<p class="text-stone-400 italic text-sm">Iniciá sesión para ver mensajes.</p>';
+    return;
+  }
   const { data, error } = await sb
     .schema('panel').from('mensajes_audio').select('*')
     .eq('activo', true)
     .contains('zonas_visibles', ['portada'])
     .order('fecha', { ascending: false }).limit(3);
-  const container = document.getElementById('portadaAudioPlayer');
   if (error) { container.innerHTML = `<p class="text-red-600">Error: ${escapeHtml(error.message)}</p>`; return; }
   if (!data || data.length === 0) {
     container.innerHTML = '<p class="text-stone-500">No hay mensajes destacados.</p>';
@@ -4895,6 +4903,10 @@ window.setupDiegoAgenda = function setupDiegoAgenda() {
 async function loadAlertasPortada() {
   const div = document.getElementById('portadaAlertas');
   if (!div) return;
+  // Guard pre-login (R-AUD-002): sin sesión, RLS sobre v_alertas_panel devuelve 42501.
+  // Ocultar bloque hasta tener sesión válida.
+  const { data: { session } } = await sb.auth.getSession();
+  if (!session) { div.innerHTML = ''; return; }
   const { data, error } = await sb.from('v_alertas_panel')
     .select('tipo_alerta,nivel,titulo,descripcion,fecha,valor')
     .order('nivel');


### PR DESCRIPTION
## Qué
Misma fix de PR #147 (loadDiegoAgenda) aplicada a las 2 funciones que quedaron sin guard en la pestaña Portada (default visible al landear).

## Funciones
- `loadPortadaAudio` (línea ~4082) → consultaba `panel.mensajes_audio` sin sesión → 42501 en consola
- `loadAlertasPortada` (línea ~4911) → consultaba `v_alertas_panel` sin sesión → 42501 en consola

## Patrón aplicado
```js
const { data: { session } } = await sb.auth.getSession();
if (!session) { /* placeholder o return silencioso */ return; }
```

- Audio: muestra `Iniciá sesión para ver mensajes`
- Alertas: oculta el bloque (`div.innerHTML = ''`)

## Edit mínimo
+13 / -1, 0 refactor. Solo prepend del guard.

## Fuera de scope (próxima ronda)
- `checkNewAudioNotification` (línea 4103)
- `loadUF` (línea 9922)

## Verificación esperada
- Consola pre-login limpia tras este PR + #147
- Otros tabs: NO afectados (cambio aislado a Portada)