### PR TITLE
G42 · Tab 📊 Vales portal pesajes en panel-rdo

### DIFF
--- a/public/panel-rdo.html
+++ b/public/panel-rdo.html
@@ -642,6 +642,10 @@
             <span class="v4-emoji" aria-hidden="true">⚖️</span>
             Pesaje
           </a>
+          <a href="#" data-v4-tab="vales_portal" class="nav-item flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm">
+            <span class="v4-emoji" aria-hidden="true">📊</span>
+            Vales portal
+          </a>
           <a href="#" data-v4-tab="facturacion" class="nav-item flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm">
             <span class="v4-emoji" aria-hidden="true">🧾</span>
             Facturación
@@ -1005,6 +1009,7 @@
         <button data-tab="firmas_pend" class="tab-btn py-3 px-3 text-stone-600"          role="tab" aria-selected="false" aria-controls="tabFirmasPend">📝 Firmas pendientes</button>
         <button data-tab="tarifas_ext" class="tab-btn py-3 px-3 text-stone-600"          role="tab" aria-selected="false" aria-controls="tabTarifasExt">💰 Tarifas externas</button>
         <button data-tab="cumplimiento" class="tab-btn py-3 px-3 text-stone-600"         role="tab" aria-selected="false" aria-controls="tabCumplimiento">⚖️ Cumplimiento</button>
+        <button data-tab="vales_portal" class="tab-btn py-3 px-3 text-stone-600"         role="tab" aria-selected="false" aria-controls="tabValesPortal">📊 Vales portal</button>
         <button data-tab="piloto_pwa"  class="tab-btn py-3 px-3 text-stone-600"          role="tab" aria-selected="false" aria-controls="tabPilotoPwa">📲 Piloto PWA</button>
         <button data-tab="mis_archivos" class="tab-btn py-3 px-3 text-stone-600"        role="tab" aria-selected="false" aria-controls="tabMisArchivos">📦 Mis archivos</button>
         <button data-tab="rdo"         class="tab-btn py-3 px-3 text-stone-600"        role="tab" aria-selected="false" aria-controls="tabRdo">📈 RDO Resumen</button>
@@ -3816,6 +3821,112 @@
       <div id="cump_lista" class="space-y-2"></div>
     </section>
 
+    <!-- Tab Vales portal · G42 · D-PESAJES-DIARIA-001 · PC2 Pablo 03-jun PM -->
+    <section id="tabValesPortal" class="tab-content hidden">
+      <div class="flex items-center justify-between mb-3 flex-wrap gap-2">
+        <div>
+          <h2 class="text-xl font-bold text-stone-800">📊 Vales portal pesajes</h2>
+          <p class="text-xs text-stone-500 mt-0.5">Ingesta vales detallados desde plataforma-virtual.com. Sincroniza 3x/día L-V + 1x/día S-D.</p>
+        </div>
+        <div class="flex gap-2 items-center flex-wrap">
+          <span id="vp_estado_pipeline" class="text-xs text-stone-500"></span>
+          <button id="vp_refresh" class="px-3 py-1 bg-emerald-600 text-white rounded text-xs hover:bg-emerald-700">↻ Actualizar</button>
+        </div>
+      </div>
+
+      <!-- Banner si no hay datos -->
+      <div id="vp_banner_sin_datos" class="hidden bg-amber-50 border border-amber-300 rounded p-3 mb-3 text-sm text-amber-900">
+        <strong>⏳ Pendiente clave Vault.</strong> La infraestructura está lista (tablas + EF + 4 crons), pero la clave del portal aún no se cargó al Vault Supabase. Dusan dicta la clave verbal a Pablo · Pablo ejecuta <code class="bg-amber-100 px-1 rounded">SELECT vault.create_secret('plataforma_virtual_pesajes_password', ...);</code> · luego se activan los 4 crons.
+      </div>
+
+      <!-- KPIs -->
+      <div class="grid grid-cols-2 md:grid-cols-4 gap-2 mb-3">
+        <div class="bg-white border border-stone-200 rounded p-2">
+          <div class="text-2xl font-bold text-stone-700" id="vp_kpi_vales">0</div>
+          <div class="text-xs text-stone-500">Vales totales</div>
+        </div>
+        <div class="bg-white border border-stone-200 rounded p-2">
+          <div class="text-2xl font-bold text-emerald-700" id="vp_kpi_saldo">$0</div>
+          <div class="text-xs text-stone-500">💰 Saldo pendiente</div>
+        </div>
+        <div class="bg-white border border-stone-200 rounded p-2">
+          <div class="text-2xl font-bold text-stone-700" id="vp_kpi_clientes">0</div>
+          <div class="text-xs text-stone-500">👥 Generadores pendientes</div>
+        </div>
+        <div class="bg-white border border-stone-200 rounded p-2">
+          <div class="text-2xl font-bold text-stone-700" id="vp_kpi_ultimo">—</div>
+          <div class="text-xs text-stone-500">📅 Último vale</div>
+        </div>
+      </div>
+
+      <!-- Resumen sucursal -->
+      <div class="bg-white border border-stone-200 rounded mb-3">
+        <div class="px-3 py-2 border-b border-stone-200 text-sm font-semibold text-stone-700">🏢 Resumen por sucursal</div>
+        <div class="overflow-x-auto">
+          <table class="w-full text-sm">
+            <thead class="bg-stone-50 text-xs text-stone-500 uppercase">
+              <tr>
+                <th class="text-left px-3 py-2">Sucursal</th>
+                <th class="text-right px-3 py-2">Vales</th>
+                <th class="text-right px-3 py-2">Clientes</th>
+                <th class="text-right px-3 py-2">Kg total</th>
+                <th class="text-right px-3 py-2">CLP total</th>
+                <th class="text-right px-3 py-2">Saldo pendiente</th>
+                <th class="text-right px-3 py-2">Último vale</th>
+              </tr>
+            </thead>
+            <tbody id="vp_sucursal_body"><tr><td colspan="7" class="text-center text-stone-400 py-4">Cargando...</td></tr></tbody>
+          </table>
+        </div>
+      </div>
+
+      <!-- Cuentas pagar generadores -->
+      <div class="bg-white border border-stone-200 rounded mb-3">
+        <div class="px-3 py-2 border-b border-stone-200 text-sm font-semibold text-stone-700 flex items-center justify-between">
+          <span>💸 Cuentas por pagar (generadores con saldo &gt; 0)</span>
+          <input id="vp_filtro_generador" type="search" placeholder="Buscar razón social o RUT..." class="px-2 py-0.5 border border-stone-300 rounded text-xs">
+        </div>
+        <div class="overflow-x-auto max-h-96 overflow-y-auto">
+          <table class="w-full text-sm">
+            <thead class="bg-stone-50 text-xs text-stone-500 uppercase sticky top-0">
+              <tr>
+                <th class="text-left px-3 py-2">Razón social</th>
+                <th class="text-left px-3 py-2">RUT</th>
+                <th class="text-left px-3 py-2">Banco</th>
+                <th class="text-right px-3 py-2">Vales</th>
+                <th class="text-right px-3 py-2">Saldo CLP</th>
+                <th class="text-left px-3 py-2">Último vale</th>
+              </tr>
+            </thead>
+            <tbody id="vp_pagar_body"><tr><td colspan="6" class="text-center text-stone-400 py-4">Cargando...</td></tr></tbody>
+          </table>
+        </div>
+      </div>
+
+      <!-- Últimos 50 vales -->
+      <div class="bg-white border border-stone-200 rounded">
+        <div class="px-3 py-2 border-b border-stone-200 text-sm font-semibold text-stone-700">📋 Últimos 50 vales</div>
+        <div class="overflow-x-auto">
+          <table class="w-full text-sm">
+            <thead class="bg-stone-50 text-xs text-stone-500 uppercase">
+              <tr>
+                <th class="text-left px-3 py-2">Folio</th>
+                <th class="text-left px-3 py-2">Fecha</th>
+                <th class="text-left px-3 py-2">Sucursal</th>
+                <th class="text-left px-3 py-2">Razón social</th>
+                <th class="text-left px-3 py-2">Tipo</th>
+                <th class="text-right px-3 py-2">Kg final</th>
+                <th class="text-right px-3 py-2">CLP total</th>
+                <th class="text-right px-3 py-2">Saldo</th>
+                <th class="text-left px-3 py-2">Estado</th>
+              </tr>
+            </thead>
+            <tbody id="vp_recientes_body"><tr><td colspan="9" class="text-center text-stone-400 py-4">Cargando...</td></tr></tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+
     <!-- Tab Piloto PWA (mig 195 backend · Pablo 02-jun PM) -->
     <section id="tabPilotoPwa" class="tab-content hidden">
       <div class="flex items-center justify-between mb-3 flex-wrap gap-2">
@@ -4917,6 +5028,7 @@ const TAB_SECTION_MAP = {
   firmas_pend: 'tabFirmasPend',
   tarifas_ext: 'tabTarifasExt',
   cumplimiento: 'tabCumplimiento',
+  vales_portal: 'tabValesPortal',
   piloto_pwa: 'tabPilotoPwa',
   mis_archivos: 'tabMisArchivos',
   diego_coord: 'tabDiegoCoord',
@@ -14822,6 +14934,146 @@ document.addEventListener('DOMContentLoaded', () => {
       var btn = e.target.closest('.cump-editar');
       if (btn) abrirFormEditar(btn.dataset.id);
     });
+  }
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init); else init();
+})();
+
+// Tab Vales Portal · G42 · D-PESAJES-DIARIA-001 · PC2 Pablo 03-jun PM
+(function () {
+  let _vpPagar = [];
+  function $$(id) { return document.getElementById(id); }
+  function esc(s) { return String(s == null ? '' : s).replace(/[&<>"']/g, function (c) { return ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c]; }); }
+  function fmtCLP(n) { if (n == null || isNaN(n)) return '—'; return '$' + Number(n).toLocaleString('es-CL', { maximumFractionDigits: 0 }); }
+  function fmtKg(n) { if (n == null || isNaN(n)) return '—'; return Number(n).toLocaleString('es-CL', { maximumFractionDigits: 1 }) + ' kg'; }
+  function fmtFecha(s) { if (!s) return '—'; try { return new Date(s).toLocaleDateString('es-CL'); } catch (e) { return s; } }
+  function badgeEstadoVale(estado) {
+    var n = Number(estado);
+    if (n === 1) return '<span class="bg-amber-100 text-amber-800 px-2 py-0.5 rounded text-xs">🟡 Pendiente</span>';
+    if (n === 2) return '<span class="bg-emerald-100 text-emerald-800 px-2 py-0.5 rounded text-xs">✅ Cerrado</span>';
+    if (n === 9) return '<span class="bg-red-100 text-red-800 px-2 py-0.5 rounded text-xs">❌ Anulado</span>';
+    return '<span class="bg-stone-100 text-stone-600 px-2 py-0.5 rounded text-xs">—</span>';
+  }
+
+  async function loadVales() {
+    if (!window.sb) return;
+    var estado = $$('vp_estado_pipeline');
+    if (estado) estado.textContent = 'Cargando...';
+
+    try {
+      var sucP = sb.schema('panel').from('v_pesajes_resumen_sucursal').select('*');
+      var pagarP = sb.schema('panel').from('v_cuentas_pagar_generadores').select('*').limit(500);
+      var recientesP = sb.schema('curated').from('vales_portal_externo').select('folio,fecha,sucursal,razon_social,tipo_servicio,peso_final,total_vale,saldo_vale,estado').order('fecha', { ascending: false }).order('folio', { ascending: false }).limit(50);
+
+      var [sucR, pagarR, recR] = await Promise.all([sucP, pagarP, recientesP]);
+
+      if (sucR.error) throw sucR.error;
+      if (pagarR.error) throw pagarR.error;
+      if (recR.error) throw recR.error;
+
+      var sucRows = sucR.data || [];
+      _vpPagar = pagarR.data || [];
+      var recRows = recR.data || [];
+
+      var totalVales = sucRows.reduce(function (a, r) { return a + (Number(r.vales) || 0); }, 0);
+      var totalSaldo = _vpPagar.reduce(function (a, r) { return a + (Number(r.saldo_clp) || 0); }, 0);
+      var ultimoVale = sucRows.reduce(function (max, r) {
+        if (!r.ultimo_vale) return max;
+        if (!max || new Date(r.ultimo_vale) > new Date(max)) return r.ultimo_vale;
+        return max;
+      }, null);
+
+      if ($$('vp_kpi_vales')) $$('vp_kpi_vales').textContent = totalVales.toLocaleString('es-CL');
+      if ($$('vp_kpi_saldo')) $$('vp_kpi_saldo').textContent = fmtCLP(totalSaldo);
+      if ($$('vp_kpi_clientes')) $$('vp_kpi_clientes').textContent = _vpPagar.length.toLocaleString('es-CL');
+      if ($$('vp_kpi_ultimo')) $$('vp_kpi_ultimo').textContent = fmtFecha(ultimoVale);
+
+      if (totalVales === 0) {
+        $$('vp_banner_sin_datos')?.classList.remove('hidden');
+      } else {
+        $$('vp_banner_sin_datos')?.classList.add('hidden');
+      }
+
+      var sucBody = $$('vp_sucursal_body');
+      if (sucBody) {
+        if (sucRows.length === 0) {
+          sucBody.innerHTML = '<tr><td colspan="7" class="text-center text-stone-400 py-4">Sin datos · pipeline aún sin ejecutar</td></tr>';
+        } else {
+          sucBody.innerHTML = sucRows.map(function (r) {
+            return '<tr class="border-t border-stone-100 hover:bg-stone-50">' +
+              '<td class="px-3 py-2 font-semibold">' + esc(r.sucursal) + '</td>' +
+              '<td class="text-right px-3 py-2">' + (Number(r.vales) || 0).toLocaleString('es-CL') + '</td>' +
+              '<td class="text-right px-3 py-2">' + (Number(r.clientes_unicos) || 0).toLocaleString('es-CL') + '</td>' +
+              '<td class="text-right px-3 py-2">' + fmtKg(r.kg_total) + '</td>' +
+              '<td class="text-right px-3 py-2">' + fmtCLP(r.clp_total) + '</td>' +
+              '<td class="text-right px-3 py-2 text-emerald-700 font-semibold">' + fmtCLP(r.saldo_pendiente_clp) + '</td>' +
+              '<td class="text-right px-3 py-2 text-xs text-stone-500">' + fmtFecha(r.ultimo_vale) + '</td>' +
+              '</tr>';
+          }).join('');
+        }
+      }
+
+      renderPagar();
+
+      var recBody = $$('vp_recientes_body');
+      if (recBody) {
+        if (recRows.length === 0) {
+          recBody.innerHTML = '<tr><td colspan="9" class="text-center text-stone-400 py-4">Sin vales · cargá la clave portal para que la EF arranque</td></tr>';
+        } else {
+          recBody.innerHTML = recRows.map(function (r) {
+            return '<tr class="border-t border-stone-100 hover:bg-stone-50">' +
+              '<td class="px-3 py-2 font-mono text-xs">' + esc(r.folio) + '</td>' +
+              '<td class="px-3 py-2 text-xs">' + fmtFecha(r.fecha) + '</td>' +
+              '<td class="px-3 py-2 text-xs">' + esc(r.sucursal || '—') + '</td>' +
+              '<td class="px-3 py-2">' + esc(r.razon_social || '—') + '</td>' +
+              '<td class="px-3 py-2 text-xs">' + esc(r.tipo_servicio || '—') + '</td>' +
+              '<td class="text-right px-3 py-2">' + fmtKg(r.peso_final) + '</td>' +
+              '<td class="text-right px-3 py-2">' + fmtCLP(r.total_vale) + '</td>' +
+              '<td class="text-right px-3 py-2 font-semibold ' + (Number(r.saldo_vale) > 0 ? 'text-emerald-700' : 'text-stone-400') + '">' + fmtCLP(r.saldo_vale) + '</td>' +
+              '<td class="px-3 py-2">' + badgeEstadoVale(r.estado) + '</td>' +
+              '</tr>';
+          }).join('');
+        }
+      }
+
+      if (estado) estado.textContent = 'Última carga ' + new Date().toLocaleTimeString('es-CL');
+    } catch (e) {
+      if (estado) estado.textContent = 'Error: ' + (e && e.message ? e.message : e);
+      console.error('[vales_portal] error:', e);
+    }
+  }
+
+  function renderPagar() {
+    var body = $$('vp_pagar_body');
+    if (!body) return;
+    var filtro = ($$('vp_filtro_generador')?.value || '').toLowerCase().trim();
+    var rows = _vpPagar;
+    if (filtro) {
+      rows = rows.filter(function (r) {
+        return (r.razon_social || '').toLowerCase().includes(filtro) ||
+               String(r.rut || '').toLowerCase().includes(filtro);
+      });
+    }
+    if (rows.length === 0) {
+      body.innerHTML = '<tr><td colspan="6" class="text-center text-stone-400 py-4">' + (filtro ? 'Sin coincidencias' : 'Sin saldos pendientes') + '</td></tr>';
+      return;
+    }
+    body.innerHTML = rows.slice(0, 200).map(function (r) {
+      return '<tr class="border-t border-stone-100 hover:bg-stone-50">' +
+        '<td class="px-3 py-2 font-semibold">' + esc(r.razon_social || '—') + '</td>' +
+        '<td class="px-3 py-2 font-mono text-xs">' + esc(r.rut ? r.rut + (r.dv ? '-' + r.dv : '') : '—') + '</td>' +
+        '<td class="px-3 py-2 text-xs">' + esc(r.banco || '—') + '</td>' +
+        '<td class="text-right px-3 py-2">' + (Number(r.vales_pendientes) || 0).toLocaleString('es-CL') + '</td>' +
+        '<td class="text-right px-3 py-2 text-emerald-700 font-semibold">' + fmtCLP(r.saldo_clp) + '</td>' +
+        '<td class="px-3 py-2 text-xs text-stone-500">' + fmtFecha(r.ultimo_vale) + '</td>' +
+        '</tr>';
+    }).join('');
+  }
+
+  function init() {
+    document.querySelector('button[data-tab="vales_portal"]')?.addEventListener('click', function () { setTimeout(loadVales, 100); });
+    document.querySelector('a[data-v4-tab="vales_portal"]')?.addEventListener('click', function () { setTimeout(loadVales, 100); });
+    $$('vp_refresh')?.addEventListener('click', loadVales);
+    $$('vp_filtro_generador')?.addEventListener('input', renderPagar);
   }
   if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init); else init();
 })();


### PR DESCRIPTION
## Resumen

Tab nuevo en panel-rdo silo 📋 Operaciones que muestra los vales detallados sincronizados desde plataforma-virtual.com vía EF `ingesta-vales-portal` + 4 crons (3x/día L-V + 1x/día S-D).

**Estado pipeline**: infra al 100% en BD (mig 192 + mig 213 helper Vault + mig 214 crons + mig 215 anti-duplicado · EF v1 ACTIVE). Falta humano Dusan dictar clave Vault → activar 4 crons → primera ingesta 1.156 vales.

## Cambios `public/panel-rdo.html` (5 lugares estándar)

1. **Sidebar v4** (silo Operaciones, entre Pesaje y Facturación):
   ```html
   <a data-v4-tab="vales_portal" class="nav-item ...">📊 Vales portal</a>
   ```
2. **Navbar horizontal viejo**:
   ```html
   <button data-tab="vales_portal" aria-controls="tabValesPortal">📊 Vales portal</button>
   ```
3. **TAB_SECTION_MAP**: `vales_portal: 'tabValesPortal'`
4. **Section `tabValesPortal`** (DOM completo, 11 IDs `vp_*`)
5. **Script IIFE** con `loadVales()` + `renderPagar()` + dispatchers click

## Layout (D-VISUAL-ORO compliant)

- 🟡 Banner amarillo si BD vacía: *"Pendiente clave Vault · infraestructura lista (tablas + EF + 4 crons), falta Dusan dictar clave"*
- 4 KPI cards: Vales totales · 💰 Saldo pendiente · 👥 Generadores pendientes · 📅 Último vale
- Tabla **Resumen por sucursal** (Talca · Maipu · Cerrillos · Cerro Sombrero · Pto Montt)
- Tabla **Cuentas pagar generadores** con filtro razón social/RUT + sticky header + max-height
- Tabla **Últimos 50 vales** con badge estado (🟡 Pendiente · ✅ Cerrado · ❌ Anulado)

## Backend ya en producción (sin cambios necesarios en este PR)

| Capa | Mig | Estado |
|---|---|---|
| `curated.vales_portal_externo` (61 cols + RLS + 6 índices) | 192 | ✅ |
| `panel.v_pesajes_resumen_sucursal` + `v_cuentas_pagar_generadores` + `v_pesajes_dia` | 192 | ✅ |
| RPC `curated.f_batch_ingesta_vales` | 192 | ✅ |
| RPC helper `mayordomo.vault_decrypt_secret` | 213 | ✅ |
| 4 crons inactivos jobids 65-68 | 214 | ✅ |
| Trigger anti-duplicado RUT en clientes | 215 | ✅ |
| EF `ingesta-vales-portal` v1 ACTIVE | — | ✅ |

## Validación

- ✅ R-AUD-064 parse pre-merge: 38 scripts JS validados (`node scripts/js-parse-check.mjs`)
- ✅ 3 vistas + tabla accesibles a `authenticated` (SQL smoke contra BD)
- ✅ 11 IDs `vp_*` en DOM · 5 referencias `vales_portal` (sidebar + navbar + map + 2 handlers)
- ⏳ Smoke con login real (requiere Andrea/Pablo · no ejecutable desde sesión sin user)
- ⏳ Smoke con datos reales (requiere clave Vault Dusan)

## Caza R-AUD-022

Memoria PC2 decía "4 lugares + section + JS = 6 lugares para agregar un tab". Real verificado en panel actual = **5 lugares estándar** (sidebar + navbar + TAB_SECTION_MAP + section + IIFE JS). TAB_SECTION_MAP línea 4936 tiene fallback CamelCase automático; no hay otro array que mantener. Memoria corregida.

## Test plan

- [ ] Andrea login real → ver "📊 Vales portal" en sidebar Operaciones · tab carga sin RLS error
- [ ] Pablo login admin → mismo + verificar permisos (no debería estar gateado)
- [ ] Sin clave Vault: banner amarillo visible · KPIs en 0 · tablas con "Sin datos"
- [ ] Con clave Vault + 1.156 vales cargados: KPI Saldo ~$88M · 142 generadores · Talca 73%
- [ ] Filtro razón social en cuentas pagar funciona client-side
- [ ] Mobile responsive (grid-cols-2 md:grid-cols-4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)