### PR TITLE
fix(panel-rdo): modal Cartero límite chars 2000 → 5000

### DIFF
--- a/public/panel-rdo.html
+++ b/public/panel-rdo.html
@@ -12882,8 +12882,8 @@ document.addEventListener('DOMContentLoaded', () => {
       </button>
     </div>
     <label for="dcmTextarea" style="font-size:.8rem;color:#475569;display:block;margin-bottom:.25rem;">Contale a Diego</label>
-    <textarea id="dcmTextarea" maxlength="2000" placeholder="Describí lo que querés contar (máx 2000)…" aria-label="Mensaje" rows="4"></textarea>
-    <div class="dcm-counter"><span id="dcmCount">0</span>/2000</div>
+    <textarea id="dcmTextarea" maxlength="5000" placeholder="Describí lo que querés contar (máx 5000)…" aria-label="Mensaje" rows="6"></textarea>
+    <div class="dcm-counter"><span id="dcmCount">0</span>/5000</div>
     <div id="diegoCarteroResp" role="status"></div>
     <div class="dcm-actions">
       <a class="dcm-chat-link" id="dcmChatLink">o hablar con Diego (chat IA)</a>


### PR DESCRIPTION
Decisión Pablo 14:10 CLT: 'puede ser hasta 5.000 caracteres por favor'. Backend mig 177 ya aplicada (CHECK + RPC). Frontend: maxlength + counter + rows=6 (más espacio visible para escribir más).