### PR TITLE
fix(asistente): aceptar email en login + fix urgente 8cb84248 (PR2 Fase 2)

### DIFF
--- a/asistente.html
+++ b/asistente.html
@@ -166,8 +166,8 @@ select.neg-input option{background:#1A2D3E;color:#fff}
       <div class="brand-desc">Ingresa con tu teléfono y PIN</div>
     </div>
     <div class="login-field">
-      <label>Teléfono WhatsApp</label>
-      <input class="login-input" id="login-tel" type="tel" inputmode="tel" placeholder="+56912345678" autocomplete="tel">
+      <label>Teléfono WhatsApp o email</label>
+      <input class="login-input" id="login-tel" type="text" inputmode="text" placeholder="+56912345678 o tu email" autocomplete="username">
     </div>
     <div class="login-field">
       <label>PIN</label>
@@ -472,29 +472,35 @@ function showLoginError(msg) {
 }
 
 async function doLogin() {
-  const tel = document.getElementById('login-tel').value.trim();
+  const raw = document.getElementById('login-tel').value.trim();
   const pin = document.getElementById('login-pin').value.trim();
-  if(!tel || !pin) { showLoginError('Ingresa tu teléfono y PIN'); return; }
+  if(!raw || !pin) { showLoginError('Ingresa tu teléfono o email + PIN'); return; }
 
   const btn = document.getElementById('login-btn');
   btn.disabled = true;
   btn.textContent = '⏳ Verificando...';
   document.getElementById('login-error').style.display = 'none';
 
-  const telNorm = normTel(tel);
+  // Fix bug 8cb84248: aceptar email O teléfono en el mismo input.
+  const isEmail = raw.includes('@');
+  const telNorm = isEmail ? null : normTel(raw);
+  const emailNorm = isEmail ? raw.toLowerCase() : null;
 
-  // Intentar con teléfono normalizado, y también con el valor original
-  const {data, error} = await _supa
+  let query = _supa
     .from('usuarios_autorizados')
     .select('*')
-    .or(`telefono.eq.${telNorm},telefono.eq.${tel}`)
     .eq('pin', pin)
     .eq('activo', true)
-    .eq('acceso_asistente', true)
-    .maybeSingle();
+    .eq('acceso_asistente', true);
+
+  query = isEmail
+    ? query.eq('email', emailNorm)
+    : query.or(`telefono.eq.${telNorm},telefono.eq.${raw}`);
+
+  const {data, error} = await query.maybeSingle();
 
   if(error || !data) {
-    showLoginError('Teléfono o PIN incorrecto');
+    showLoginError(isEmail ? 'Email o PIN incorrecto' : 'Teléfono o PIN incorrecto');
     return;
   }
 


### PR DESCRIPTION
## Summary

PR2 Fase 2 plan 13 inbox. Resuelve **urgente 8cb84248** (gestorcomercial@):
"Asistente Comercial no permite ingresar con las credenciales que tengo, a Juan Mendoza le ocurre lo mismo".

## Causa raíz

Ingrid (gestorcomercial@) y Juan (comercial@) **SÍ tienen acceso_asistente=true** + PIN válido (2026). El bug: estaban ingresando su **email** en el campo "Teléfono WhatsApp". La función `normTel()` no procesa emails → query usuarios_autorizados no matcheaba → error engañoso.

Confirmado en BD:
- Ingrid · gestorcomercial@gestionrepchile.cl · phone +56961908322 · pin 2026 · activo · acceso_asistente=true · sucursal Talca
- Juan · comercial@gestionrepchile.cl · phone +56990552591 · pin 2026 · activo · acceso_asistente=true · todas sucursales

## Cambio

- `doLogin()` detecta si input es email (contiene `@`) → busca por `email` O por `telefono` según corresponda
- Input cambia de `type="tel"` a `type="text"` + placeholder "tu teléfono o email"
- Label "Teléfono WhatsApp o email"
- Mensaje error contextual

## Test plan

- [ ] Ingrid (gestorcomercial@gestionrepchile.cl + PIN 2026) → ingresa OK
- [ ] Juan (comercial@gestionrepchile.cl + PIN 2026) → ingresa OK
- [ ] Quien siga usando teléfono → sigue funcionando igual
- [ ] PIN incorrecto → "Email o PIN incorrecto"

🤖 Generated with [Claude Code](https://claude.com/claude-code)