### PR TITLE
[PROMO] main->prod: fix Diego Coord schema panel (PR #172)

### DIFF
--- a/public/panel-rdo.html
+++ b/public/panel-rdo.html
@@ -12355,11 +12355,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
     try {
       const [kpi, plani, hist, atascos, metricas] = await Promise.all([
-        sb.from('v_diego_ciclo_cerrado_kpi').select('*').single(),
-        sb.from('v_diego_avisos_planificados').select('*').limit(50),
-        sb.from('v_diego_avisos_historico').select('*').limit(30),
-        sb.from('v_diego_atascos').select('*').limit(30),
-        sb.from('v_diego_metricas_semanales').select('*').limit(20)
+        sb.schema('panel').from('v_diego_ciclo_cerrado_kpi').select('*').single(),
+        sb.schema('panel').from('v_diego_avisos_planificados').select('*').limit(50),
+        sb.schema('panel').from('v_diego_avisos_historico').select('*').limit(30),
+        sb.schema('panel').from('v_diego_atascos').select('*').limit(30),
+        sb.schema('panel').from('v_diego_metricas_semanales').select('*').limit(20)
       ]);
 
       // KPI Banner
@@ -12478,7 +12478,7 @@ document.addEventListener('DOMContentLoaded', () => {
       : (prompt('Razón cancelación (opcional):', '') || null);
     if (razon === null) return;  // canceló el modal
     try {
-      const { error } = await sb.rpc('diego_cancelar_aviso', { p_aviso_id: id, p_razon: razon || null });
+      const { error } = await sb.schema('panel').rpc('diego_cancelar_aviso', { p_aviso_id: id, p_razon: razon || null });
       if (error) throw error;
       if (window.showToast) window.showToast('Aviso cancelado', 'success');
       refrescar();


### PR DESCRIPTION
## Summary

Promo a producción del fix mergeado en main vía PR #172 (PC Pablo autónomo + firma Dusan 13:51Z).

**Qué se promueve:** 6 líneas en `public/panel-rdo.html` agregando `.schema('panel')` a 5 vistas Diego (`v_diego_ciclo_cerrado_kpi`, `v_diego_avisos_planificados`, `v_diego_avisos_historico`, `v_diego_atascos`, `v_diego_metricas_semanales`) + 1 RPC (`diego_cancelar_aviso`).

**Por qué urgente:** el handler tab "🎭 Diego Coordinador" en panel productivo carga SIEMPRE vacío desde 31-may PM (PR #155 lo mergeó roto sin smoke logueado). Con este promo, el tab empieza a mostrar datos reales.

## Test plan post-promo

- [ ] Vercel auto-deploy prod completa (~2 min después del merge)
- [ ] Login Pablo o Dusan en `https://reciclean-sistema.vercel.app/panel-rdo.html`
- [ ] Tab 🎭 Diego Coordinador carga: KPI banner con %, lista planificados, histórico, atascos, métricas semanales
- [ ] DevTools Console sin errores 4xx PostgREST

## Firma

Pablo via chat 2026-06-01 ~17:00 CLT: *"dale tu"* en respuesta a propuesta PC Pablo autónomo de abrir el promo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)