### PR TITLE
fix(panel-rdo): Mi Bandeja cerrar_mi_tarea faltaba .schema('panel')

### DIFF
--- a/public/panel-rdo.html
+++ b/public/panel-rdo.html
@@ -12137,7 +12137,7 @@ document.addEventListener('DOMContentLoaded', () => {
       : (prompt('Notas de cierre (opcional):', '') || null);
     if (notas === null) return;  // canceló
     try {
-      const { data, error } = await sb.rpc('cerrar_mi_tarea', { p_id: id, p_notas: notas || null });
+      const { data, error } = await sb.schema('panel').rpc('cerrar_mi_tarea', { p_id: id, p_notas: notas || null });
       if (error) throw error;
       if (window.showToast) window.showToast(`Tarea cerrada: ${data.titulo}`, 'success');
       else alert(`✓ Tarea cerrada: ${data.titulo}`);


### PR DESCRIPTION
## Summary

Bug pre-existente detectado por Pablo durante smoke del PR #176 (perf mobile): al cerrar tarea en Mi Bandeja salta error PostgREST 404:

\`\`\`
Error cerrando tarea: Could not find the function public.cerrar_mi_tarea(p_id, p_notas) in the schema cache
\`\`\`

La función vive en \`panel.cerrar_mi_tarea(p_id uuid, p_notas text)\`, no en \`public\`. Mismo patrón del fix Diego Coord PR #172 esta mañana (5 vistas + 1 RPC sin \`.schema('panel')\`).

## Caza honesta R-AUD-024

Cuando arreglé Diego Coord esta mañana NO grep el resto del archivo por otros \`sb.rpc(...)\` sin \`.schema('panel')\`. Si lo hubiera hecho, este bug se encontraba antes del smoke de Pablo. **Auditoría amplia ejecutada AHORA**:

| RPC | Vive en | Status |
|---|---|---|
| cerrar_mi_tarea | panel | 🔴 BUG (este PR lo corrige) |
| auth_get_user_context | public | ✅ OK |
| consultar_permisos_usuario | public | ✅ OK |
| f_panel_health | public | ✅ OK |
| f_panel_cartera_cobertura | public | ✅ OK |
| f_operaciones_dia | public | ✅ OK |
| f_panel_top_n | public | ✅ OK |
| f_pesajes_por_sucursal | public | ✅ OK |
| f_panel_actividad_reciente | public | ✅ OK |

## Cambio

1 línea en `public/panel-rdo.html` (12140): agregar `.schema('panel')` a `sb.rpc('cerrar_mi_tarea')`.

## Impact

Bug también afecta producción actual. Este fix + promo main→prod (firma separada) lo destraba para todo el equipo que use Mi Bandeja.

## Test plan post-merge

- [ ] Login Pablo o Dusan → Mi Bandeja → seleccionar tarea → cerrar con o sin notas → toast "Tarea cerrada: ..." + tarea desaparece de lista
- [ ] Vercel preview verde
- [ ] DevTools Console sin errors PostgREST 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)