### PR TITLE
fix(panel-rdo): tab Diego Coordinador faltaba .schema('panel') en 6 calls

### DIFF
--- a/public/panel-rdo.html
+++ b/public/panel-rdo.html
@@ -12355,11 +12355,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
     try {
       const [kpi, plani, hist, atascos, metricas] = await Promise.all([
-        sb.from('v_diego_ciclo_cerrado_kpi').select('*').single(),
-        sb.from('v_diego_avisos_planificados').select('*').limit(50),
-        sb.from('v_diego_avisos_historico').select('*').limit(30),
-        sb.from('v_diego_atascos').select('*').limit(30),
-        sb.from('v_diego_metricas_semanales').select('*').limit(20)
+        sb.schema('panel').from('v_diego_ciclo_cerrado_kpi').select('*').single(),
+        sb.schema('panel').from('v_diego_avisos_planificados').select('*').limit(50),
+        sb.schema('panel').from('v_diego_avisos_historico').select('*').limit(30),
+        sb.schema('panel').from('v_diego_atascos').select('*').limit(30),
+        sb.schema('panel').from('v_diego_metricas_semanales').select('*').limit(20)
       ]);
 
       // KPI Banner
@@ -12478,7 +12478,7 @@ document.addEventListener('DOMContentLoaded', () => {
       : (prompt('Razón cancelación (opcional):', '') || null);
     if (razon === null) return;  // canceló el modal
     try {
-      const { error } = await sb.rpc('diego_cancelar_aviso', { p_aviso_id: id, p_razon: razon || null });
+      const { error } = await sb.schema('panel').rpc('diego_cancelar_aviso', { p_aviso_id: id, p_razon: razon || null });
       if (error) throw error;
       if (window.showToast) window.showToast('Aviso cancelado', 'success');
       refrescar();


### PR DESCRIPTION
## Summary

Bug detectado durante smoke pre-PR Bloque 5 plan autónomo PC Pablo 01-jun: el handler del tab Diego Coordinador (PR #155 mergeado 31-may) hacía `sb.from('v_diego_X')` y `sb.rpc('diego_cancelar_aviso')`, pero esas 5 vistas y ese RPC viven en schema `panel`, no `public`.

**Resultado actual en main**: el tab carga con todas las secciones vacías ("Sin avisos pendientes ✅" / "Sin envíos en últimos 7 días" / "Sin atascos ✅") porque PostgREST devuelve 200 OK con cuerpos vacíos al no encontrar las vistas en `public`. "Cancelar aviso" tira 404 silencioso atrapado por `try/catch`.

**Verificación que confirma el bug:**
- `panel.v_diego_ciclo_cerrado_kpi` existe ✅ (información_schema.views)
- `public.v_diego_ciclo_cerrado_kpi` NO existe ❌
- `panel.diego_cancelar_aviso` existe ✅ (pg_proc)
- `public.diego_cancelar_aviso` NO existe ❌
- Patrón canónico `sb.schema('panel').from(...)` usado en 44 otros lugares del mismo archivo

## Cambios (6 líneas)

- 5 en `refrescar()` (líneas 12358-12362): `sb.from('v_diego_*')` → `sb.schema('panel').from('v_diego_*')`
- 1 en `cancelarAviso()` (línea 12481): `sb.rpc('diego_cancelar_aviso', ...)` → `sb.schema('panel').rpc(...)`

## Test plan

- [ ] Login real Dusan (admin) → tab "🎭 Diego Coordinador" → verificar que cargan: KPI banner con %, lista planificados, histórico, atascos, métricas semanales
- [ ] Si hay aviso `listo_para_enviar` → botón "✕ Cancelar aviso" → modal con razón → toast "Aviso cancelado" → aviso desaparece de planificados
- [ ] Console DevTools sin errores de schema/PostgREST

🤖 Generated with [Claude Code](https://claude.com/claude-code)