### PR TITLE
perf(panel-rdo): SPEC perf mobile PASO A+B · defer Supabase CDN + bootstrap promise

### DIFF
--- a/public/panel-rdo.html
+++ b/public/panel-rdo.html
@@ -23,8 +23,25 @@
   <link rel="preconnect" href="https://unpkg.com" crossorigin>
   <link rel="preconnect" href="https://eknmtsrtfkzroxnovfqn.supabase.co" crossorigin>
   <link rel="dns-prefetch" href="https://graph.facebook.com">
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
-  <script src="/js/page-logger.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2" defer></script>
+  <script src="/js/page-logger.js" defer></script>
+  <script>
+    // SPEC-PERF-MOBILE-REFACTOR-V1 PASO A · bootstrap promise para defer-safe initSupabase
+    // Permite que el script Supabase CDN (línea 26) tenga defer sin romper línea 8703 initSupabase().
+    window.__supabaseReady = new Promise((resolve) => {
+      if (window.supabase) return resolve();
+      var tag = document.querySelector('script[src*="supabase-js"]');
+      if (tag) {
+        tag.addEventListener('load',  function () { resolve(); }, { once: true });
+        tag.addEventListener('error', function () { resolve(); }, { once: true });
+      } else {
+        var tick = setInterval(function () {
+          if (window.supabase) { clearInterval(tick); resolve(); }
+        }, 20);
+        setTimeout(function () { clearInterval(tick); resolve(); }, 5000);
+      }
+    });
+  </script>
   <!-- v4-design F1 · CDNs Chart.js + Leaflet (defer para no bloquear render)
        DeepSeek ronda 2: Chart.js cargado 1 sola vez (antes había duplicado L11298 → quitado). -->
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js" defer></script>
@@ -8699,12 +8716,19 @@ async function loadOpsDiarias() {
     <span class="${Number(al.contraparte) > 0 ? 'text-amber-700' : 'text-stone-600'}">${al.contraparte || 0} contrapartes con discrepancia</span>`;
 }
 
-// ---------- INIT ----------
-initSupabase();
-setupTabs();
-setupRecorder();
-setupAuthListener();
-bootstrapAuth();
+// ---------- INIT ---------- (SPEC-PERF-MOBILE-REFACTOR-V1 PASO A+B · defer-safe)
+// Wrap en async IIFE para esperar window.__supabaseReady (bootstrap promise en líneas 26-44)
+// antes de inicializar Supabase client. Permite defer en línea 26 sin romper.
+(async function () {
+  if (window.__supabaseReady) {
+    await window.__supabaseReady;
+  }
+  initSupabase();
+  setupTabs();
+  setupRecorder();
+  setupAuthListener();
+  bootstrapAuth();
+})();
 
 // Enter handlers para los 3 paneles de auth
 document.getElementById('loginEmail').addEventListener('keypress', e => {


### PR DESCRIPTION
## Summary

PASO A+B del SPEC-PERF-MOBILE-REFACTOR-V1 (Bloque 4 plan autónomo Pablo). Firma Pablo "arrancá el SPEC perf mobile" 2026-06-01 ~13:30 CLT.

**Cambios técnicos (+24 líneas netas):**
- `defer` agregado a Supabase CDN (línea 26) + page-logger.js (línea 27)
- Bootstrap promise `window.__supabaseReady` que espera carga de Supabase CDN
- Init wrap en async IIFE que await la promise antes de `initSupabase / setupTabs / setupRecorder / setupAuthListener / bootstrapAuth`

## Resultados Lighthouse mobile (3 corridas local pre / 3 post)

| Métrica | PRE (avg) | POST (avg) | Delta |
|---|---|---|---|
| **Score** | 41.7 | 43.0 | **+1.3** (dentro variabilidad ±2) |
| **LCP** | 14.3s | 9.6s | **-4.7s (-33%)** ← mejora dominante |
| **FCP** | 7.1s | 6.3s | -0.8s |
| **TBT** | 663ms | 707ms | +44ms (leve regresión) |

**Honesto:** el delta de score (+1.3) NO cierra el objetivo ≥70. Lo que mueve fuerte es LCP -33%, que es lo que el usuario percibe como "página tarda en mostrar contenido".

**Para llegar a score ≥70 hace falta PASO C** (extraer script inline 5800 líneas a archivo externo). Eso es PR aparte por ser cirugía mayor con riesgo más alto que requiere smoke logueado completo (Dusan admin + 1 operador no-admin + Andrea/Cony visual).

## Smoke estático

- HTML balanceado: body 1/1, html 1/1
- defer en place: línea 26 ✅
- bootstrap promise: 4 ocurrencias (1 def + 3 uso) ✅

## Smoke E2E pendiente humano (no autónomo)

- [ ] Login Dusan (admin) → panel abre + console sin errors
- [ ] Tab Diego Coordinador carga datos
- [ ] Tab Mi Bandeja carga datos
- [ ] Login operador no-admin (Cony/Dyana) → mismas pestañas funcionan
- [ ] Vercel preview verde

## Riesgo

**Bajo:** análisis confirmó que todos los usos de `sb.*` están en funciones (no top-level), y la única llamada síncrona top-level (línea 8703) ahora está en async IIFE. Si bootstrap promise falla (timeout 5s), fallback poll asegura que init eventualmente corre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)