### PR TITLE
panel-rdo: 2 fetchs Diego → diego-secure (D-OVERRIDE-DIEGO-001 FASE 2a)

### DIFF
--- a/public/panel-rdo.html
+++ b/public/panel-rdo.html
@@ -11136,7 +11136,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 <script>
 (function () {
-  // Diego v6 · chat inteligente conectado a Edge Function diego-chat-process
+  // Diego v6 · chat inteligente conectado a Edge Function diego-secure (wrapper FASE 2a) → diego-chat-process interno
   // D-DIEGO-PROMPT-V6 (Dusan 22-may-2026). System prompt fuente: DIEGO-PROMPT-MAXIMO.md
   function ready() { return typeof sb !== 'undefined' && sb && sb.schema; }
 
@@ -11326,7 +11326,8 @@ document.addEventListener('DOMContentLoaded', () => {
       ...(attach ? { file_url: attach.file_url, file_mime: attach.file_mime, file_name: attach.file_name } : {}),
     };
     try {
-      const r = await fetch(`${SUPABASE_URL_LOCAL}/functions/v1/diego-chat-process`, {
+      // D-OVERRIDE-DIEGO-001 FASE 2a (PC1 Dusan 2026-06-05): target diego-secure (verify_jwt=true) + router verbos ambiguos.
+      const r = await fetch(`${SUPABASE_URL_LOCAL}/functions/v1/diego-secure`, {
         method: 'POST',
         headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
         body: JSON.stringify(body),
@@ -13925,7 +13926,8 @@ document.addEventListener('DOMContentLoaded', () => {
     try {
       var SUPA = (typeof SUPABASE_URL !== 'undefined') ? SUPABASE_URL : 'https://eknmtsrtfkzroxnovfqn.supabase.co';
       var ANON = (typeof SUPABASE_ANON_KEY !== 'undefined') ? SUPABASE_ANON_KEY : '';
-      var r = await fetch(SUPA + '/functions/v1/diego-chat-process', {
+      // D-OVERRIDE-DIEGO-001 FASE 2a (PC1 Dusan 2026-06-05): target diego-secure (verify_jwt=true). FAB cartero mode skip router.
+      var r = await fetch(SUPA + '/functions/v1/diego-secure', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + ANON },
         body: JSON.stringify({


### PR DESCRIPTION
## Summary

2 fetchs en `public/panel-rdo.html` cambian de `diego-chat-process` directo → `diego-secure` (wrapper EF con `verify_jwt=true`).

| Línea | Caller | Auth header |
|---|---|---|
| ~11330 | Chat Diego v6 (modal FAB conversacional) | `Bearer ${token}` (JWT usuario) |
| ~13930 | FAB cartero `mode=feedback_cartero` | `Bearer ANON_KEY` |

> El fetch de "limpiar memoria sesión" ya fue refactoreado a `sb.rpc('mi_memoria_borrar_memoria_sesion')` directo en main, no requiere cambio en este PR.

## Contexto · D-OVERRIDE-DIEGO-001 FASE 2a

- `diego-secure` v1 deployada en Supabase con `verify_jwt=true`. Edge Runtime valida `Bearer` automático.
- Router de verbos ambiguos inline en la wrapper: saludo simple ("hola", "orientame", "ayuda") + mensaje corto sin palabra concreta (precio/cliente/factura/etc) → devuelve menú 5 opciones sin pasar por Claude API (1 ms latencia).
- Si no matchea router, forwards a `diego-chat-process` con `X-Internal-Caller-Secret` (futuro check en v73 cerrará el gap residual de URL pública).
- Otras EFs ya actualizadas en mismo D-OVERRIDE: `dieguito-whatsapp v11` (HMAC strict hardcoded + target diego-secure), `diego-health-check v8` (target diego-secure).

## Validación pre-merge

### R-AUD-064 · parser oficial
```bash
$ node scripts/js-parse-check.mjs
✓ public/panel-rdo.html · 39 scripts OK
✓ asistente.html · 9 scripts OK
OK · sin errores sintacticos.
```

### Smoke end-to-end real (prod)
Pablo manda "hola" WhatsApp 2026-06-05 13:35:17 CLT → recibe menú 5 opciones en su WhatsApp.

Cadena 9 piezas validadas:
1. Meta webhook llega a `dieguito-whatsapp v11`
2. Firma HMAC `X-Hub-Signature-256` válida (STRICT enforcement)
3. Consent check `granted` (post fix RPC layer)
4. Forward a `diego-secure` con Bearer ANON
5. `verify_jwt=true` valida Bearer (Supabase auto)
6. Router detecta "hola" + corto + sin negativo → activa
7. Menú generado (1 ms)
8. `dieguito-whatsapp` envía a Meta WhatsApp
9. WhatsApp Pablo recibe

Evidencia: `panel.diego_conv_log` muestra `sig_status=valid`, `target=diego-secure`, `had_error=false`, latency 2370ms. Afirmación R-AUD-024 #420.

## Checklist CLAUDE.md (regla 3)

- [x] bypass 4 lugares (`config_kv` + RLS + `v_panel_silos_visibles` + fallback HTML)? **NO APLICA** — solo cambio URL de fetch
- [x] GRANTs `cesar_readonly` a tablas nuevas en `curated.*`? **NO APLICA** — sin tablas nuevas
- [x] Mobile responsive verificado? **NO APLICA** — sin cambio visual UI

## Gap residual conocido

`diego-chat-process` v72 sigue accesible públicamente con `verify_jwt=false`. Task #50 abierta con SLA 7 días: big deploy v73 con shared-secret check al inicio del handler. Mitigación actual: ningún caller documentado externamente usa la URL directa.

## Test plan post-merge

- [ ] Abrir preview Vercel + login normal en panel-rdo.html
- [ ] FAB Diego → "hola" → debe aparecer menú 5 opciones (no fallback "no tengo certeza")
- [ ] FAB Diego → "cuanto cuesta el cartón hoy" → debe forwardear a Claude API y devolver precios reales
- [ ] FAB cartero (🚨 urgente) → escribir mensaje → debe insertar en `panel.diego_inbox`
- [ ] WhatsApp Diego → "hola" → debe recibir menú 5 opciones

🤖 Generated with [Claude Code](https://claude.com/claude-code)