### PR TITLE
fix(R-AUD-034): sidebar v4 link para Cumplimiento (Wave 7 · f2a1cbaf)

### DIFF
--- a/public/panel-rdo.html
+++ b/public/panel-rdo.html
@@ -784,6 +784,10 @@
             <span class="v4-emoji" aria-hidden="true">🎧</span>
             Comunicados
           </a>
+          <a href="#" data-v4-tab="cumplimiento" class="nav-item flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm">
+            <span class="v4-emoji" aria-hidden="true">⚖️</span>
+            Cumplimiento
+          </a>
         </div>
       </details>
 


### PR DESCRIPTION
## Summary
- **Tarea f2a1cbaf** · cola_construccion · Wave 7 · R-AUD-034
- Agrega `<a data-v4-tab=\"cumplimiento\">` en categoría 📚 Soporte del sidebar v4
- Cierra el único fantasma real detectado por la auditoría 01-jun

## Contexto
La auditoría del 01-jun listó 5 fantasmas (campanas, cumplimiento, dotacion, inventario, rutas). Al revisar el estado vivo:

| pestana | activa | manifest vivo | section + handler | sidebar link |
|---|---|---|---|---|
| campanas | ❌ | ❌ OCULTA | — | — |
| cumplimiento | ✅ | ✅ | ✅ | 🔴 falta |
| dotacion | ❌ | ❌ OCULTA | — | — |
| inventario | ❌ | ❌ OCULTA | — | — |
| rutas | ❌ | ❌ OCULTA | — | — |

Las 4 OCULTAS son intencionales (`sidebar_v4_manifest.vivo=false`). El único gap real era Cumplimiento.

## Test plan
- [x] R-AUD-064 parse JS 29/29 OK
- [x] Balance div 1391/1391 · section 40/40
- [ ] Verificar visualmente que el link aparece en categoría Soporte del sidebar
- [ ] Click en link abre tabCumplimiento y dispara loadCumplimiento()

🤖 Generated with [Claude Code](https://claude.com/claude-code)