### PR TITLE
fix(panel-rdo): modal Cartero límite chars 500 → 2000 · bug [9]

### DIFF
--- a/public/panel-rdo.html
+++ b/public/panel-rdo.html
@@ -12882,8 +12882,8 @@ document.addEventListener('DOMContentLoaded', () => {
       </button>
     </div>
     <label for="dcmTextarea" style="font-size:.8rem;color:#475569;display:block;margin-bottom:.25rem;">Contale a Diego</label>
-    <textarea id="dcmTextarea" maxlength="500" placeholder="Describí lo que querés contar (máx 500)…" aria-label="Mensaje"></textarea>
-    <div class="dcm-counter"><span id="dcmCount">0</span>/500</div>
+    <textarea id="dcmTextarea" maxlength="2000" placeholder="Describí lo que querés contar (máx 2000)…" aria-label="Mensaje" rows="4"></textarea>
+    <div class="dcm-counter"><span id="dcmCount">0</span>/2000</div>
     <div id="diegoCarteroResp" role="status"></div>
     <div class="dcm-actions">
       <a class="dcm-chat-link" id="dcmChatLink">o hablar con Diego (chat IA)</a>


### PR DESCRIPTION
Feedback gestorcomercial@ via Cartero 13:05: '500 caracteres es muy baja'. Backend mig 176 ya aplicada (CHECK + RPC). Frontend: maxlength + counter + rows=4.