### PR TITLE
fix(asistente): login por email O teléfono (bug Ingrid 04-jun)

### DIFF
--- a/asistente.html
+++ b/asistente.html
@@ -163,11 +163,11 @@ select.neg-input option{background:#1A2D3E;color:#fff}
     <div class="login-logo">
       <div class="brand-sub">Reciclean · Farex</div>
       <div class="brand-title">Asistente Comercial</div>
-      <div class="brand-desc">Ingresa con tu teléfono y PIN</div>
+      <div class="brand-desc">Ingresa con tu teléfono o email + PIN</div>
     </div>
     <div class="login-field">
-      <label>Teléfono WhatsApp</label>
-      <input class="login-input" id="login-tel" type="tel" inputmode="tel" placeholder="+56912345678" autocomplete="tel">
+      <label>Teléfono WhatsApp o email</label>
+      <input class="login-input" id="login-tel" type="text" inputmode="email" placeholder="+56912345678 o tu@correo.cl" autocomplete="username">
     </div>
     <div class="login-field">
       <label>PIN</label>
@@ -472,29 +472,34 @@ function showLoginError(msg) {
 }
 
 async function doLogin() {
-  const tel = document.getElementById('login-tel').value.trim();
+  const raw = document.getElementById('login-tel').value.trim();
   const pin = document.getElementById('login-pin').value.trim();
-  if(!tel || !pin) { showLoginError('Ingresa tu teléfono y PIN'); return; }
+  if(!raw || !pin) { showLoginError('Ingresa tu teléfono/email y PIN'); return; }
 
   const btn = document.getElementById('login-btn');
   btn.disabled = true;
   btn.textContent = '⏳ Verificando...';
   document.getElementById('login-error').style.display = 'none';
 
-  const telNorm = normTel(tel);
+  // Detección email vs teléfono: si tiene '@' lo tratamos como email,
+  // sino como teléfono y aplicamos normTel.
+  const esEmail = raw.includes('@');
+  let query = _supa.from('usuarios_autorizados').select('*');
+  if (esEmail) {
+    query = query.eq('email', raw.toLowerCase());
+  } else {
+    const telNorm = normTel(raw);
+    query = query.or(`telefono.eq.${telNorm},telefono.eq.${raw}`);
+  }
 
-  // Intentar con teléfono normalizado, y también con el valor original
-  const {data, error} = await _supa
-    .from('usuarios_autorizados')
-    .select('*')
-    .or(`telefono.eq.${telNorm},telefono.eq.${tel}`)
+  const {data, error} = await query
     .eq('pin', pin)
     .eq('activo', true)
     .eq('acceso_asistente', true)
     .maybeSingle();
 
   if(error || !data) {
-    showLoginError('Teléfono o PIN incorrecto');
+    showLoginError(esEmail ? 'Email o PIN incorrecto' : 'Teléfono o PIN incorrecto');
     return;
   }
 


### PR DESCRIPTION
## Resumen

`asistente.html` solo permitía login por teléfono. Cuando el usuario pegaba su email, `normTel('xxx@yyy.cl')` deja string vacío y la query falla con "Teléfono o PIN incorrecto".

Reporte fuente:
- 04-jun 13:40 CLT · gestorcomercial@ (Ingrid, Talca, admin) · pegó email + PIN 2026 → no entró.
- 03-jun 08:58 CLT · misma usuaria · probó teléfono → "Teléfono o PIN incorrecto" (probable cache Vercel pre-PR #223+#224).

## Cambio

- Label: "Teléfono WhatsApp" → "Teléfono WhatsApp o email"
- Input `type=tel/inputmode=tel` → `type=text/inputmode=email`
- Placeholder agrega "o tu@correo.cl"
- `doLogin()` detecta `@` y rutea:
  - `.eq('email', raw.toLowerCase())`
  - sino rama teléfono existente con `normTel()`

## Smoke

SQL contra `usuarios_autorizados` real de Ingrid (`gestorcomercial@`, PIN 2026, activo, acceso_asistente=true):
- Path email → 1 fila ✅
- Path teléfono `+56961908322` → 1 fila ✅
- Path teléfono `961908322` → 1 fila ✅

Smoke E2E con Playwright contra prod tras merge.

## Cierra
- `panel.diego_inbox` id `b369f98b-492f-49b9-86ca-9e49f3e794ab` (04-jun)
- `panel.diego_inbox` id `c43a55e2-a1b5-473e-8a92-b1159dd4f6b4` (03-jun)

## R-AUD-024
Afirmación post-merge tras smoke E2E real.