### PR TITLE
fix(R-AUD-034): agregar sidebar v4 link para Cumplimiento (#237)

### DIFF
--- a/public/panel-rdo.html
+++ b/public/panel-rdo.html
@@ -784,6 +784,10 @@
             <span class="v4-emoji" aria-hidden="true">🎧</span>
             Comunicados
           </a>
+          <a href="#" data-v4-tab="cumplimiento" class="nav-item flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm">
+            <span class="v4-emoji" aria-hidden="true">⚖️</span>
+            Cumplimiento
+          </a>
         </div>
       </details>
 


### PR DESCRIPTION
Tarea f2a1cbaf · Wave 7 · cola_construccion.

Cumplimiento tenía button-tab + section + handler (líneas 1003, 3726, 14809) pero faltaba el sidebar v4 link. Por eso quedaba inalcanzable desde el menú lateral aunque la pestaña estaba activa (pestanas.activa=true · manifest vivo=true · silos 05+10).

Las otras 4 reportadas (campanas, dotacion, inventario, rutas) están OCULTAS intencionalmente en sidebar_v4_manifest.vivo=false — no son fantasmas reales, no violan R-AUD-034.

Smoke:
- Parse JS 29/29 OK (R-AUD-064)
- Balance div 1391/1391 · section 40/40

## Qué cambia
<!-- resumen 1-3 líneas: qué problema resolvés / qué feature agregás -->

## Tipo de cambio (label)
- [ ] `risk:low` — texto, color, label, traducción, fix de typo
- [ ] `risk:med` — lógica JS, nueva pestaña, query Supabase, CSS estructural
- [ ] `risk:high` — auth/RLS, schema `curated.*`, deploys, secrets, `vercel.json`, `package.json`, `vite.config.js`

## Checklist técnico
<!-- marcá los que aplican; tachá los que no -->

- [ ] Si toqué `public/panel-rdo.html`: probé login + cambio de silo + responsive mobile (<768px) en el preview Vercel de esta rama
- [ ] Si creé tabla en `curated.*`: ejecuté `GRANT SELECT ON ... TO cesar_readonly` (sin esto, César/PowerBI rompe con `42501`)
- [ ] Si toqué visibilidad por silo o usuario: sincronicé los 4 lugares:
  - [ ] `panel.config_kv`
  - [ ] política RLS
  - [ ] vista `v_panel_silos_visibles`
  - [ ] fallback HTML del panel (constantes `FALLBACK_*`)
- [ ] Si toqué CSS: usé build local `/tailwind.css`, NO `cdn.tailwindcss.com`
- [ ] Si toqué Edge Functions: bumpié versión + corrí `supabase functions deploy <nombre>`
- [ ] Si tocaste schema curated: agregaste migración en `reciclean-rdo/supabase/migrations/` con nombre `YYYY-MM-DD_NNN_descripcion.sql`

## Preview Vercel
<!-- URL del deploy preview de esta rama -->
<URL>

## Riesgo de rollback
<!-- bajo / medio / alto + cómo revertir si rompe -->

## Bitácora paralela
- [ ] Entrada agregada en `reciclean-manifiesto-diego/docs/BITACORA-PARALELO-MAYO-2026.md`
