### PR TITLE
feat(e2e): Playwright MVP nivel mínimo (cierra ea2f04b4)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,64 @@
+name: E2E Playwright nightly
+
+# SPEC: mayordomo/SPEC-E2E-PLAYWRIGHT-MVP.md (firma Dusan 31-may opción 1)
+# Detector #9 detect-e2e-playwright-regresiones en catalogo bucle.
+# Falla del test => INSERT panel.sesgos_detectados via REST + artifact playwright-report.
+
+on:
+  schedule:
+    - cron: '0 3 * * *'  # 03:00 UTC = 23:00 CLT (post promo prod del día)
+  workflow_dispatch:      # ejecución manual desde GitHub UI
+
+jobs:
+  e2e:
+    name: E2E chromium contra prod
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers (chromium only)
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Playwright tests
+        env:
+          QA_EMAIL: ${{ secrets.QA_EMAIL }}
+          QA_PASSWORD: ${{ secrets.QA_PASSWORD }}
+          E2E_BASE_URL: https://reciclean-sistema.vercel.app
+        run: npm run test:e2e -- --reporter=html,list
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            playwright-report/
+            test-results/
+          retention-days: 30
+
+      - name: Notify detector bucle si falla (detector #9)
+        if: failure() && secrets.SUPABASE_URL != '' && secrets.SUPABASE_SERVICE_ROLE != ''
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE: ${{ secrets.SUPABASE_SERVICE_ROLE }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          curl -sS --max-time 10 -X POST "$SUPABASE_URL/rest/v1/sesgos_detectados" \
+            -H "apikey: $SUPABASE_SERVICE_ROLE" \
+            -H "Authorization: Bearer $SUPABASE_SERVICE_ROLE" \
+            -H "Content-Type: application/json" \
+            -H "Prefer: return=minimal" \
+            -d "{\"detector\":\"detect-e2e-playwright-regresiones\",\"score\":85,\"pc_afectado\":\"PC2_pablo\",\"mensaje\":\"E2E nightly falló - ver artifact playwright-report\",\"evidencia\":{\"run_url\":\"$RUN_URL\"}}" \
+            || echo "POST a sesgos_detectados falló (no crítico, el test fail ya es la señal)"

--- a/package.json
+++ b/package.json
@@ -8,13 +8,17 @@
     "build:css": "tailwindcss -i ./public/tailwind.input.css -o ./public/tailwind.css --minify",
     "build:css:watch": "tailwindcss -i ./public/tailwind.input.css -o ./public/tailwind.css --watch",
     "build": "npm run build:css && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:report": "playwright show-report"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.101.1",
     "vite": "^8.0.3"
   },
   "devDependencies": {
+    "@playwright/test": "^1.48.0",
     "tailwindcss": "^3.4.17"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,25 @@
+// Playwright config · MVP E2E · SPEC mayordomo/SPEC-E2E-PLAYWRIGHT-MVP.md
+// Firma Dusan 31-may opción 1. Solo chromium para MVP, agregar firefox/webkit en nivel MEDIO.
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  timeout: 30_000,
+  expect: { timeout: 5_000 },
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI
+    ? [['html', { open: 'never' }], ['list']]
+    : [['html', { open: 'on-failure' }], ['list']],
+  use: {
+    baseURL: process.env.E2E_BASE_URL || 'https://reciclean-sistema.vercel.app',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+  ],
+});

--- a/tests/FLAKY-TESTS.md
+++ b/tests/FLAKY-TESTS.md
@@ -1,0 +1,15 @@
+# Tests flaky · registro
+
+Cada vez que un test pase en local pero falle en CI (o viceversa), registrar acá:
+
+```
+## YYYY-MM-DD test/<archivo>.spec.ts
+- Síntoma: "..."
+- Frecuencia: N falsos positivos en M ejecuciones
+- Hipótesis: timeout, race condition, datos cambiantes
+- Acción: agregar retry, esperar selector específico, normalizar datos seed
+```
+
+---
+
+(sin entradas todavía — agregar al detectar primer flaky)

--- a/tests/login-mi-bandeja.spec.ts
+++ b/tests/login-mi-bandeja.spec.ts
@@ -1,0 +1,65 @@
+// E2E MVP · Flujo crítico #1 · Login + Mi Bandeja Personal
+// SPEC: mayordomo/SPEC-E2E-PLAYWRIGHT-MVP.md
+// PC2 Pablo 2026-06-02
+//
+// CORRECCIONES vs SPEC literal:
+// - Tab Mi Bandeja Personal real es data-v4-tab="mi_bandeja" / section#tabMiBandeja
+//   (el SPEC mencionaba bandeja_dieg que es "Bandeja Diego" — tab DISTINTO).
+// - Selector login botón: "Ingresar" o "Iniciar sesión" (verificar runtime).
+import { test, expect } from '@playwright/test';
+
+const QA_EMAIL = process.env.QA_EMAIL || 'qa@reciclean.cl';
+const QA_PASSWORD = process.env.QA_PASSWORD || '';
+
+test.describe('Flujo crítico #1 — Login + Mi Bandeja Personal', () => {
+  test.skip(!QA_PASSWORD, 'QA_PASSWORD env var no configurada (set GitHub Secret)');
+
+  const consoleErrors: string[] = [];
+
+  test.beforeEach(async ({ page }) => {
+    consoleErrors.length = 0;
+    page.on('console', msg => {
+      if (msg.type() === 'error') {
+        consoleErrors.push(msg.text());
+      }
+    });
+    page.on('pageerror', err => {
+      consoleErrors.push('pageerror: ' + err.message);
+    });
+  });
+
+  test('login QA + carga Mi Bandeja sin errores RPC', async ({ page }) => {
+    // Step 1 — Abrir panel
+    await page.goto('/panel-rdo.html');
+    await expect(page).toHaveTitle(/Panel RDO|Gestión REP/i);
+
+    // Step 2 — Login (selectores actuales del panel-rdo.html)
+    await page.fill('input[type="email"]', QA_EMAIL);
+    await page.fill('input[type="password"]', QA_PASSWORD);
+    await page.click('button:has-text("Ingresar"), button:has-text("Iniciar")');
+
+    // Step 3 — Esperar sidebar v4 visible (post-login muestra app-container)
+    await page.waitForSelector('[data-v4-tab]', { timeout: 15_000 });
+
+    // Step 4 — Navegar a Mi Bandeja Personal (corregido: mi_bandeja, no bandeja_dieg)
+    await page.click('[data-v4-tab="mi_bandeja"], button[data-tab="mi_bandeja"]');
+
+    // Step 5 — Verificar section visible
+    await page.waitForSelector('section#tabMiBandeja:not(.hidden)', { timeout: 5_000 });
+
+    // Step 6 — Verificar que NO hay error visible de RPC/permission denied en pantalla
+    const errorVisible = await page
+      .locator('text=/Could not find the function|permission denied|Error: 42501/i')
+      .count();
+    expect(errorVisible).toBe(0);
+
+    // Step 7 — Verificar no console errors críticos
+    const criticosConsole = consoleErrors.filter(e =>
+      /Could not find|permission denied|42501|TypeError/i.test(e),
+    );
+    expect(criticosConsole, `Console errors críticos: ${JSON.stringify(criticosConsole)}`).toEqual([]);
+
+    // Step 8 — Screenshot evidencia
+    await page.screenshot({ path: 'test-results/login-mi-bandeja-final.png', fullPage: true });
+  });
+});


### PR DESCRIPTION
Bloque autónomo PC2 04-jun · cierra tarea PC1 ea2f04b4 E2E Playwright MVP. Sigue SPEC mayordomo/SPEC-E2E-PLAYWRIGHT-MVP.md literal con corrección selector tab (mi_bandeja vs bandeja_dieg). Estructura: package.json + playwright.config.ts + 1 test crítico + workflow GHA cron nightly + usuario qa@reciclean.cl creado backend. Detector #9 ya en CHECK constraint. NECESITA acción humana: configurar 3 GitHub Secrets (QA_EMAIL + QA_PASSWORD + SUPABASE_SERVICE_ROLE) + trigger workflow manual primera vez.