### PR TITLE
fix(panel-rdo): refresh contenido tab activo al cambiar silo · bug [6] feedback Cartero

### DIFF
--- a/public/panel-rdo.html
+++ b/public/panel-rdo.html
@@ -4467,6 +4467,15 @@ async function loadSilos() {
     currentSilo = v === '__global__' ? null : v;
     localStorage.setItem(LS_KEY_SILO, v);
     applySiloTabs();
+    // BUG [6] fix · feedback Cartero 12:10 comercial@ sucursal 02:
+    // "Porque si yo cambio de silo no se cambia la pantalla de portada".
+    // applySiloTabs() solo gestiona visibilidad de tabs, NO refresca contenido.
+    // Solución: disparar el handler del tab activo simulando click sobre su botón.
+    // Eso ejecuta el switch tabId→loaders (línea ~4623) y refresca portada/rdo/pesaje/etc.
+    try {
+      const activeBtn = document.querySelector('.tab-btn.active');
+      if (activeBtn) activeBtn.click();
+    } catch (e) { console.warn('[silo-change refresh]', e); }
   });
 }
 


### PR DESCRIPTION
## Summary

Bug cazado vía Diego Cartero por comercial@gestionrepchile.cl 12:10 CLT:
> "Porque si yo cambio de silo no se cambia la pantalla de portada"

**Causa**: handler change del selector silo solo llamaba a applySiloTabs() (visibilidad), no refrescaba contenido del tab activo.

**Fix** (5 líneas, minimal-risk): después de applySiloTabs() disparar click() sobre el botón del tab activo. El handler existente (línea ~4623) ejecuta los loaders apropiados.

## Test plan post-merge

- [ ] Login admin → estar en tab Portada con silo A → cambiar a silo B → ver KPIs/datos refrescados
- [ ] Repetir con tab RDO, Pesaje, Facturación, Cartera
- [ ] Console DevTools sin errores

## Riesgo

**Bajo.** No toca lógica existente. Solo agrega 1 call que simula el comportamiento que ya tienen los tabs cuando el usuario clickea.

🤖 Generated with [Claude Code](https://claude.com/claude-code)