### PR TITLE
feat(cotizador): multi-servicio por linea (PR4 Fase 3)

### DIFF
--- a/public/panel-rdo.html
+++ b/public/panel-rdo.html
@@ -3077,6 +3077,7 @@
                 <thead>
                   <tr class="border-b text-stone-500 text-xs">
                     <th class="text-left py-2 pr-2" title="Nombre del material o servicio cotizado">Material / Descripción</th>
+                    <th class="text-left py-2 px-2 w-40" title="Servicio asociado a esta linea. Vacio = usa el servicio principal del cotizador. Permite multi-servicio en una sola cotizacion (ej: arriendo + retiros).">Servicio</th>
                     <th class="text-right py-2 px-2 w-24" title="Cantidad numérica (la unidad la elegís en la columna siguiente)">Cantidad</th>
                     <th class="text-center py-2 px-2 w-20" title="Unidad de medida: kg, t (toneladas), u (unidades), m³ o litros">Unidad</th>
                     <th class="text-right py-2 px-2 w-36" title="Precio en UF por unidad. Ej: 0.05 UF por kg, 50 UF por tonelada">Precio <span class="text-stone-400">(UF / u)</span></th>
@@ -7297,7 +7298,8 @@ async function initCotizador() {
 }
 
 function agregarLineaCot() {
-  _cotLineas.push({ desc: '', material_id: null, qty: 1, unidad: 'kg', precioUF: 0, descPct: 0 });
+  // PR4 Fase 3: servicio_id por linea (default null = usa el del cotizador principal)
+  _cotLineas.push({ desc: '', material_id: null, qty: 1, unidad: 'kg', precioUF: 0, descPct: 0, servicio_id: null });
   renderLineasCot();
 }
 
@@ -7357,8 +7359,15 @@ function eliminarLineaCot(idx) {
 function renderLineasCot() {
   const tbody = document.getElementById('cotLineas');
   const UNIDADES = ['kg','t','u','m3','lt'];
+  // PR4 Fase 3: opciones de servicio por linea (multi-servicio en una sola cotizacion)
+  const servicios = window._cotServiciosCatalogo || [];
+  const srvOptsFn = (selectedId) => {
+    return '<option value="">— Usa servicio principal —</option>' +
+      servicios.map(s => `<option value="${escapeHtml(s.servicio_id)}"${selectedId === s.servicio_id ? ' selected' : ''}>${escapeHtml(s.nombre)}</option>`).join('');
+  };
   tbody.innerHTML = _cotLineas.map((l, i) => {
     if (!l.unidad) l.unidad = 'kg';
+    if (l.servicio_id === undefined) l.servicio_id = null;
     const opts = UNIDADES.map(u => `<option value="${u}"${l.unidad===u?' selected':''}>${u}</option>`).join('');
     return `
     <tr class="border-b border-stone-100">
@@ -7371,6 +7380,14 @@ function renderLineasCot() {
                class="w-full border border-stone-200 rounded px-2 py-1 text-sm focus:border-green-700 focus:outline-none">
         ${l.material_id ? '<span class="absolute right-2 top-2 text-emerald-600 text-xs" title="Vinculado a catálogo">✓</span>' : ''}
         <div id="cotMaterialSug-${i}" class="hidden absolute left-0 right-0 top-full mt-0.5 border border-stone-200 rounded bg-white shadow-lg z-30 max-h-48 overflow-y-auto"></div>
+      </td>
+      <td class="py-1 px-2">
+        <select aria-label="Servicio de la linea ${i + 1}"
+                title="Servicio especifico de esta linea. Vacio = usa el servicio principal del cotizador."
+                onchange="_cotLineas[${i}].servicio_id = this.value || null; cotRecalcular()"
+                class="cot-servicio border border-stone-200 rounded px-1 py-1 text-sm focus:border-green-700 focus:outline-none">
+          ${srvOptsFn(l.servicio_id)}
+        </select>
       </td>
       <td class="py-1 px-2">
         <input type="number" value="${l.qty}" min="0" step="any" inputmode="decimal"


### PR DESCRIPTION
## Summary

PR4 Fase 3 plan 13 inbox. Resuelve urgente 35944a93 servicios@: AVO II SPA solicita arriendo de 3 contenedores + 6 retiros semanales de chatarra en una sola cotización. El cotizador anterior solo permitía 1 servicio principal.

## Cambios

- Tabla cotización: nueva columna **Servicio** entre Material y Cantidad
- Cada línea con select propio de servicio (catálogo cotServiciosCatalogo)
- Vacío = usa servicio principal del cotizador (compatibilidad hacia atrás)
- `agregarLineaCot` inicializa `servicio_id = null`
- **RPC cotizador_guardar_v1 NO requiere cambio**: servicio_id queda persistido dentro de `metadata.lineas` como jsonb

## Test plan

- [ ] Andrea entra cotizador, elige cliente + sucursal
- [ ] Agrega línea 1: Arriendo contenedor (servicio = Arriendo contenedor) · cantidad 3 · UF
- [ ] Agrega línea 2: Retiro (servicio = Retiro camión 3/4) · cantidad 6 · UF
- [ ] Guarda → cotización OK con servicios distintos en cada línea
- [ ] Verifica que cotizaciones viejas (sin servicio_id por línea) siguen visualizándose OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)