### PR TITLE
feat(permisologia): Expedientes 4x5 + gobernanza completa + reclasificación 40 obligaciones

### DIFF
--- a/public/expedientes/expediente.html
+++ b/public/expedientes/expediente.html
@@ -7,10 +7,10 @@
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
 <style>
-:root{--primary:#059669;--dark:#064e3b;--text:#111827;--muted:#6b7280;--border:#e5e7eb;--cream:#fef3c7;--amber:#d97706}
+:root{--primary:#059669;--dark:#064e3b;--text:#111827;--muted:#6b7280;--border:#e5e7eb;--cream:#fef3c7;--amber:#d97706;--red:#dc2626;--blue:#2563eb}
 *{box-sizing:border-box}
 body{font-family:'Inter',sans-serif;margin:0;background:#f3f4f6;color:var(--text);line-height:1.55}
-.page{max-width:840px;margin:0 auto;background:#fff;box-shadow:0 0 24px rgba(0,0,0,.08);min-height:100vh}
+.page{max-width:920px;margin:0 auto;background:#fff;box-shadow:0 0 24px rgba(0,0,0,.08);min-height:100vh}
 .toolbar{position:sticky;top:0;background:#111827;color:#fff;padding:12px 24px;display:flex;justify-content:space-between;align-items:center;z-index:10;flex-wrap:wrap;gap:12px}
 .toolbar .info{font-size:13px;display:flex;gap:16px;flex-wrap:wrap;align-items:center}
 .toolbar .info strong{color:#86efac}
@@ -19,19 +19,34 @@ body{font-family:'Inter',sans-serif;margin:0;background:#f3f4f6;color:var(--text
 .toolbar button.secondary{background:transparent;border:1px solid #4b5563}
 .body{padding:48px 56px}
 .loading{padding:80px;text-align:center;color:var(--muted)}
+.error{padding:40px;color:var(--red);background:#fee2e2;border-radius:8px;margin:24px;font-family:monospace;font-size:13px;white-space:pre-wrap}
 .cover{text-align:center;padding:60px 24px;border-bottom:3px solid var(--dark);page-break-after:always}
 .cover h1{font-size:28px;color:var(--dark);margin:0 0 8px;letter-spacing:-.5px}
 .cover p{margin:6px 0;font-size:14px;color:#374151}
 .cover .badge{display:inline-block;background:var(--cream);border:1px solid var(--amber);color:#92400e;padding:4px 12px;border-radius:6px;font-size:12px;font-weight:700;margin-top:16px}
+
+/* Mesa de control */
+.mesa{margin:24px 0 36px;padding:20px;background:#f9fafb;border:1px solid var(--border);border-radius:10px}
+.mesa h3{margin:0 0 12px;font-size:15px;color:var(--dark)}
+.mesa table{width:100%;border-collapse:collapse;font-size:13px}
+.mesa th{text-align:left;padding:8px;border-bottom:2px solid var(--border);color:var(--muted);font-weight:600;font-size:11px;text-transform:uppercase;letter-spacing:.05em}
+.mesa td{padding:10px 8px;border-bottom:1px solid var(--border);vertical-align:middle}
+.mesa tr:hover{background:#fff;cursor:pointer}
+.mesa tr.activa{background:#ecfdf5}
+.dot{display:inline-block;width:10px;height:10px;border-radius:50%;margin-right:6px;vertical-align:middle}
+.dot.verde{background:#10b981}
+.dot.amarillo{background:#f59e0b}
+.dot.rojo{background:#ef4444}
+.dot.azul{background:#3b82f6}
+.mini-chip{display:inline-block;background:#e5e7eb;color:#374151;padding:2px 8px;border-radius:4px;font-size:11px;font-weight:600;margin-left:4px}
+.mini-chip.alerta{background:#fef3c7;color:#92400e}
+.mini-chip.ok{background:#d1fae5;color:#065f46}
+
 .section{padding:36px 0;border-bottom:1px solid var(--border)}
 .section h2{font-size:20px;color:var(--dark);margin:0 0 16px;font-weight:800}
-.section p{margin:0 0 10px;font-size:14px}
-.toc{background:#f9fafb;border:1px solid var(--border);border-radius:8px;padding:20px;margin:24px 0}
-.toc h3{margin:0 0 12px;font-size:15px;color:var(--dark)}
-.toc ol{margin:0;padding-left:24px;font-size:13px;line-height:1.9}
-.toc li.completo{color:#065f46;font-weight:600}
-.toc li.falta{color:#b45309}
+
 .punto{padding:32px 0;page-break-before:always;border-top:2px solid var(--dark)}
+.punto[data-active="1"]{background:#fefce8;margin-left:-32px;margin-right:-32px;padding-left:32px;padding-right:32px;border-radius:8px}
 .punto .head{display:flex;justify-content:space-between;align-items:flex-start;gap:16px;margin-bottom:16px}
 .punto h3{font-size:17px;color:var(--dark);margin:0;flex:1}
 .punto .meta{font-size:11px;color:var(--muted);text-align:right;line-height:1.7}
@@ -39,23 +54,64 @@ body{font-family:'Inter',sans-serif;margin:0;background:#f3f4f6;color:var(--text
 .punto .estado-respaldo.ok{background:#d1fae5;color:#065f46}
 .punto .estado-respaldo.falta{background:#fef3c7;color:#92400e}
 .punto .descripcion{font-size:13px;color:#374151;margin:8px 0 16px}
-.punto .archivo-box{border:2px dashed var(--border);border-radius:8px;padding:24px;text-align:center;color:var(--muted);font-size:13px;background:#f9fafb}
+.punto .archivo-box{border:2px dashed var(--border);border-radius:8px;padding:18px;text-align:center;color:var(--muted);font-size:13px;background:#f9fafb;margin-bottom:14px}
 .punto .archivo-box.con-archivo{background:#ecfdf5;border-color:#10b981;color:#065f46}
-.punto img{max-width:100%;border:1px solid var(--border);border-radius:6px;margin-top:12px}
-.punto .pdf-link{display:inline-block;background:#dbeafe;color:#1e40af;padding:8px 16px;border-radius:6px;text-decoration:none;font-size:13px;font-weight:600;margin-top:8px}
-.tareas{background:#fef3c7;border-left:4px solid var(--amber);padding:12px 16px;margin-top:12px;border-radius:4px;font-size:12px}
+.pdf-link{display:inline-block;background:#dbeafe;color:#1e40af;padding:6px 12px;border-radius:6px;text-decoration:none;font-size:12px;font-weight:600;margin:4px}
+
+.tareas{background:#fef3c7;border-left:4px solid var(--amber);padding:12px 16px;margin:12px 0;border-radius:4px;font-size:12px}
 .tareas strong{color:#92400e;display:block;margin-bottom:4px}
 .tareas ul{margin:0;padding-left:20px}
+
+/* Bitácora gestiones */
+.bitacora{margin-top:16px;border:1px solid var(--border);border-radius:8px;overflow:hidden}
+.bitacora .bit-head{background:#1f2937;color:#fff;padding:10px 14px;display:flex;justify-content:space-between;align-items:center;font-size:13px;font-weight:700}
+.bitacora .bit-head .count{font-size:11px;background:#374151;padding:2px 8px;border-radius:10px;font-weight:600}
+.bitacora .bit-list{padding:0;margin:0;list-style:none;background:#fff;max-height:none}
+.bitacora .bit-item{padding:12px 14px;border-bottom:1px solid var(--border);font-size:12px;line-height:1.5}
+.bitacora .bit-item:last-child{border-bottom:none}
+.bitacora .bit-tipo{display:inline-block;font-size:10px;font-weight:700;padding:2px 8px;border-radius:4px;margin-right:8px;text-transform:uppercase;letter-spacing:.04em}
+.bitacora .bit-tipo.whatsapp{background:#25d366;color:#fff}
+.bitacora .bit-tipo.correo{background:#2563eb;color:#fff}
+.bitacora .bit-tipo.llamada{background:#7c3aed;color:#fff}
+.bitacora .bit-tipo.visita{background:#ea580c;color:#fff}
+.bitacora .bit-tipo.reunion{background:#0891b2;color:#fff}
+.bitacora .bit-tipo.nota{background:#6b7280;color:#fff}
+.bitacora .bit-tipo.solicitud_interna{background:#be185d;color:#fff}
+.bitacora .bit-tipo.respuesta_autoridad{background:#064e3b;color:#fff}
+.bitacora .bit-tipo.otro{background:#94a3b8;color:#fff}
+.bitacora .bit-meta{color:var(--muted);font-size:11px;margin-top:4px}
+.bitacora .bit-texto{margin:6px 0 0;color:#1f2937}
+.bitacora .bit-adjunto{margin-top:8px}
+.bitacora .bit-adjunto img{max-width:280px;max-height:200px;border:1px solid var(--border);border-radius:6px;cursor:zoom-in}
+.bitacora .bit-vacia{padding:20px;text-align:center;color:var(--muted);font-size:12px;font-style:italic}
+.btn-agregar{background:var(--primary);color:#fff;border:none;padding:8px 14px;border-radius:6px;font-weight:600;cursor:pointer;font-size:12px;margin:10px 14px}
+.btn-agregar:hover{background:#047857}
+
+/* Modal agregar gestión */
+.modal-bg{position:fixed;inset:0;background:rgba(0,0,0,.6);display:none;align-items:center;justify-content:center;z-index:100;padding:20px}
+.modal-bg.open{display:flex}
+.modal{background:#fff;border-radius:12px;max-width:540px;width:100%;padding:24px;max-height:90vh;overflow-y:auto}
+.modal h3{margin:0 0 16px;color:var(--dark);font-size:18px}
+.modal label{display:block;font-size:12px;font-weight:600;color:#374151;margin:10px 0 4px}
+.modal input,.modal select,.modal textarea{width:100%;padding:8px 10px;border:1px solid var(--border);border-radius:6px;font-size:13px;font-family:inherit}
+.modal textarea{min-height:80px;resize:vertical}
+.modal .actions{margin-top:20px;display:flex;gap:10px;justify-content:flex-end}
+.modal .actions button{padding:8px 16px;border-radius:6px;border:none;font-weight:600;cursor:pointer;font-size:13px}
+.modal .actions .ok{background:var(--primary);color:#fff}
+.modal .actions .cancel{background:#e5e7eb;color:#374151}
+.modal .file-info{font-size:11px;color:var(--muted);margin-top:4px}
+
 .firma{margin-top:60px;padding-top:40px;border-top:1px solid var(--border);display:grid;grid-template-columns:1fr 1fr;gap:60px;page-break-inside:avoid}
 .firma .linea{border-bottom:1px solid var(--text);height:50px}
 .firma .label{font-size:12px;color:var(--muted);margin-top:6px;text-align:center}
 @media print{
-  .toolbar{display:none}
+  .toolbar,.btn-agregar,.modal-bg{display:none !important}
   body{background:#fff}
   .page{box-shadow:none;max-width:none}
   .body{padding:24px 32px}
-  .punto{page-break-before:always}
+  .punto{page-break-before:always;background:#fff !important}
   .cover{page-break-after:always}
+  .bitacora{break-inside:avoid}
 }
 </style>
 </head>
@@ -66,16 +122,56 @@ body{font-family:'Inter',sans-serif;margin:0;background:#f3f4f6;color:var(--text
       <span>📋 Expediente: <strong id="t-codigo">cargando...</strong></span>
       <span>Estado: <strong id="t-estado">—</strong></span>
       <span>Respaldos: <strong id="t-respaldos">—</strong></span>
+      <span>Gestiones: <strong id="t-gestiones">—</strong></span>
     </div>
     <div>
-      <button class="secondary" onclick="window.location.href='/panel-rdo.html'">← Volver al panel</button>
-      <button onclick="window.print()">🖨️ Imprimir todo</button>
+      <button class="secondary" onclick="window.location.href='/panel-rdo.html'">← Panel</button>
+      <button onclick="window.print()">🖨️ Imprimir</button>
     </div>
   </div>
   <div class="body" id="contenido">
     <div class="loading">Cargando expediente...</div>
   </div>
 </div>
+
+<!-- Modal agregar gestión -->
+<div class="modal-bg" id="modalGestion">
+  <div class="modal">
+    <h3>➕ Registrar gestión efectuada</h3>
+    <input type="hidden" id="g_obligacion_id">
+    <div id="g_punto_titulo" style="font-size:13px;color:var(--muted);margin-bottom:12px"></div>
+    <label>Tipo de gestión</label>
+    <select id="g_tipo">
+      <option value="whatsapp">📱 WhatsApp</option>
+      <option value="correo">📧 Correo</option>
+      <option value="llamada">📞 Llamada</option>
+      <option value="visita">🚗 Visita en terreno</option>
+      <option value="reunion">👥 Reunión</option>
+      <option value="solicitud_interna">📤 Solicitud interna</option>
+      <option value="respuesta_autoridad">🏛️ Respuesta autoridad</option>
+      <option value="nota">📝 Nota / comentario</option>
+      <option value="otro">❓ Otro</option>
+    </select>
+    <label>¿Cuándo ocurrió?</label>
+    <input type="datetime-local" id="g_cuando">
+    <label>¿Quién hizo la gestión? (email)</label>
+    <input type="email" id="g_actor_email" placeholder="ej: asistente@gestionrepchile.cl">
+    <label>Nombre actor (opcional)</label>
+    <input type="text" id="g_actor_nombre" placeholder="ej: Jair">
+    <label>¿A quién va dirigida? (opcional)</label>
+    <input type="text" id="g_destinatario" placeholder="ej: Dyana / Municipalidad de Maule">
+    <label>Descripción de la gestión</label>
+    <textarea id="g_texto" placeholder="Ej: Le envié WhatsApp a Dyana pidiendo el PDF firmado del SAG. Quedó en mandarlo hoy en la tarde."></textarea>
+    <label>Adjunto (foto WhatsApp / PDF correo / etc · opcional)</label>
+    <input type="file" id="g_archivo" accept="image/*,application/pdf,.eml">
+    <div class="file-info" id="g_archivo_info"></div>
+    <div class="actions">
+      <button class="cancel" onclick="cerrarModal()">Cancelar</button>
+      <button class="ok" id="g_guardar" onclick="guardarGestion()">Guardar gestión</button>
+    </div>
+  </div>
+</div>
+
 <script>
 const SUPABASE_URL = 'https://eknmtsrtfkzroxnovfqn.supabase.co';
 const SUPABASE_ANON = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImVrbm10c3J0Zmt6cm94bm92ZnFuIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzU0MDY2ODgsImV4cCI6MjA5MDk4MjY4OH0.8Y4N0lw3DFN3Y8-R6ID7t_LAfgHWDM5N-oa4Ji9bncg';
@@ -83,89 +179,150 @@ const sb = supabase.createClient(SUPABASE_URL, SUPABASE_ANON);
 const params = new URLSearchParams(location.search);
 const codigo = params.get('codigo') || 'EXP-TALCA-PATENTE-DEFINITIVA';
 
+let _data = null;
+
 function esc(s){return String(s==null?'':s).replace(/[&<>"']/g,c=>({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;"}[c]));}
+function fmtFecha(d){if(!d)return '—';try{return new Date(d).toLocaleString('es-CL',{day:'2-digit',month:'short',hour:'2-digit',minute:'2-digit'});}catch(_){return String(d);}}
+function fmtDia(d){if(!d)return '—';try{return new Date(d).toLocaleDateString('es-CL');}catch(_){return String(d);}}
+
+function semaforoColor(o){
+  const tieneArch = (o.archivos||[]).length > 0;
+  const tienBit = (o.bitacora||[]).length > 0;
+  if (o.estado === 'cumplido' && tieneArch) return 'verde';
+  if (o.estado === 'cumplido' && !tieneArch && tienBit) return 'amarillo';
+  if (o.estado === 'cumplido' && !tieneArch) return 'amarillo';
+  if (o.estado === 'en_proceso') return 'azul';
+  return 'rojo';
+}
 
 async function cargar(){
   try{
-    const {data:exp,error:e1} = await sb.schema('panel').from('expedientes').select('*').eq('codigo',codigo).single();
-    if(e1) throw e1;
-    if(!exp){document.getElementById('contenido').innerHTML='<div class="loading">Expediente no encontrado: '+esc(codigo)+'</div>';return;}
-
-    const {data:obls,error:e2} = await sb.schema('panel').from('cumplimiento_legal').select('*').in('id',exp.obligaciones_ids);
-    if(e2) throw e2;
-
-    const oblsOrdenadas = exp.obligaciones_ids.map(id => obls.find(o => o.id === id)).filter(Boolean);
-
-    const {data:articulos} = await sb.schema('panel').from('articulos_ley').select('id,titulo,contenido').in('id',exp.obligaciones_ids);
-    const mapArt = {};(articulos||[]).forEach(a=>mapArt[a.id]=a);
-
-    const {data:tareas} = await sb.schema('panel').from('cumplim_evidencia_tareas').select('*').in('obligacion_id',exp.obligaciones_ids).neq('estado','cancelado');
-    const mapTareas = {};(tareas||[]).forEach(t=>{(mapTareas[t.obligacion_id]=mapTareas[t.obligacion_id]||[]).push(t)});
-
-    let archivosTotal = {};
-    try{
-      const {data:archivos} = await sb.schema('panel').from('cumplimiento_archivos').select('*').in('obligacion_id',exp.obligaciones_ids);
-      (archivos||[]).forEach(a=>{(archivosTotal[a.obligacion_id]=archivosTotal[a.obligacion_id]||[]).push(a)});
-    }catch(_){}
-
-    const conRespaldo = oblsOrdenadas.filter(o => (archivosTotal[o.id]||[]).length > 0).length;
-
-    document.getElementById('t-codigo').textContent = exp.codigo;
-    document.getElementById('t-estado').textContent = exp.estado;
-    document.getElementById('t-respaldos').textContent = conRespaldo + '/' + oblsOrdenadas.length;
-
-    const toc = oblsOrdenadas.map((o,i) => {
-      const a = mapArt[o.articulo_id] || {titulo:'(sin título)'};
-      const tieneArch = (archivosTotal[o.id]||[]).length > 0;
-      return '<li class="'+(tieneArch?'completo':'falta')+'">'+esc(a.titulo)+(tieneArch?' ✓':' · falta respaldo')+'</li>';
-    }).join('');
-
-    const puntos = oblsOrdenadas.map((o,i) => {
-      const a = mapArt[o.articulo_id] || {titulo:'(sin título)',contenido:''};
-      const archs = archivosTotal[o.id]||[];
-      const ts = mapTareas[o.id]||[];
-      const tieneArch = archs.length > 0;
-      return ''
-        + '<div class="punto">'
-        + '  <div class="head">'
-        + '    <h3>'+(i+1)+'. '+esc(a.titulo)+'</h3>'
-        + '    <div class="meta">Estado: <strong>'+esc(o.estado)+'</strong>'
-        +        '<br>Plazo: '+esc(o.fecha_verificacion||'—')
-        +        '<br>Responsable: '+esc(o.responsable||'—')
-        +        '<br><span class="estado-respaldo '+(tieneArch?'ok':'falta')+'">'+(tieneArch?'✓ respaldo digital':'⚠ falta respaldo digital')+'</span>'
-        +     '</div>'
-        + '  </div>'
-        + '  <div class="descripcion">'+esc(a.contenido||'')+'</div>'
-        + '  <div class="archivo-box '+(tieneArch?'con-archivo':'')+'">'
-        +     (tieneArch
-              ? archs.map(ar => '📎 '+esc(ar.filename||'archivo')+' · '+esc(ar.mime_type||'')+(ar.storage_path?'<br><a class="pdf-link" href="#" onclick="abrir(\\''+esc(ar.storage_path)+'\\',\\''+esc(ar.bucket||'impulsa-documentos')+'\\');return false">Ver documento</a>':'')).join('<br>')
-              : 'Falta cargar el respaldo digital de este punto. Trabajo asignado a Jair (ver tareas abajo).'
-            )
-        + '  </div>'
-        +    (ts.length ? '<div class="tareas"><strong>📋 Tareas para completar este respaldo:</strong><ul>'
-                          + ts.map(t=>'<li>'+esc(t.descripcion)+' · <em>'+esc(t.responsable_nombre||t.responsable_email)+'</em> · plazo '+esc(t.fecha_meta||'sin fecha')+' · <strong>'+esc(t.estado)+'</strong></li>').join('')
-                          + '</ul></div>' : '')
-        + '</div>';
-    }).join('');
-
-    document.getElementById('contenido').innerHTML =
-        '<div class="cover">'
-      + '  <h1>'+esc(exp.titulo)+'</h1>'
-      + '  <p><strong>Destinatario:</strong> '+esc(exp.autoridad_destinataria)+'</p>'
-      + '  <p><strong>Solicitante:</strong> '+esc(exp.razon_social||'')+' · RUT '+esc(exp.rut_empresa||'')+'</p>'
-      + '  <p><strong>Sucursal:</strong> '+esc(exp.sucursal_id||'')+'</p>'
-      + '  <p><strong>Código expediente:</strong> '+esc(exp.codigo)+'</p>'
-      + '  <p style="margin-top:24px;font-size:12px;color:#6b7280">Fecha de impresión: '+new Date().toLocaleDateString('es-CL')+'</p>'
-      + '  <div class="badge">'+conRespaldo+' de '+oblsOrdenadas.length+' respaldos digitales cargados</div>'
-      + '</div>'
-      + (exp.cuerpo_html || '')
-      + '<div class="section"><h2>Índice de documentos adjuntos</h2><div class="toc"><ol>'+toc+'</ol></div></div>'
-      + puntos
-      + '<div class="firma"><div><div class="linea"></div><div class="label">Firma representante legal · Reciclean SpA</div></div><div><div class="linea"></div><div class="label">Recepción · I. Municipalidad de Maule</div></div></div>';
-
+    const {data,error} = await sb.schema('panel').rpc('expediente_get',{p_codigo:codigo});
+    if(error) throw error;
+    if(!data || data.error){
+      document.getElementById('contenido').innerHTML = '<div class="error">Expediente no encontrado: '+esc(codigo)+'</div>';
+      return;
+    }
+    _data = data;
+    render();
   }catch(err){
-    document.getElementById('contenido').innerHTML = '<div class="loading" style="color:#dc2626">Error: '+esc(err.message||err)+'</div>';
+    document.getElementById('contenido').innerHTML = '<div class="error">Error cargando: '+esc(err.message||JSON.stringify(err))+'</div>';
   }
+}
+
+function render(){
+  const exp = _data.expediente;
+  const obls = _data.obligaciones || [];
+  const totalArchivos = obls.reduce((s,o)=>s+(o.archivos||[]).length,0);
+  const totalGestiones = obls.reduce((s,o)=>s+(o.bitacora||[]).length,0);
+  const conRespaldo = obls.filter(o => (o.archivos||[]).length > 0).length;
+
+  document.getElementById('t-codigo').textContent = exp.codigo;
+  document.getElementById('t-estado').textContent = exp.estado;
+  document.getElementById('t-respaldos').textContent = conRespaldo+'/'+obls.length;
+  document.getElementById('t-gestiones').textContent = totalGestiones;
+
+  const mesaRows = obls.map(o => {
+    const color = semaforoColor(o);
+    const nArch = (o.archivos||[]).length;
+    const nBit = (o.bitacora||[]).length;
+    const nTareas = (o.tareas||[]).filter(t=>t.estado!=='hecho').length;
+    return '<tr onclick="irA('+o.id+')">'
+      + '<td><span class="dot '+color+'"></span><strong>'+o.orden+'.</strong> '+esc(o.titulo||'(sin título)')+'</td>'
+      + '<td>'+esc(o.estado)+'</td>'
+      + '<td>'+(nArch>0?'<span class="mini-chip ok">📎 '+nArch+'</span>':'<span class="mini-chip alerta">sin doc</span>')+'</td>'
+      + '<td>'+(nBit>0?'<span class="mini-chip">💬 '+nBit+'</span>':'<span class="mini-chip alerta">sin gestiones</span>')+'</td>'
+      + '<td>'+(nTareas>0?'<span class="mini-chip alerta">'+nTareas+' pend</span>':'<span class="mini-chip ok">ok</span>')+'</td>'
+      + '<td>'+fmtDia(o.fecha_verificacion)+'</td>'
+      + '</tr>';
+  }).join('');
+
+  const puntos = obls.map(o => renderPunto(o)).join('');
+
+  document.getElementById('contenido').innerHTML =
+      '<div class="cover">'
+    + '  <h1>'+esc(exp.titulo)+'</h1>'
+    + '  <p><strong>Destinatario:</strong> '+esc(exp.autoridad_destinataria)+'</p>'
+    + '  <p><strong>Solicitante:</strong> '+esc(exp.razon_social||'')+' · RUT '+esc(exp.rut_empresa||'')+'</p>'
+    + '  <p><strong>Sucursal:</strong> '+esc(exp.sucursal_id||'')+'</p>'
+    + '  <p><strong>Código:</strong> '+esc(exp.codigo)+'</p>'
+    + '  <p style="margin-top:24px;font-size:12px;color:#6b7280">Impreso: '+new Date().toLocaleDateString('es-CL')+'</p>'
+    + '  <div class="badge">'+conRespaldo+'/'+obls.length+' respaldos · '+totalGestiones+' gestiones registradas</div>'
+    + '</div>'
+    + (exp.cuerpo_html || '')
+    + '<div class="section"><h2>🎛️ Mesa de control · click en una fila para ir al punto</h2>'
+    + '  <div class="mesa"><table>'
+    + '    <thead><tr><th>Documento</th><th>Estado</th><th>Respaldo</th><th>Gestiones</th><th>Tareas</th><th>Plazo</th></tr></thead>'
+    + '    <tbody>'+mesaRows+'</tbody>'
+    + '  </table></div>'
+    + '</div>'
+    + puntos
+    + '<div class="firma"><div><div class="linea"></div><div class="label">Firma representante legal · Reciclean SpA</div></div><div><div class="linea"></div><div class="label">Recepción · '+esc(exp.autoridad_destinataria)+'</div></div></div>';
+}
+
+function renderPunto(o){
+  const archs = o.archivos||[];
+  const tieneArch = archs.length > 0;
+  const tareas = (o.tareas||[]).filter(t=>t.estado!=='cancelado');
+  const bit = o.bitacora||[];
+
+  return ''
+    + '<div class="punto" id="punto-'+o.id+'">'
+    + '  <div class="head">'
+    + '    <h3>'+o.orden+'. '+esc(o.titulo||'(sin título)')+'</h3>'
+    + '    <div class="meta">Estado: <strong>'+esc(o.estado)+'</strong>'
+    +        '<br>Plazo: '+fmtDia(o.fecha_verificacion)
+    +        '<br>Responsable: '+esc(o.responsable||'—')
+    +        '<br><span class="estado-respaldo '+(tieneArch?'ok':'falta')+'">'+(tieneArch?'✓ con respaldo':'⚠ falta respaldo')+'</span>'
+    +     '</div>'
+    + '  </div>'
+    + '  <div class="descripcion">'+esc(o.contenido||'')+'</div>'
+    + '  <div class="archivo-box '+(tieneArch?'con-archivo':'')+'">'
+    +     (tieneArch
+            ? archs.map(ar => '📎 '+esc(ar.filename||'archivo')+(ar.storage_path?' · <a class="pdf-link" href="#" onclick="abrir(\''+esc(ar.storage_path)+'\',\''+esc(ar.bucket||'impulsa-documentos')+'\');return false">Ver</a>':'')).join('<br>')
+            : 'Falta cargar respaldo digital. Ver tareas y gestiones abajo.'
+          )
+    + '  </div>'
+    +    (tareas.length ? '<div class="tareas"><strong>📋 Tareas planificadas:</strong><ul>'
+                        + tareas.map(t=>'<li>'+esc(t.descripcion)+' · <em>'+esc(t.responsable_nombre||t.responsable_email)+'</em> · plazo '+fmtDia(t.fecha_meta)+' · <strong>'+esc(t.estado)+'</strong></li>').join('')
+                        + '</ul></div>' : '')
+    + '  <div class="bitacora">'
+    + '    <div class="bit-head"><span>💬 Bitácora de gestiones · esfuerzo del equipo</span><span class="count">'+bit.length+'</span></div>'
+    +      (bit.length
+              ? '<ul class="bit-list">'+bit.map(b => renderBit(b)).join('')+'</ul>'
+              : '<div class="bit-vacia">Sin gestiones registradas. Tocá "Agregar gestión" para sumar tu primer WhatsApp/correo.</div>'
+            )
+    + '    <button class="btn-agregar" onclick="abrirModal('+o.id+',\''+esc(o.titulo||'').replace(/\'/g,"\\'")+'\')">➕ Agregar gestión</button>'
+    + '  </div>'
+    + '</div>';
+}
+
+function renderBit(b){
+  let adj = '';
+  if (b.archivo_path) {
+    const isImg = (b.archivo_mime||'').startsWith('image/');
+    if (isImg) {
+      adj = '<div class="bit-adjunto"><img src="" data-path="'+esc(b.archivo_path)+'" data-bucket="'+esc(b.archivo_bucket||'impulsa-documentos')+'" onclick="abrir(this.dataset.path,this.dataset.bucket)" alt="adjunto" onload="this.style.opacity=1"></div>';
+    } else {
+      adj = '<div class="bit-adjunto"><a class="pdf-link" href="#" onclick="abrir(\''+esc(b.archivo_path)+'\',\''+esc(b.archivo_bucket||'impulsa-documentos')+'\');return false">📎 '+esc(b.archivo_nombre||'adjunto')+'</a></div>';
+    }
+  }
+  return '<li class="bit-item">'
+    + '<span class="bit-tipo '+esc(b.tipo)+'">'+esc(b.tipo)+'</span>'
+    + '<strong>'+esc(b.actor_nombre||b.actor_email||'—')+'</strong>'
+    + (b.destinatario_nombre||b.destinatario_email ? ' → '+esc(b.destinatario_nombre||b.destinatario_email) : '')
+    + '<div class="bit-meta">'+fmtFecha(b.ocurrida_en)+'</div>'
+    + '<div class="bit-texto">'+esc(b.texto)+'</div>'
+    + adj
+    + '</li>';
+}
+
+function irA(id){
+  const el = document.getElementById('punto-'+id);
+  if(!el) return;
+  document.querySelectorAll('.punto[data-active="1"]').forEach(p=>p.removeAttribute('data-active'));
+  el.setAttribute('data-active','1');
+  el.scrollIntoView({behavior:'smooth',block:'start'});
 }
 
 async function abrir(path,bucket){
@@ -176,7 +333,101 @@ async function abrir(path,bucket){
   }catch(e){alert('No se pudo abrir: '+(e.message||e));}
 }
 window.abrir = abrir;
-cargar();
+window.irA = irA;
+
+// Cargar previews imágenes
+async function cargarPreviewsImagenes(){
+  const imgs = document.querySelectorAll('.bit-adjunto img[data-path]');
+  for (const img of imgs) {
+    try{
+      const s = await sb.storage.from(img.dataset.bucket).createSignedUrl(img.dataset.path,300);
+      if(!s.error) img.src = s.data.signedUrl;
+    }catch(_){}
+  }
+}
+
+function abrirModal(oblId, titulo){
+  document.getElementById('g_obligacion_id').value = oblId;
+  document.getElementById('g_punto_titulo').textContent = 'Punto: '+titulo;
+  document.getElementById('g_tipo').value = 'whatsapp';
+  document.getElementById('g_cuando').value = new Date().toISOString().slice(0,16);
+  document.getElementById('g_actor_email').value = localStorage.getItem('g_last_actor_email') || '';
+  document.getElementById('g_actor_nombre').value = localStorage.getItem('g_last_actor_nombre') || '';
+  document.getElementById('g_destinatario').value = '';
+  document.getElementById('g_texto').value = '';
+  document.getElementById('g_archivo').value = '';
+  document.getElementById('g_archivo_info').textContent = '';
+  document.getElementById('modalGestion').classList.add('open');
+}
+function cerrarModal(){document.getElementById('modalGestion').classList.remove('open');}
+window.abrirModal = abrirModal;
+window.cerrarModal = cerrarModal;
+
+document.getElementById('g_archivo').addEventListener('change', function(){
+  const f = this.files[0];
+  document.getElementById('g_archivo_info').textContent = f ? f.name+' · '+(f.size/1024).toFixed(1)+' KB' : '';
+});
+
+async function guardarGestion(){
+  const btn = document.getElementById('g_guardar');
+  btn.disabled = true; btn.textContent = 'Guardando...';
+  try{
+    const oblId = parseInt(document.getElementById('g_obligacion_id').value);
+    const tipo = document.getElementById('g_tipo').value;
+    const cuando = document.getElementById('g_cuando').value;
+    const actor_email = document.getElementById('g_actor_email').value.trim();
+    const actor_nombre = document.getElementById('g_actor_nombre').value.trim();
+    const destinatario = document.getElementById('g_destinatario').value.trim();
+    const texto = document.getElementById('g_texto').value.trim();
+    const file = document.getElementById('g_archivo').files[0];
+
+    if (!actor_email) throw new Error('Falta email del actor');
+    if (!texto) throw new Error('Falta descripción');
+
+    localStorage.setItem('g_last_actor_email', actor_email);
+    localStorage.setItem('g_last_actor_nombre', actor_nombre);
+
+    let archivo_path = null, archivo_nombre = null, archivo_mime = null, archivo_size = null;
+    if (file) {
+      const path = 'expediente/'+oblId+'/'+Date.now()+'_'+file.name.replace(/[^\w.\-]/g,'_');
+      const up = await sb.storage.from('impulsa-documentos').upload(path, file, {upsert:false});
+      if (up.error) throw new Error('Storage: '+up.error.message);
+      archivo_path = path;
+      archivo_nombre = file.name;
+      archivo_mime = file.type;
+      archivo_size = file.size;
+    }
+
+    const {data,error} = await sb.schema('panel').rpc('bitacora_registrar', {
+      p_obligacion_id: oblId,
+      p_tipo: tipo,
+      p_texto: texto,
+      p_actor_email: actor_email,
+      p_actor_nombre: actor_nombre || null,
+      p_destinatario_email: destinatario.includes('@') ? destinatario : null,
+      p_destinatario_nombre: !destinatario.includes('@') ? (destinatario||null) : null,
+      p_archivo_path: archivo_path,
+      p_archivo_nombre: archivo_nombre,
+      p_archivo_mime: archivo_mime,
+      p_archivo_size: archivo_size,
+      p_archivo_bucket: 'impulsa-documentos',
+      p_ocurrida_en: cuando ? new Date(cuando).toISOString() : null
+    });
+    if (error) throw error;
+
+    cerrarModal();
+    await cargar();
+    setTimeout(cargarPreviewsImagenes, 100);
+    irA(oblId);
+  }catch(e){
+    alert('Error: '+(e.message||e));
+  }finally{
+    btn.disabled = false; btn.textContent = 'Guardar gestión';
+  }
+}
+window.guardarGestion = guardarGestion;
+
+cargar().then(()=>setTimeout(cargarPreviewsImagenes, 200));
 </script>
 </body>
 </html>

--- a/public/expedientes/expediente.html
+++ b/public/expedientes/expediente.html
@@ -78,7 +78,7 @@ body{font-family:'Inter',sans-serif;margin:0;background:#f3f4f6;color:var(--text
 </div>
 <script>
 const SUPABASE_URL = 'https://eknmtsrtfkzroxnovfqn.supabase.co';
-const SUPABASE_ANON = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImVrbm10c3J0Zmt6cm94bm92ZnFuIiwicm9sZSI6ImFub24iLCJpYXQiOjE3MTU3NDc3MjAsImV4cCI6MjAzMTMyMzcyMH0.fpQB3iL_F8KOzwXP9wAm-Cy6yTpz8KfYa6XGCq0t-MQ';
+const SUPABASE_ANON = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImVrbm10c3J0Zmt6cm94bm92ZnFuIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzU0MDY2ODgsImV4cCI6MjA5MDk4MjY4OH0.8Y4N0lw3DFN3Y8-R6ID7t_LAfgHWDM5N-oa4Ji9bncg';
 const sb = supabase.createClient(SUPABASE_URL, SUPABASE_ANON);
 const params = new URLSearchParams(location.search);
 const codigo = params.get('codigo') || 'EXP-TALCA-PATENTE-DEFINITIVA';
@@ -104,7 +104,7 @@ async function cargar(){
 
     let archivosTotal = {};
     try{
-      const {data:archivos} = await sb.schema('panel').from('cumplim_archivos').select('*').in('obligacion_id',exp.obligaciones_ids);
+      const {data:archivos} = await sb.schema('panel').from('cumplimiento_archivos').select('*').in('obligacion_id',exp.obligaciones_ids);
       (archivos||[]).forEach(a=>{(archivosTotal[a.obligacion_id]=archivosTotal[a.obligacion_id]||[]).push(a)});
     }catch(_){}
 

--- a/public/expedientes/expediente.html
+++ b/public/expedientes/expediente.html
@@ -180,6 +180,15 @@ const params = new URLSearchParams(location.search);
 const codigo = params.get('codigo') || 'EXP-TALCA-PATENTE-DEFINITIVA';
 
 let _data = null;
+let _isAuth = false;
+
+async function checkAuth(){
+  try {
+    const s = await sb.auth.getSession();
+    _isAuth = !!(s && s.data && s.data.session && s.data.session.user);
+  } catch(_) { _isAuth = false; }
+  return _isAuth;
+}
 
 function esc(s){return String(s==null?'':s).replace(/[&<>"']/g,c=>({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;"}[c]));}
 function fmtFecha(d){if(!d)return '—';try{return new Date(d).toLocaleString('es-CL',{day:'2-digit',month:'short',hour:'2-digit',minute:'2-digit'});}catch(_){return String(d);}}
@@ -292,7 +301,9 @@ function renderPunto(o){
               ? '<ul class="bit-list">'+bit.map(b => renderBit(b)).join('')+'</ul>'
               : '<div class="bit-vacia">Sin gestiones registradas. Tocá "Agregar gestión" para sumar tu primer WhatsApp/correo.</div>'
             )
-    + '    <button class="btn-agregar" onclick="abrirModal('+o.id+',\''+esc(o.titulo||'').replace(/\'/g,"\\'")+'\')">➕ Agregar gestión</button>'
+    + (_isAuth
+        ? '    <button class="btn-agregar" onclick="abrirModal('+o.id+',\''+esc(o.titulo||'').replace(/\'/g,"\\'")+'\')">➕ Agregar gestión</button>'
+        : '    <div style="padding:10px 14px;background:#fef3c7;color:#92400e;font-size:11px;border-top:1px solid var(--border)">🔒 Iniciá sesión en <a href="/panel-rdo.html" style="color:#92400e;font-weight:700">/panel-rdo.html</a> para agregar gestiones y subir adjuntos.</div>')
     + '  </div>'
     + '</div>';
 }
@@ -427,7 +438,7 @@ async function guardarGestion(){
 }
 window.guardarGestion = guardarGestion;
 
-cargar().then(()=>setTimeout(cargarPreviewsImagenes, 200));
+checkAuth().then(cargar).then(()=>setTimeout(cargarPreviewsImagenes, 200));
 </script>
 </body>
 </html>

--- a/public/expedientes/expediente.html
+++ b/public/expedientes/expediente.html
@@ -1,0 +1,182 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Expediente · Reciclean-Farex</title>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+<style>
+:root{--primary:#059669;--dark:#064e3b;--text:#111827;--muted:#6b7280;--border:#e5e7eb;--cream:#fef3c7;--amber:#d97706}
+*{box-sizing:border-box}
+body{font-family:'Inter',sans-serif;margin:0;background:#f3f4f6;color:var(--text);line-height:1.55}
+.page{max-width:840px;margin:0 auto;background:#fff;box-shadow:0 0 24px rgba(0,0,0,.08);min-height:100vh}
+.toolbar{position:sticky;top:0;background:#111827;color:#fff;padding:12px 24px;display:flex;justify-content:space-between;align-items:center;z-index:10;flex-wrap:wrap;gap:12px}
+.toolbar .info{font-size:13px;display:flex;gap:16px;flex-wrap:wrap;align-items:center}
+.toolbar .info strong{color:#86efac}
+.toolbar button{background:#059669;color:#fff;border:none;padding:8px 16px;border-radius:6px;font-weight:700;cursor:pointer;font-size:14px}
+.toolbar button:hover{background:#047857}
+.toolbar button.secondary{background:transparent;border:1px solid #4b5563}
+.body{padding:48px 56px}
+.loading{padding:80px;text-align:center;color:var(--muted)}
+.cover{text-align:center;padding:60px 24px;border-bottom:3px solid var(--dark);page-break-after:always}
+.cover h1{font-size:28px;color:var(--dark);margin:0 0 8px;letter-spacing:-.5px}
+.cover p{margin:6px 0;font-size:14px;color:#374151}
+.cover .badge{display:inline-block;background:var(--cream);border:1px solid var(--amber);color:#92400e;padding:4px 12px;border-radius:6px;font-size:12px;font-weight:700;margin-top:16px}
+.section{padding:36px 0;border-bottom:1px solid var(--border)}
+.section h2{font-size:20px;color:var(--dark);margin:0 0 16px;font-weight:800}
+.section p{margin:0 0 10px;font-size:14px}
+.toc{background:#f9fafb;border:1px solid var(--border);border-radius:8px;padding:20px;margin:24px 0}
+.toc h3{margin:0 0 12px;font-size:15px;color:var(--dark)}
+.toc ol{margin:0;padding-left:24px;font-size:13px;line-height:1.9}
+.toc li.completo{color:#065f46;font-weight:600}
+.toc li.falta{color:#b45309}
+.punto{padding:32px 0;page-break-before:always;border-top:2px solid var(--dark)}
+.punto .head{display:flex;justify-content:space-between;align-items:flex-start;gap:16px;margin-bottom:16px}
+.punto h3{font-size:17px;color:var(--dark);margin:0;flex:1}
+.punto .meta{font-size:11px;color:var(--muted);text-align:right;line-height:1.7}
+.punto .estado-respaldo{display:inline-block;padding:3px 10px;border-radius:4px;font-size:11px;font-weight:700;margin-top:4px}
+.punto .estado-respaldo.ok{background:#d1fae5;color:#065f46}
+.punto .estado-respaldo.falta{background:#fef3c7;color:#92400e}
+.punto .descripcion{font-size:13px;color:#374151;margin:8px 0 16px}
+.punto .archivo-box{border:2px dashed var(--border);border-radius:8px;padding:24px;text-align:center;color:var(--muted);font-size:13px;background:#f9fafb}
+.punto .archivo-box.con-archivo{background:#ecfdf5;border-color:#10b981;color:#065f46}
+.punto img{max-width:100%;border:1px solid var(--border);border-radius:6px;margin-top:12px}
+.punto .pdf-link{display:inline-block;background:#dbeafe;color:#1e40af;padding:8px 16px;border-radius:6px;text-decoration:none;font-size:13px;font-weight:600;margin-top:8px}
+.tareas{background:#fef3c7;border-left:4px solid var(--amber);padding:12px 16px;margin-top:12px;border-radius:4px;font-size:12px}
+.tareas strong{color:#92400e;display:block;margin-bottom:4px}
+.tareas ul{margin:0;padding-left:20px}
+.firma{margin-top:60px;padding-top:40px;border-top:1px solid var(--border);display:grid;grid-template-columns:1fr 1fr;gap:60px;page-break-inside:avoid}
+.firma .linea{border-bottom:1px solid var(--text);height:50px}
+.firma .label{font-size:12px;color:var(--muted);margin-top:6px;text-align:center}
+@media print{
+  .toolbar{display:none}
+  body{background:#fff}
+  .page{box-shadow:none;max-width:none}
+  .body{padding:24px 32px}
+  .punto{page-break-before:always}
+  .cover{page-break-after:always}
+}
+</style>
+</head>
+<body>
+<div class="page">
+  <div class="toolbar">
+    <div class="info">
+      <span>📋 Expediente: <strong id="t-codigo">cargando...</strong></span>
+      <span>Estado: <strong id="t-estado">—</strong></span>
+      <span>Respaldos: <strong id="t-respaldos">—</strong></span>
+    </div>
+    <div>
+      <button class="secondary" onclick="window.location.href='/panel-rdo.html'">← Volver al panel</button>
+      <button onclick="window.print()">🖨️ Imprimir todo</button>
+    </div>
+  </div>
+  <div class="body" id="contenido">
+    <div class="loading">Cargando expediente...</div>
+  </div>
+</div>
+<script>
+const SUPABASE_URL = 'https://eknmtsrtfkzroxnovfqn.supabase.co';
+const SUPABASE_ANON = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImVrbm10c3J0Zmt6cm94bm92ZnFuIiwicm9sZSI6ImFub24iLCJpYXQiOjE3MTU3NDc3MjAsImV4cCI6MjAzMTMyMzcyMH0.fpQB3iL_F8KOzwXP9wAm-Cy6yTpz8KfYa6XGCq0t-MQ';
+const sb = supabase.createClient(SUPABASE_URL, SUPABASE_ANON);
+const params = new URLSearchParams(location.search);
+const codigo = params.get('codigo') || 'EXP-TALCA-PATENTE-DEFINITIVA';
+
+function esc(s){return String(s==null?'':s).replace(/[&<>"']/g,c=>({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;"}[c]));}
+
+async function cargar(){
+  try{
+    const {data:exp,error:e1} = await sb.schema('panel').from('expedientes').select('*').eq('codigo',codigo).single();
+    if(e1) throw e1;
+    if(!exp){document.getElementById('contenido').innerHTML='<div class="loading">Expediente no encontrado: '+esc(codigo)+'</div>';return;}
+
+    const {data:obls,error:e2} = await sb.schema('panel').from('cumplimiento_legal').select('*').in('id',exp.obligaciones_ids);
+    if(e2) throw e2;
+
+    const oblsOrdenadas = exp.obligaciones_ids.map(id => obls.find(o => o.id === id)).filter(Boolean);
+
+    const {data:articulos} = await sb.schema('panel').from('articulos_ley').select('id,titulo,contenido').in('id',exp.obligaciones_ids);
+    const mapArt = {};(articulos||[]).forEach(a=>mapArt[a.id]=a);
+
+    const {data:tareas} = await sb.schema('panel').from('cumplim_evidencia_tareas').select('*').in('obligacion_id',exp.obligaciones_ids).neq('estado','cancelado');
+    const mapTareas = {};(tareas||[]).forEach(t=>{(mapTareas[t.obligacion_id]=mapTareas[t.obligacion_id]||[]).push(t)});
+
+    let archivosTotal = {};
+    try{
+      const {data:archivos} = await sb.schema('panel').from('cumplim_archivos').select('*').in('obligacion_id',exp.obligaciones_ids);
+      (archivos||[]).forEach(a=>{(archivosTotal[a.obligacion_id]=archivosTotal[a.obligacion_id]||[]).push(a)});
+    }catch(_){}
+
+    const conRespaldo = oblsOrdenadas.filter(o => (archivosTotal[o.id]||[]).length > 0).length;
+
+    document.getElementById('t-codigo').textContent = exp.codigo;
+    document.getElementById('t-estado').textContent = exp.estado;
+    document.getElementById('t-respaldos').textContent = conRespaldo + '/' + oblsOrdenadas.length;
+
+    const toc = oblsOrdenadas.map((o,i) => {
+      const a = mapArt[o.articulo_id] || {titulo:'(sin título)'};
+      const tieneArch = (archivosTotal[o.id]||[]).length > 0;
+      return '<li class="'+(tieneArch?'completo':'falta')+'">'+esc(a.titulo)+(tieneArch?' ✓':' · falta respaldo')+'</li>';
+    }).join('');
+
+    const puntos = oblsOrdenadas.map((o,i) => {
+      const a = mapArt[o.articulo_id] || {titulo:'(sin título)',contenido:''};
+      const archs = archivosTotal[o.id]||[];
+      const ts = mapTareas[o.id]||[];
+      const tieneArch = archs.length > 0;
+      return ''
+        + '<div class="punto">'
+        + '  <div class="head">'
+        + '    <h3>'+(i+1)+'. '+esc(a.titulo)+'</h3>'
+        + '    <div class="meta">Estado: <strong>'+esc(o.estado)+'</strong>'
+        +        '<br>Plazo: '+esc(o.fecha_verificacion||'—')
+        +        '<br>Responsable: '+esc(o.responsable||'—')
+        +        '<br><span class="estado-respaldo '+(tieneArch?'ok':'falta')+'">'+(tieneArch?'✓ respaldo digital':'⚠ falta respaldo digital')+'</span>'
+        +     '</div>'
+        + '  </div>'
+        + '  <div class="descripcion">'+esc(a.contenido||'')+'</div>'
+        + '  <div class="archivo-box '+(tieneArch?'con-archivo':'')+'">'
+        +     (tieneArch
+              ? archs.map(ar => '📎 '+esc(ar.filename||'archivo')+' · '+esc(ar.mime_type||'')+(ar.storage_path?'<br><a class="pdf-link" href="#" onclick="abrir(\\''+esc(ar.storage_path)+'\\',\\''+esc(ar.bucket||'impulsa-documentos')+'\\');return false">Ver documento</a>':'')).join('<br>')
+              : 'Falta cargar el respaldo digital de este punto. Trabajo asignado a Jair (ver tareas abajo).'
+            )
+        + '  </div>'
+        +    (ts.length ? '<div class="tareas"><strong>📋 Tareas para completar este respaldo:</strong><ul>'
+                          + ts.map(t=>'<li>'+esc(t.descripcion)+' · <em>'+esc(t.responsable_nombre||t.responsable_email)+'</em> · plazo '+esc(t.fecha_meta||'sin fecha')+' · <strong>'+esc(t.estado)+'</strong></li>').join('')
+                          + '</ul></div>' : '')
+        + '</div>';
+    }).join('');
+
+    document.getElementById('contenido').innerHTML =
+        '<div class="cover">'
+      + '  <h1>'+esc(exp.titulo)+'</h1>'
+      + '  <p><strong>Destinatario:</strong> '+esc(exp.autoridad_destinataria)+'</p>'
+      + '  <p><strong>Solicitante:</strong> '+esc(exp.razon_social||'')+' · RUT '+esc(exp.rut_empresa||'')+'</p>'
+      + '  <p><strong>Sucursal:</strong> '+esc(exp.sucursal_id||'')+'</p>'
+      + '  <p><strong>Código expediente:</strong> '+esc(exp.codigo)+'</p>'
+      + '  <p style="margin-top:24px;font-size:12px;color:#6b7280">Fecha de impresión: '+new Date().toLocaleDateString('es-CL')+'</p>'
+      + '  <div class="badge">'+conRespaldo+' de '+oblsOrdenadas.length+' respaldos digitales cargados</div>'
+      + '</div>'
+      + (exp.cuerpo_html || '')
+      + '<div class="section"><h2>Índice de documentos adjuntos</h2><div class="toc"><ol>'+toc+'</ol></div></div>'
+      + puntos
+      + '<div class="firma"><div><div class="linea"></div><div class="label">Firma representante legal · Reciclean SpA</div></div><div><div class="linea"></div><div class="label">Recepción · I. Municipalidad de Maule</div></div></div>';
+
+  }catch(err){
+    document.getElementById('contenido').innerHTML = '<div class="loading" style="color:#dc2626">Error: '+esc(err.message||err)+'</div>';
+  }
+}
+
+async function abrir(path,bucket){
+  try{
+    const s = await sb.storage.from(bucket).createSignedUrl(path,300);
+    if(s.error) throw s.error;
+    window.open(s.data.signedUrl,'_blank','noopener');
+  }catch(e){alert('No se pudo abrir: '+(e.message||e));}
+}
+window.abrir = abrir;
+cargar();
+</script>
+</body>
+</html>

--- a/public/expedientes/index.html
+++ b/public/expedientes/index.html
@@ -1,0 +1,222 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Expedientes · mesa de control general · Reciclean-Farex</title>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap" rel="stylesheet">
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+<style>
+:root{--primary:#059669;--dark:#064e3b;--text:#111827;--muted:#6b7280;--border:#e5e7eb;--cream:#fef3c7;--amber:#d97706;--red:#dc2626;--blue:#2563eb;--bg:#f3f4f6}
+*{box-sizing:border-box}
+body{font-family:'Inter',sans-serif;margin:0;background:var(--bg);color:var(--text);line-height:1.5}
+.toolbar{position:sticky;top:0;background:#111827;color:#fff;padding:14px 24px;display:flex;justify-content:space-between;align-items:center;z-index:10;flex-wrap:wrap;gap:12px;box-shadow:0 2px 10px rgba(0,0,0,.1)}
+.toolbar h1{margin:0;font-size:16px;font-weight:800;letter-spacing:-.02em}
+.toolbar .info{font-size:13px;color:#9ca3af}
+.toolbar button{background:#059669;color:#fff;border:none;padding:8px 14px;border-radius:6px;font-weight:600;cursor:pointer;font-size:13px}
+.toolbar button.secondary{background:transparent;border:1px solid #4b5563}
+.container{max-width:1240px;margin:0 auto;padding:24px}
+.intro{background:#fff;border-radius:12px;padding:20px 24px;margin-bottom:20px;border:1px solid var(--border)}
+.intro h2{margin:0 0 6px;color:var(--dark);font-size:18px}
+.intro p{margin:0;color:var(--muted);font-size:13px}
+.kpis{display:grid;grid-template-columns:repeat(5,1fr);gap:12px;margin-bottom:24px}
+.kpi{background:#fff;border:1px solid var(--border);border-radius:10px;padding:16px;text-align:center}
+.kpi .n{font-size:28px;font-weight:900;color:var(--dark);letter-spacing:-.03em;line-height:1}
+.kpi .lbl{font-size:11px;color:var(--muted);text-transform:uppercase;letter-spacing:.06em;margin-top:6px}
+.kpi.alerta .n{color:var(--amber)}
+.kpi.rojo .n{color:var(--red)}
+.kpi.ok .n{color:#10b981}
+.matriz-wrap{background:#fff;border:1px solid var(--border);border-radius:12px;overflow:hidden;margin-bottom:24px}
+.matriz-wrap h3{margin:0;padding:16px 20px;background:#f9fafb;border-bottom:1px solid var(--border);font-size:14px;color:var(--dark);font-weight:700}
+table{width:100%;border-collapse:collapse;font-size:13px}
+th{text-align:left;padding:12px;background:#f9fafb;border-bottom:1px solid var(--border);font-size:11px;color:var(--muted);font-weight:700;text-transform:uppercase;letter-spacing:.05em;position:sticky;top:64px}
+td{padding:12px;border-bottom:1px solid var(--border);vertical-align:middle}
+tr:hover{background:#fefce8;cursor:pointer}
+.codigo{font-family:ui-monospace,SFMono-Regular,monospace;font-size:11px;color:var(--muted)}
+.suc{font-weight:700;color:var(--dark)}
+.tipo{display:inline-block;background:#e0e7ff;color:#3730a3;padding:3px 8px;border-radius:4px;font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.04em}
+.pill{display:inline-block;padding:2px 8px;border-radius:10px;font-size:11px;font-weight:700}
+.pill.ok{background:#d1fae5;color:#065f46}
+.pill.alerta{background:#fef3c7;color:#92400e}
+.pill.rojo{background:#fee2e2;color:#991b1b}
+.pill.muted{background:#e5e7eb;color:#6b7280}
+.progressbar{display:flex;align-items:center;gap:8px}
+.bar{width:80px;height:8px;background:#e5e7eb;border-radius:4px;overflow:hidden}
+.bar > div{height:100%;background:#10b981;transition:width .3s}
+.bar.amarillo > div{background:#f59e0b}
+.bar.rojo > div{background:#ef4444}
+.dot{display:inline-block;width:10px;height:10px;border-radius:50%;margin-right:6px;vertical-align:middle}
+.dot.verde{background:#10b981}.dot.amarillo{background:#f59e0b}.dot.rojo{background:#ef4444}.dot.azul{background:#3b82f6}.dot.muted{background:#d1d5db}
+.muted{color:var(--muted);font-style:italic}
+.action{text-align:right}
+.action a{display:inline-block;background:var(--primary);color:#fff;padding:5px 12px;border-radius:5px;text-decoration:none;font-size:12px;font-weight:600}
+.action a:hover{background:#047857}
+.loading{padding:60px;text-align:center;color:var(--muted)}
+.error{padding:40px;color:var(--red);background:#fee2e2;border-radius:8px;font-family:monospace;font-size:13px}
+.filtros{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:16px;background:#fff;padding:12px;border-radius:8px;border:1px solid var(--border)}
+.filtros button{background:#fff;border:1px solid var(--border);color:#374151;padding:6px 12px;border-radius:6px;font-size:12px;cursor:pointer;font-weight:600}
+.filtros button.active{background:var(--dark);color:#fff;border-color:var(--dark)}
+.filtros span{font-size:12px;color:var(--muted);align-self:center;margin-right:6px;font-weight:600}
+@media (max-width:768px){.kpis{grid-template-columns:repeat(2,1fr)}.toolbar{padding:10px 14px}.container{padding:14px}th,td{padding:8px}}
+</style>
+</head>
+<body>
+<div class="toolbar">
+  <div>
+    <h1>📂 Expedientes · mesa de control general</h1>
+    <div class="info">4 sucursales × 5 tipos de trámite</div>
+  </div>
+  <div>
+    <button class="secondary" onclick="window.location.href='/panel-rdo.html'">← Panel</button>
+    <button onclick="cargar()">🔄 Refrescar</button>
+  </div>
+</div>
+
+<div class="container">
+  <div class="intro">
+    <h2>Vista global de permisología</h2>
+    <p>Cada fila es un expediente (sucursal + tipo de trámite). Click para abrir su mesa de control detallada · agregar gestiones · imprimir el expediente completo para presentar a la autoridad.</p>
+  </div>
+
+  <div class="kpis" id="kpis">
+    <div class="kpi"><div class="n" id="k-total">—</div><div class="lbl">Expedientes</div></div>
+    <div class="kpi ok"><div class="n" id="k-conobls">—</div><div class="lbl">Con docs cargados</div></div>
+    <div class="kpi alerta"><div class="n" id="k-vacios">—</div><div class="lbl">Sin docs · falta info</div></div>
+    <div class="kpi rojo"><div class="n" id="k-vencidos">—</div><div class="lbl">Plazos &lt; 14 días</div></div>
+    <div class="kpi"><div class="n" id="k-gestiones">—</div><div class="lbl">Gestiones registradas</div></div>
+  </div>
+
+  <div class="filtros">
+    <span>Sucursal:</span>
+    <button data-suc="" class="active" onclick="filtrar('suc',this)">Todas</button>
+    <button data-suc="cerrillos" onclick="filtrar('suc',this)">Cerrillos</button>
+    <button data-suc="maipu" onclick="filtrar('suc',this)">Maipú</button>
+    <button data-suc="talca" onclick="filtrar('suc',this)">Talca</button>
+    <button data-suc="puerto_montt" onclick="filtrar('suc',this)">Puerto Montt</button>
+  </div>
+  <div class="filtros">
+    <span>Tipo:</span>
+    <button data-tip="" class="active" onclick="filtrar('tip',this)">Todos</button>
+    <button data-tip="calificacion_tecnica" onclick="filtrar('tip',this)">Calificación Técnica</button>
+    <button data-tip="patente_provisoria" onclick="filtrar('tip',this)">Patente Provisoria</button>
+    <button data-tip="patente_definitiva" onclick="filtrar('tip',this)">Patente Definitiva</button>
+    <button data-tip="resolucion_sanitaria" onclick="filtrar('tip',this)">Resolución Sanitaria</button>
+    <button data-tip="resolucion_transporte_rnp" onclick="filtrar('tip',this)">Transporte RNP</button>
+  </div>
+
+  <div class="matriz-wrap">
+    <h3>Matriz · 20 expedientes</h3>
+    <div id="tabla"><div class="loading">Cargando expedientes...</div></div>
+  </div>
+</div>
+
+<script>
+const SUPABASE_URL = 'https://eknmtsrtfkzroxnovfqn.supabase.co';
+const SUPABASE_ANON = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImVrbm10c3J0Zmt6cm94bm92ZnFuIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzU0MDY2ODgsImV4cCI6MjA5MDk4MjY4OH0.8Y4N0lw3DFN3Y8-R6ID7t_LAfgHWDM5N-oa4Ji9bncg';
+const sb = supabase.createClient(SUPABASE_URL, SUPABASE_ANON);
+
+const SUC = {cerrillos:'Cerrillos', maipu:'Maipú', talca:'Talca (Maule)', puerto_montt:'Puerto Montt'};
+const TIP = {calificacion_tecnica:'Calif. Técnica', patente_provisoria:'Pat. Provisoria', patente_definitiva:'Pat. Definitiva', resolucion_sanitaria:'Res. Sanitaria', resolucion_transporte_rnp:'Transporte RNP'};
+
+let _data = [];
+let _filtros = {suc:'', tip:''};
+
+function esc(s){return String(s==null?'':s).replace(/[&<>"']/g,c=>({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;"}[c]));}
+function fmtDia(d){if(!d)return '—';try{return new Date(d).toLocaleDateString('es-CL');}catch(_){return String(d);}}
+
+function diasAPlazo(d){if(!d)return null;const ms=new Date(d).getTime()-Date.now();return Math.floor(ms/86400000);}
+
+function semaforoFila(e){
+  if (e.sucursal_id === 'puerto_montt') return 'muted';
+  if (e.n_obls === 0) return 'rojo';
+  const pct = e.n_obls > 0 ? e.n_archivos / e.n_obls : 0;
+  const dias = diasAPlazo(e.plazo_mas_urgente);
+  if (pct >= 1) return 'verde';
+  if (dias !== null && dias <= 14) return 'rojo';
+  if (pct > 0) return 'amarillo';
+  return 'azul';
+}
+
+async function cargar(){
+  document.getElementById('tabla').innerHTML = '<div class="loading">Cargando...</div>';
+  try{
+    const {data,error} = await sb.schema('panel').rpc('expedientes_listar');
+    if(error) throw error;
+    _data = data || [];
+    renderKpis();
+    renderTabla();
+  }catch(err){
+    document.getElementById('tabla').innerHTML = '<div class="error">Error: '+esc(err.message||JSON.stringify(err))+'</div>';
+  }
+}
+
+function renderKpis(){
+  const total = _data.length;
+  const conobls = _data.filter(e => e.n_obls > 0).length;
+  const vacios = total - conobls;
+  const vencidos = _data.filter(e => {
+    const d = diasAPlazo(e.plazo_mas_urgente);
+    return d !== null && d <= 14;
+  }).length;
+  const gestiones = _data.reduce((s,e)=>s+(e.n_gestiones||0), 0);
+  document.getElementById('k-total').textContent = total;
+  document.getElementById('k-conobls').textContent = conobls;
+  document.getElementById('k-vacios').textContent = vacios;
+  document.getElementById('k-vencidos').textContent = vencidos;
+  document.getElementById('k-gestiones').textContent = gestiones;
+}
+
+function renderTabla(){
+  let rows = _data;
+  if (_filtros.suc) rows = rows.filter(e => e.sucursal_id === _filtros.suc);
+  if (_filtros.tip) rows = rows.filter(e => e.tipo_tramite === _filtros.tip);
+
+  if (!rows.length){
+    document.getElementById('tabla').innerHTML = '<div class="loading">No hay expedientes con esos filtros.</div>';
+    return;
+  }
+
+  const tbody = rows.map(e => {
+    const color = semaforoFila(e);
+    const pct = e.n_obls > 0 ? Math.round((e.n_archivos / e.n_obls) * 100) : 0;
+    const dias = diasAPlazo(e.plazo_mas_urgente);
+    const barCls = pct >= 60 ? '' : (pct > 0 ? 'amarillo' : 'rojo');
+    const plazoTxt = e.plazo_mas_urgente
+      ? fmtDia(e.plazo_mas_urgente) + ' (' + (dias>=0?dias+'d':'vencido')+')'
+      : '—';
+    const plazoPill = dias===null ? '' : (dias<=14 ? 'pill rojo' : (dias<=30 ? 'pill alerta' : 'pill ok'));
+    const link = '/expedientes/expediente.html?codigo='+encodeURIComponent(e.codigo);
+    return '<tr onclick="window.location.href=\''+link+'\'">'
+      + '<td><span class="dot '+color+'"></span><span class="suc">'+esc(SUC[e.sucursal_id]||e.sucursal_id)+'</span><div class="codigo">'+esc(e.codigo)+'</div></td>'
+      + '<td><span class="tipo">'+esc(TIP[e.tipo_tramite]||e.tipo_tramite)+'</span></td>'
+      + '<td>'+(e.n_obls>0
+            ? '<div class="progressbar"><div class="bar '+barCls+'"><div style="width:'+pct+'%"></div></div><span>'+e.n_archivos+'/'+e.n_obls+'</span></div>'
+            : '<span class="pill muted">sin docs</span>')+'</td>'
+      + '<td>'+(e.n_tareas_pend>0 ? '<span class="pill alerta">'+e.n_tareas_pend+' pend</span>' : '<span class="muted">—</span>')+'</td>'
+      + '<td>'+(e.n_gestiones>0 ? '<span class="pill ok">💬 '+e.n_gestiones+'</span>' : '<span class="muted">—</span>')+'</td>'
+      + '<td>'+(plazoPill ? '<span class="'+plazoPill+'">'+plazoTxt+'</span>' : '<span class="muted">'+plazoTxt+'</span>')+'</td>'
+      + '<td class="action"><a href="'+link+'" onclick="event.stopPropagation()">Abrir →</a></td>'
+      + '</tr>';
+  }).join('');
+
+  document.getElementById('tabla').innerHTML =
+      '<table>'
+    + '<thead><tr><th>Sucursal · código</th><th>Trámite</th><th>Respaldos</th><th>Tareas</th><th>Gestiones</th><th>Plazo más urgente</th><th></th></tr></thead>'
+    + '<tbody>'+tbody+'</tbody>'
+    + '</table>';
+}
+
+function filtrar(grupo, btn){
+  const val = btn.dataset[grupo];
+  _filtros[grupo] = val;
+  document.querySelectorAll('.filtros button[data-'+grupo+']').forEach(b => b.classList.remove('active'));
+  btn.classList.add('active');
+  renderTabla();
+}
+window.filtrar = filtrar;
+window.cargar = cargar;
+
+cargar();
+</script>
+</body>
+</html>

--- a/public/mi-cola.html
+++ b/public/mi-cola.html
@@ -1,0 +1,260 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Mi cola · Jair · Reciclean-Farex</title>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap" rel="stylesheet">
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+<style>
+:root{--primary:#059669;--dark:#064e3b;--bg:#f3f4f6;--text:#111827;--muted:#6b7280;--border:#e5e7eb;--amber:#d97706;--red:#dc2626;--blue:#2563eb}
+*{box-sizing:border-box}
+body{font-family:'Inter',sans-serif;margin:0;background:var(--bg);color:var(--text);line-height:1.5}
+.hero{background:linear-gradient(135deg,var(--primary),var(--dark));color:#fff;padding:24px 20px;text-align:center}
+.hero h1{margin:0 0 6px;font-size:22px;font-weight:900;letter-spacing:-.02em}
+.hero p{margin:0;opacity:.95;font-size:13px}
+.hero .kpis{display:flex;gap:10px;justify-content:center;margin-top:14px;flex-wrap:wrap}
+.hero .kpi{background:rgba(255,255,255,.15);padding:8px 14px;border-radius:20px;font-size:12px;font-weight:600}
+.hero .kpi strong{font-size:18px;display:block;line-height:1}
+.cont{max-width:720px;margin:0 auto;padding:20px 16px 80px}
+.loading{padding:60px;text-align:center;color:var(--muted)}
+.error{padding:16px;background:#fee2e2;color:#991b1b;border-radius:8px;margin:16px 0;font-size:13px}
+.empty{padding:40px;text-align:center;color:var(--muted);background:#fff;border-radius:12px;border:1px solid var(--border)}
+.empty .big{font-size:48px;margin-bottom:12px}
+
+.card{background:#fff;border-radius:16px;box-shadow:0 2px 12px rgba(0,0,0,.06);margin-bottom:16px;overflow:hidden;border:2px solid transparent;transition:border-color .2s}
+.card.priori-1{border-color:var(--red)}
+.card.priori-2{border-color:var(--amber)}
+.card .head{padding:14px 18px;display:flex;justify-content:space-between;align-items:flex-start;gap:10px}
+.card .num{font-size:11px;font-weight:700;color:var(--muted);text-transform:uppercase;letter-spacing:.06em}
+.card .badge-plazo{font-size:11px;font-weight:700;padding:4px 10px;border-radius:12px}
+.card .badge-plazo.vencida{background:#fee2e2;color:#991b1b}
+.card .badge-plazo.urgente{background:#fef3c7;color:#92400e}
+.card .badge-plazo.normal{background:#dcfce7;color:#065f46}
+.card h2{margin:4px 0 8px;font-size:17px;color:var(--dark);font-weight:800;line-height:1.3;padding:0 18px}
+.card .meta{padding:0 18px;font-size:12px;color:var(--muted);margin-bottom:10px;display:flex;gap:12px;flex-wrap:wrap}
+.card .meta strong{color:var(--text)}
+.card .descr{padding:0 18px;font-size:13px;color:#374151;margin-bottom:14px}
+.card .ultima-gestion{margin:10px 18px;padding:10px 12px;background:#fffbeb;border-left:3px solid var(--amber);border-radius:4px;font-size:12px;color:#92400e}
+.card .ultima-gestion strong{color:#78350f}
+.card .acciones{padding:14px 18px;background:#f9fafb;border-top:1px solid var(--border);display:grid;grid-template-columns:repeat(2,1fr);gap:8px}
+.btn{padding:14px;border-radius:10px;border:none;font-weight:700;cursor:pointer;font-size:14px;display:flex;align-items:center;justify-content:center;gap:6px;transition:transform .1s}
+.btn:active{transform:scale(0.97)}
+.btn.wa{background:#25d366;color:#fff}
+.btn.correo{background:#2563eb;color:#fff}
+.btn.llamada{background:#7c3aed;color:#fff}
+.btn.cumplido{background:var(--primary);color:#fff}
+.btn.traba{background:var(--red);color:#fff;grid-column:1/-1;margin-top:4px}
+
+.modal-bg{position:fixed;inset:0;background:rgba(0,0,0,.6);display:none;align-items:flex-end;justify-content:center;z-index:100}
+.modal-bg.open{display:flex}
+.modal{background:#fff;border-radius:16px 16px 0 0;max-width:520px;width:100%;padding:24px;max-height:85vh;overflow-y:auto;animation:slideUp .25s ease-out}
+@keyframes slideUp{from{transform:translateY(100%)}to{transform:translateY(0)}}
+.modal h3{margin:0 0 14px;color:var(--dark);font-size:17px}
+.modal .ctx{background:#f9fafb;border-radius:8px;padding:10px;font-size:12px;color:var(--muted);margin-bottom:14px}
+.modal label{display:block;font-size:12px;font-weight:600;color:#374151;margin:10px 0 4px}
+.modal textarea{width:100%;padding:12px;border:1px solid var(--border);border-radius:8px;font-size:14px;font-family:inherit;min-height:90px;resize:vertical}
+.modal input[type=file]{font-size:13px}
+.modal .acts{margin-top:18px;display:flex;gap:10px}
+.modal .acts button{flex:1;padding:14px;border-radius:8px;border:none;font-weight:700;font-size:14px;cursor:pointer}
+.modal .cancel{background:#e5e7eb;color:#374151}
+.modal .ok{background:var(--primary);color:#fff}
+
+.confetti{position:fixed;top:30%;left:50%;transform:translateX(-50%);background:#fff;padding:24px 32px;border-radius:16px;box-shadow:0 10px 40px rgba(0,0,0,.2);text-align:center;z-index:200;display:none;font-size:18px;font-weight:800;color:var(--dark)}
+.confetti.show{display:block;animation:pop .4s}
+@keyframes pop{from{transform:translateX(-50%) scale(.6);opacity:0}to{transform:translateX(-50%) scale(1);opacity:1}}
+
+.auth-warn{margin:12px;padding:14px;background:#fef3c7;color:#92400e;border-radius:8px;font-size:13px;text-align:center}
+.auth-warn a{color:#92400e;font-weight:700}
+
+@media (max-width:600px){.card h2{font-size:16px}.btn{padding:16px;font-size:15px}}
+</style>
+</head>
+<body>
+<div class="hero">
+  <h1>👋 Hola Jair</h1>
+  <p>Lo que más traba hoy · 1 cosa a la vez</p>
+  <div class="kpis">
+    <div class="kpi"><strong id="k-pend">—</strong>pendientes</div>
+    <div class="kpi"><strong id="k-venc">—</strong>vencidas</div>
+    <div class="kpi"><strong id="k-7d">—</strong>esta semana</div>
+  </div>
+</div>
+
+<div class="cont">
+  <div id="auth_warn" class="auth-warn" style="display:none">
+    🔒 Iniciá sesión en <a href="/panel-rdo.html">/panel-rdo.html</a> para que tus gestiones queden guardadas con tu nombre.
+  </div>
+  <div id="lista"><div class="loading">Cargando...</div></div>
+</div>
+
+<!-- Modal gestión rápida -->
+<div class="modal-bg" id="modal">
+  <div class="modal">
+    <h3 id="m_titulo">Registrar gestión</h3>
+    <div class="ctx" id="m_ctx"></div>
+    <input type="hidden" id="m_tarea_id">
+    <input type="hidden" id="m_canal">
+    <label>¿Qué pasó? (lo que dijiste · lo que respondieron · acuerdo)</label>
+    <textarea id="m_texto" placeholder="Ej: le mandé WA a Dyana, dijo que lo manda hoy 5pm"></textarea>
+    <label>Adjunto (opcional · foto WhatsApp / PDF)</label>
+    <input type="file" id="m_archivo" accept="image/*,application/pdf">
+    <div class="acts">
+      <button class="cancel" onclick="cerrarModal()">Cancelar</button>
+      <button class="ok" id="m_guardar" onclick="guardarRapido()">Guardar y siguiente</button>
+    </div>
+  </div>
+</div>
+
+<div class="confetti" id="confetti">✅ Listo · siguiente</div>
+
+<script>
+const SUPABASE_URL='https://eknmtsrtfkzroxnovfqn.supabase.co';
+const SUPABASE_ANON='eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImVrbm10c3J0Zmt6cm94bm92ZnFuIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzU0MDY2ODgsImV4cCI6MjA5MDk4MjY4OH0.8Y4N0lw3DFN3Y8-R6ID7t_LAfgHWDM5N-oa4Ji9bncg';
+const sb=supabase.createClient(SUPABASE_URL,SUPABASE_ANON);
+const MI_EMAIL='asistente@gestionrepchile.cl';
+let _myEmail=MI_EMAIL, _myNombre='Jair', _isAuth=false;
+
+function esc(s){return String(s==null?'':s).replace(/[&<>"']/g,c=>({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;"}[c]));}
+function diasAPlazo(d){if(!d)return null;return Math.floor((new Date(d).getTime()-Date.now())/86400000);}
+function fmtAgo(d){if(!d)return '—';const ms=Date.now()-new Date(d).getTime();const h=Math.floor(ms/3600000);if(h<1)return 'hace minutos';if(h<24)return 'hace '+h+'h';return 'hace '+Math.floor(h/24)+'d';}
+
+async function checkAuth(){
+  try{
+    const s=await sb.auth.getSession();
+    if(s?.data?.session?.user){
+      _isAuth=true;_myEmail=s.data.session.user.email||MI_EMAIL;
+    }else{
+      try{const rf=JSON.parse(localStorage.getItem('rf_session')||'{}');if(rf.email)_myEmail=rf.email;}catch(_){}
+      document.getElementById('auth_warn').style.display='block';
+    }
+  }catch(_){}
+}
+
+async function cargar(){
+  try{
+    const {data,error}=await sb.schema('panel').rpc('jair_cola',{p_email:MI_EMAIL,p_limit:5});
+    if(error) throw error;
+    document.getElementById('k-pend').textContent=data.total_pendientes||0;
+    document.getElementById('k-venc').textContent=data.vencidas||0;
+    document.getElementById('k-7d').textContent=data.criticas_7d||0;
+    render(data.cola||[]);
+  }catch(e){
+    document.getElementById('lista').innerHTML='<div class="error">'+esc(e.message||JSON.stringify(e))+'</div>';
+  }
+}
+
+function render(cola){
+  if(!cola.length){
+    document.getElementById('lista').innerHTML='<div class="empty"><div class="big">🎉</div><h2 style="margin:0 0 8px">¡Cola vacía!</h2><p style="margin:0">No tenés tareas pendientes.</p></div>';
+    return;
+  }
+  document.getElementById('lista').innerHTML=cola.map((t,i)=>renderCard(t,i+1)).join('');
+}
+
+function renderCard(t,n){
+  const dias=diasAPlazo(t.fecha_meta);
+  let plazoCls='normal',plazoTxt='Sin plazo';
+  if(dias!==null){
+    if(dias<0){plazoCls='vencida';plazoTxt='Vencida hace '+Math.abs(dias)+'d';}
+    else if(dias<=7){plazoCls='urgente';plazoTxt='Vence en '+dias+'d';}
+    else{plazoCls='normal';plazoTxt='Vence en '+dias+'d';}
+  }
+  const priori=dias!==null && dias<0 ? 'priori-1' : (dias!==null && dias<=7 ? 'priori-2' : '');
+  const dest=t.origen_nombre||t.origen_email||'—';
+  return ''
+    +'<div class="card '+priori+'" id="card-'+t.tarea_id+'">'
+    +'  <div class="head"><span class="num">#'+n+' · '+esc(t.sucursal_id||'').toUpperCase()+' · '+esc(t.ley_id||'')+'</span><span class="badge-plazo '+plazoCls+'">'+plazoTxt+'</span></div>'
+    +'  <h2>'+esc(t.titulo||t.descripcion)+'</h2>'
+    +'  <div class="meta"><span>👤 a <strong>'+esc(dest)+'</strong></span>'+(t.expediente_codigo?'<span>📂 '+esc(t.expediente_titulo||t.expediente_codigo)+'</span>':'')+'</div>'
+    +'  <div class="descr">'+esc(t.descripcion)+'</div>'
+    +  (t.ultima_gestion ? '<div class="ultima-gestion">💬 <strong>Última gestión:</strong> '+fmtAgo(t.ultima_gestion)+' · '+t.n_gestiones+' total</div>' : '<div class="ultima-gestion" style="background:#f3f4f6;border-color:#9ca3af;color:#6b7280">💤 Sin gestiones aún</div>')
+    +'  <div class="acciones">'
+    +'    <button class="btn wa" onclick="abrirModal('+t.tarea_id+',\'whatsapp\',\''+esc(t.titulo||'').replace(/\'/g,"\\'")+'\',\''+esc(dest).replace(/\'/g,"\\'")+'\')">📱 WhatsApp</button>'
+    +'    <button class="btn correo" onclick="abrirModal('+t.tarea_id+',\'correo\',\''+esc(t.titulo||'').replace(/\'/g,"\\'")+'\',\''+esc(dest).replace(/\'/g,"\\'")+'\')">📧 Correo</button>'
+    +'    <button class="btn llamada" onclick="abrirModal('+t.tarea_id+',\'llamada\',\''+esc(t.titulo||'').replace(/\'/g,"\\'")+'\',\''+esc(dest).replace(/\'/g,"\\'")+'\')">📞 Llamada</button>'
+    +'    <button class="btn cumplido" onclick="cumplir('+t.tarea_id+')">✓ Cumplido</button>'
+    +'    <button class="btn traba" onclick="trabarse('+t.tarea_id+',\''+esc(t.titulo||'').replace(/\'/g,"\\'")+'\')">🆘 No avanza · escalar a 3</button>'
+    +'  </div>'
+    +'</div>';
+}
+
+function abrirModal(tareaId,canal,titulo,dest){
+  document.getElementById('m_tarea_id').value=tareaId;
+  document.getElementById('m_canal').value=canal;
+  document.getElementById('m_titulo').textContent=({whatsapp:'📱 WhatsApp',correo:'📧 Correo',llamada:'📞 Llamada'}[canal]||'Gestión')+' · '+titulo;
+  document.getElementById('m_ctx').textContent='Destinatario: '+dest+' · plazo se moverá +2 días al guardar.';
+  document.getElementById('m_texto').value='';
+  document.getElementById('m_archivo').value='';
+  document.getElementById('modal').classList.add('open');
+  setTimeout(()=>document.getElementById('m_texto').focus(),200);
+}
+function cerrarModal(){document.getElementById('modal').classList.remove('open');}
+window.abrirModal=abrirModal;window.cerrarModal=cerrarModal;
+
+async function guardarRapido(){
+  const btn=document.getElementById('m_guardar');btn.disabled=true;btn.textContent='Guardando...';
+  try{
+    const tareaId=parseInt(document.getElementById('m_tarea_id').value);
+    const canal=document.getElementById('m_canal').value;
+    const texto=document.getElementById('m_texto').value.trim();
+    const file=document.getElementById('m_archivo').files[0];
+    if(!texto)throw new Error('Contame qué pasó');
+
+    const {error}=await sb.schema('panel').rpc('tarea_avanzar',{
+      p_tarea_id:tareaId,p_canal:canal,p_texto:texto,
+      p_actor_email:_myEmail,p_actor_nombre:_myNombre,p_bump_dias:2
+    });
+    if(error) throw error;
+
+    if(file && _isAuth){
+      const path='gestiones/'+tareaId+'/'+Date.now()+'_'+file.name.replace(/[^\w.\-]/g,'_');
+      const up=await sb.storage.from('impulsa-documentos').upload(path,file);
+      if(up.error){console.warn('upload fallo',up.error)}
+    }
+
+    cerrarModal();
+    showConfetti('✅ Listo · siguiente');
+    setTimeout(cargar,800);
+  }catch(e){
+    alert('Error: '+(e.message||e));
+  }finally{btn.disabled=false;btn.textContent='Guardar y siguiente';}
+}
+window.guardarRapido=guardarRapido;
+
+async function cumplir(tareaId){
+  if(!confirm('¿Marcar como CUMPLIDO? Esta acción cierra la tarea.'))return;
+  try{
+    const {error}=await sb.schema('panel').rpc('tarea_cerrar',{p_tarea_id:tareaId,p_nota:'Cerrada por Jair desde /mi-cola'});
+    if(error) throw error;
+    showConfetti('🎉 ¡Cerrada!');
+    setTimeout(cargar,800);
+  }catch(e){alert('Error: '+(e.message||e));}
+}
+window.cumplir=cumplir;
+
+async function trabarse(tareaId,titulo){
+  const motivo=prompt('¿Qué te traba? Se avisa a Dusan + Cesar + Dyana.','');
+  if(motivo===null)return;
+  try{
+    const {error}=await sb.schema('panel').rpc('tarea_avanzar',{
+      p_tarea_id:tareaId,p_canal:'nota',
+      p_texto:'🆘 ESCALADO 3 · '+titulo+' · Motivo: '+(motivo||'sin detalle'),
+      p_actor_email:_myEmail,p_actor_nombre:_myNombre,p_bump_dias:0
+    });
+    if(error) throw error;
+    showConfetti('📡 Escalado a los 3');
+    setTimeout(cargar,800);
+  }catch(e){alert('Error: '+(e.message||e));}
+}
+window.trabarse=trabarse;
+
+function showConfetti(t){
+  const el=document.getElementById('confetti');el.textContent=t;el.classList.add('show');
+  setTimeout(()=>el.classList.remove('show'),1500);
+}
+
+checkAuth().then(cargar);
+</script>
+</body>
+</html>

--- a/public/panel-rdo.html
+++ b/public/panel-rdo.html
@@ -784,6 +784,10 @@
             <span class="v4-emoji" aria-hidden="true">🎧</span>
             Comunicados
           </a>
+          <a href="#" data-v4-tab="cumplimiento" class="nav-item flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm">
+            <span class="v4-emoji" aria-hidden="true">⚖️</span>
+            Cumplimiento
+          </a>
         </div>
       </details>
 

--- a/public/panel-rdo.html
+++ b/public/panel-rdo.html
@@ -446,6 +446,10 @@
           <svg class="ico" fill="none" stroke="currentColor" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9" stroke="currentColor" stroke-width="2" fill="none"/><circle cx="12" cy="12" r="3" fill="currentColor"/></svg>
           Estado vivo 4 PCs
         </a>
+        <a href="#" data-v4-tab="plan_2026" class="nav-item flex items-center gap-3 px-3 py-2 rounded-lg text-sm" data-v4-tab-perfil="dusan,admin">
+          <svg class="ico" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"/></svg>
+          Plan 2026
+        </a>
       </div>
     </nav>
 
@@ -581,6 +585,7 @@
         <button data-tab="cartera"        class="tab-btn py-3 px-3 text-stone-600"     role="tab" aria-selected="false" aria-controls="tabCartera">👥 Cartera</button>
         <button data-tab="oportunidades" class="tab-btn py-3 px-3 text-stone-600"      role="tab" aria-selected="false" aria-controls="tabOportunidades">🎯 Oportunidades</button>
         <button data-tab="entregables"    class="tab-btn py-3 px-3 text-stone-600"     role="tab" aria-selected="false" aria-controls="tabEntregables">📤 Entregables</button>
+        <button data-tab="plan_2026"      class="tab-btn py-3 px-3 text-stone-600"     role="tab" aria-selected="false" aria-controls="tabPlan2026">🗳️ Plan 2026</button>
         <button data-tab="bandeja_dieg"   class="tab-btn py-3 px-3 text-stone-600"     role="tab" aria-selected="false" aria-controls="tabBandejaDiego">📥 Bandeja Diego</button>
         <button data-tab="ops_diarias"    class="tab-btn py-3 px-3 text-stone-600"     role="tab" aria-selected="false" aria-controls="tabOpsDiarias">🌅 Operaciones Día</button>
         <button data-tab="comercial"      class="tab-btn py-3 px-3 text-stone-600"     role="tab" aria-selected="false" aria-controls="tabComercial">💼 Comercial</button>
@@ -1323,8 +1328,7 @@
       </div>
 
       <p class="text-xs text-stone-400 mt-3">
-        Fuente: <code>staging.v_bandeja_precios</code> · Click una fila para ver detalle y aprobar/rechazar.
-        Aprobación atómica via <code>/functions/v1/precio-aplicar</code> (cierre vigencia anterior + INSERT nueva + log histórico).
+        Click una fila para ver el detalle y aprobar o rechazar la propuesta.
       </p>
 
       <!-- Drawer aprobar/rechazar -->
@@ -2926,6 +2930,61 @@
       </style>
     </section>
 
+    <!-- R-AUD-032 + R-AUD-033 · Tab Cuestionario Plan 2026 (PC2 Pablo 2026-05-31 tarea 6dc97ab6) -->
+    <section id="tabPlan2026" class="tab-content hidden">
+      <div class="flex items-center justify-between mb-3">
+        <h2 class="text-xl font-bold text-stone-800">🗳️ Cuestionario Plan 2026</h2>
+        <div id="plan2026Resumen" class="text-sm text-stone-600">Cargando…</div>
+      </div>
+
+      <p class="text-xs text-stone-500 mb-3">
+        39 preguntas en 10 bloques. Datos en vivo de Supabase (<code>panel.cuestionario_plan_2026</code>).
+        Para editar respuestas: abrí el formulario completo en <code>mayordomo/PLAN-2026/cuestionario-decisiones-dusan.html</code> y los cambios sincronizan automático.
+      </p>
+
+      <!-- Card progreso global -->
+      <div class="bg-white p-4 rounded-lg shadow-sm mb-4">
+        <div class="flex items-center justify-between mb-2">
+          <span class="text-sm font-semibold text-stone-700">Progreso global</span>
+          <span id="plan2026ProgresoTexto" class="text-sm text-stone-600">— / 39</span>
+        </div>
+        <div class="w-full bg-stone-200 rounded-full h-3 overflow-hidden">
+          <div id="plan2026ProgresoBar" class="h-3 bg-emerald-600 transition-all" style="width:0%"></div>
+        </div>
+      </div>
+
+      <!-- Grid bloques -->
+      <div id="plan2026Bloques" class="space-y-3">
+        <div class="text-stone-400 text-center py-8">Cargando bloques…</div>
+      </div>
+
+      <!-- Modal detalle pregunta -->
+      <div id="plan2026Modal" class="hidden fixed inset-0 z-50 bg-black/50 flex items-center justify-center p-4">
+        <div class="bg-white rounded-lg shadow-xl max-w-2xl w-full p-5 max-h-[85vh] overflow-y-auto">
+          <div class="flex items-center justify-between mb-3 border-b pb-2">
+            <h3 class="font-bold text-stone-800">Pregunta <span id="plan2026ModalNum"></span></h3>
+            <button onclick="plan2026CerrarModal()" class="text-stone-400 hover:text-stone-700 text-xl">×</button>
+          </div>
+          <div id="plan2026ModalBody"></div>
+          <div class="mt-4 text-right">
+            <button onclick="plan2026CerrarModal()" class="px-3 py-1.5 text-sm text-stone-600 hover:bg-stone-100 rounded">Cerrar</button>
+          </div>
+        </div>
+      </div>
+
+      <style>
+        .p26-bloque { background:#fff; border-radius:8px; box-shadow:0 1px 3px rgba(0,0,0,.05); }
+        .p26-bloque-header { padding:.75rem 1rem; cursor:pointer; display:flex; align-items:center; justify-content:space-between; border-bottom:1px solid #f3f4f6; }
+        .p26-bloque-header:hover { background:#fafaf9; }
+        .p26-preguntas { padding:.5rem 0; }
+        .p26-pregunta { padding:.5rem 1rem; cursor:pointer; display:flex; align-items:start; gap:.5rem; border-top:1px solid #f3f4f6; }
+        .p26-pregunta:hover { background:#fafaf9; }
+        .p26-badge-ok { background:#d1fae5; color:#065f46; padding:1px 6px; border-radius:999px; font-size:.65rem; font-weight:600; flex-shrink:0; }
+        .p26-badge-pendiente { background:#fef3c7; color:#92400e; padding:1px 6px; border-radius:999px; font-size:.65rem; font-weight:600; flex-shrink:0; }
+        .p26-pct { font-family: 'Inter', system-ui, sans-serif; font-weight:700; }
+      </style>
+    </section>
+
     <!-- D-GANTT-VIVA-001 · Tab Gantt Viva (PC2 Pablo 2026-05-29 PM) -->
     <section id="tabGantt" class="tab-content hidden">
       <div class="flex items-center justify-between mb-3">
@@ -3101,7 +3160,7 @@ let recordedUrl = null;
 //
 // FALLBACKS (defaults): si las consultas fallan (red/RLS/tabla vacía) el
 // HTML no se rompe — el navbar aparece como en versión hardcoded.
-const FALLBACK_TABS_GLOBALES   = ['portada', 'pesaje', 'facturacion', 'dieguito', 'comunicados', 'manual', 'mi_memoria', 'rdo', 'negocios', 'cotizador', 'cierres', 'precios', 'bandeja_precios', 'operativos', 'reconciliacion', 'cartera', 'oportunidades', 'entregables', 'bandeja_dieg', 'ops_diarias', 'pcs_vivo', 'gantt', 'admin'];
+const FALLBACK_TABS_GLOBALES   = ['portada', 'pesaje', 'facturacion', 'dieguito', 'comunicados', 'manual', 'mi_memoria', 'rdo', 'negocios', 'cotizador', 'cierres', 'precios', 'bandeja_precios', 'operativos', 'reconciliacion', 'cartera', 'oportunidades', 'entregables', 'bandeja_dieg', 'ops_diarias', 'pcs_vivo', 'plan_2026', 'gantt', 'admin'];
 const FALLBACK_TABS_TRANSVERSALES = ['portada', 'dieguito', 'comunicados', 'cierres', 'precios', 'operativos'];
 const FALLBACK_BYPASS_EMAILS = [
   'gerencia@gestionrepchile.cl',
@@ -9981,7 +10040,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     tbody.innerHTML = rows.map(r => {
       const lockActive = r.lock_until && new Date(r.lock_until).getTime() > Date.now();
-      const lockTag = lockActive ? `<span class="ml-1 text-[10px] text-amber-700">🔒 ${esc(r.revisando_por ?? '?')}</span>` : '';
+      const lockTag = lockActive ? `<span class="ml-1 text-[10px] text-amber-700">🔒 Editando: ${esc(r.revisando_por ?? '?')}</span>` : '';
       const deltaCls = r.desviacion_pct == null ? 'text-stone-400'
                     : Math.abs(Number(r.desviacion_pct)) > 30 ? 'text-red-700'
                     : Math.abs(Number(r.desviacion_pct)) > 15 ? 'text-amber-700'
@@ -10027,7 +10086,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const lockActive = r.lock_until && new Date(r.lock_until).getTime() > Date.now();
     const lockWarn = document.getElementById('bpDrawerLockWarn');
     if (lockActive && r.revisando_por && r.revisando_por !== (currentUser ?? '')) {
-      lockWarn.textContent = `🔒 Esta propuesta la está revisando ${r.revisando_por} desde ${fmtEdad(r.lock_until)} (lock expira en breve).`;
+      lockWarn.textContent = `🔒 Esta propuesta la está editando ${r.revisando_por} desde hace ${fmtEdad(r.lock_until)}. Vas a poder editarla en unos minutos.`;
       lockWarn.classList.remove('hidden');
     } else {
       lockWarn.classList.add('hidden');
@@ -11124,5 +11183,146 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 })();
 </script>
+
+<!-- R-AUD-032 + R-AUD-033 · Bootstrap tab Cuestionario Plan 2026 (PC2 Pablo 2026-05-31 tarea 6dc97ab6) -->
+<script>
+(function () {
+  let bloquesAbiertos = new Set();
+  let dataActual = [];
+
+  function esc(s) {
+    return (s ?? '').toString()
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;').replace(/'/g, '&#039;');
+  }
+
+  async function cargarCuestionario() {
+    try {
+      const { data, error } = await sb
+        .schema('panel')
+        .from('cuestionario_plan_2026')
+        .select('id, bloque, bloque_nombre, pregunta, por_que, opciones, recomendacion_pc1, confidence, que_se_graba, impacto_plan_2026, aclaracion_diego, asignado_a, estado, respuesta_opcion, respuesta_justificacion, pendiente_de_carga_razon, respondido_por, respondido_en')
+        .order('id', { ascending: true });
+      if (error) {
+        document.getElementById('plan2026Bloques').innerHTML = `<div class="text-red-600 p-4">Error cargando: ${esc(error.message)}</div>`;
+        document.getElementById('plan2026Resumen').textContent = 'Error';
+        return;
+      }
+      dataActual = data || [];
+      renderResumen(dataActual);
+      renderBloques(dataActual);
+    } catch (e) {
+      document.getElementById('plan2026Bloques').innerHTML = `<div class="text-red-600 p-4">Excepción: ${esc(String(e))}</div>`;
+    }
+  }
+
+  function renderResumen(rows) {
+    const total = rows.length;
+    const ok = rows.filter(r => r.respuesta_opcion != null).length;
+    const pct = total ? Math.round(100 * ok / total) : 0;
+    document.getElementById('plan2026Resumen').innerHTML =
+      `<span class="p26-pct">${ok}/${total}</span> respondidas · <span class="text-emerald-700 font-semibold">${pct}%</span>`;
+    document.getElementById('plan2026ProgresoTexto').innerHTML = `<span class="p26-pct">${ok}</span> / ${total} (${pct}%)`;
+    document.getElementById('plan2026ProgresoBar').style.width = pct + '%';
+  }
+
+  function renderBloques(rows) {
+    const grupos = new Map();
+    for (const r of rows) {
+      const key = r.bloque;
+      if (!grupos.has(key)) grupos.set(key, { nombre: r.bloque_nombre, preguntas: [] });
+      grupos.get(key).preguntas.push(r);
+    }
+    const html = [...grupos.entries()].map(([num, g]) => {
+      const total = g.preguntas.length;
+      const ok = g.preguntas.filter(r => r.respuesta_opcion != null).length;
+      const pct = total ? Math.round(100 * ok / total) : 0;
+      const colorPct = pct === 100 ? 'text-emerald-700' : pct >= 50 ? 'text-amber-600' : 'text-red-600';
+      const abierto = bloquesAbiertos.has(num);
+      const chevron = abierto ? '▼' : '▶';
+      const preguntasHtml = abierto ? `<div class="p26-preguntas">${g.preguntas.map(renderPregunta).join('')}</div>` : '';
+      return `
+        <div class="p26-bloque" data-bloque="${num}">
+          <div class="p26-bloque-header" onclick="plan2026ToggleBloque(${num})">
+            <div class="flex items-center gap-2">
+              <span class="text-stone-400">${chevron}</span>
+              <span class="font-semibold text-stone-700">Bloque ${num}: ${esc(g.nombre)}</span>
+            </div>
+            <div class="text-xs">
+              <span class="p26-pct ${colorPct}">${ok}/${total}</span> · ${pct}%
+            </div>
+          </div>
+          ${preguntasHtml}
+        </div>`;
+    }).join('');
+    document.getElementById('plan2026Bloques').innerHTML = html;
+  }
+
+  function renderPregunta(r) {
+    const badge = r.respuesta_opcion != null
+      ? '<span class="p26-badge-ok">RESPONDIDA</span>'
+      : '<span class="p26-badge-pendiente">PENDIENTE</span>';
+    const corta = (r.pregunta || '').slice(0, 90) + ((r.pregunta || '').length > 90 ? '…' : '');
+    return `
+      <div class="p26-pregunta" onclick="plan2026AbrirModal(${r.id})">
+        ${badge}
+        <div class="flex-1 text-sm text-stone-700">
+          <div><span class="font-semibold">#${r.id}.</span> ${esc(corta)}</div>
+          ${r.respuesta_opcion != null ? `<div class="text-xs text-stone-500 mt-1">→ ${esc(r.respuesta_opcion)}</div>` : ''}
+        </div>
+      </div>`;
+  }
+
+  window.plan2026ToggleBloque = function (num) {
+    if (bloquesAbiertos.has(num)) bloquesAbiertos.delete(num);
+    else bloquesAbiertos.add(num);
+    renderBloques(dataActual);
+  };
+
+  window.plan2026AbrirModal = function (id) {
+    const r = dataActual.find(x => x.id === id);
+    if (!r) return;
+    document.getElementById('plan2026ModalNum').textContent = `#${r.id} · Bloque ${r.bloque} ${esc(r.bloque_nombre || '')}`;
+    const body = document.getElementById('plan2026ModalBody');
+    const opciones = Array.isArray(r.opciones)
+      ? r.opciones.map((o, i) => `<li class="text-sm text-stone-600">${esc(typeof o === 'string' ? o : JSON.stringify(o))}</li>`).join('')
+      : '<li class="text-xs text-stone-400">Sin opciones cargadas</li>';
+    body.innerHTML = `
+      <div class="space-y-3 text-sm">
+        <div><span class="font-semibold text-stone-700">Pregunta:</span><div class="mt-1 text-stone-800">${esc(r.pregunta)}</div></div>
+        ${r.por_que ? `<div><span class="font-semibold text-stone-700">¿Por qué importa?</span><div class="mt-1 text-stone-600 text-xs">${esc(r.por_que)}</div></div>` : ''}
+        <div><span class="font-semibold text-stone-700">Opciones:</span><ul class="list-disc pl-5 mt-1">${opciones}</ul></div>
+        ${r.recomendacion_pc1 ? `<div><span class="font-semibold text-stone-700">Recomendación PC1:</span><div class="mt-1 text-stone-600">${esc(r.recomendacion_pc1)} ${r.confidence ? `<span class="text-xs text-stone-400">(confianza ${esc(r.confidence)})</span>` : ''}</div></div>` : ''}
+        ${r.respuesta_opcion != null
+          ? `<div class="bg-emerald-50 border border-emerald-200 rounded p-3">
+              <div><span class="font-semibold text-emerald-800">Respuesta firmada:</span> ${esc(r.respuesta_opcion)}</div>
+              ${r.respuesta_justificacion ? `<div class="text-xs text-emerald-700 mt-1">${esc(r.respuesta_justificacion)}</div>` : ''}
+              ${r.respondido_por ? `<div class="text-xs text-stone-500 mt-1">Por ${esc(r.respondido_por)}${r.respondido_en ? ' · ' + new Date(r.respondido_en).toLocaleString('es-CL') : ''}</div>` : ''}
+            </div>`
+          : `<div class="bg-amber-50 border border-amber-200 rounded p-3">
+              <div><span class="font-semibold text-amber-800">PENDIENTE de carga</span></div>
+              ${r.pendiente_de_carga_razon ? `<div class="text-xs text-amber-700 mt-1">${esc(r.pendiente_de_carga_razon)}</div>` : ''}
+              ${r.asignado_a ? `<div class="text-xs text-stone-500 mt-1">Asignado a: ${esc(r.asignado_a)}</div>` : ''}
+            </div>`}
+        ${r.impacto_plan_2026 ? `<div><span class="font-semibold text-stone-700">Impacto Plan 2026:</span><div class="mt-1 text-stone-600 text-xs">${esc(r.impacto_plan_2026)}</div></div>` : ''}
+      </div>`;
+    document.getElementById('plan2026Modal').classList.remove('hidden');
+  };
+
+  window.plan2026CerrarModal = function () {
+    document.getElementById('plan2026Modal').classList.add('hidden');
+  };
+
+  function init() {
+    document.querySelector('button[data-tab="plan_2026"]')?.addEventListener('click', () => {
+      setTimeout(cargarCuestionario, 100);
+    });
+  }
+
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init);
+  else init();
+})();
+</script>
+
 </body>
 </html>

--- a/public/panel-rdo.html
+++ b/public/panel-rdo.html
@@ -338,120 +338,225 @@
       </div>
     </div>
 
-    <!-- Navegación: shortcuts a los tabs productivos (los buttons reales siguen vivos en <nav> abajo) -->
-    <nav class="flex-1 overflow-y-auto px-3 py-3 space-y-5" aria-label="Atajos de pestañas">
-      <div>
-        <h3 class="px-3 mb-1 text-[10px] font-semibold text-slate-400 uppercase tracking-wider">Inicio</h3>
-        <a href="#" data-v4-tab="portada" class="nav-item active flex items-center gap-3 px-3 py-2 rounded-lg text-sm">
-          <svg class="ico" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"/></svg>
-          Portada
-        </a>
-      </div>
-      <div>
-        <h3 class="px-3 mb-1 text-[10px] font-semibold text-slate-400 uppercase tracking-wider">Día a día</h3>
-        <a href="#" data-v4-tab="pesaje" class="nav-item flex items-center gap-3 px-3 py-2 rounded-lg text-sm">
-          <svg class="ico" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 6l3 1m0 0l-3 9a5 5 0 006 0M6 7l3 9M6 7l6-2m6 2l3-1m-3 1l-3 9a5 5 0 006 0M18 7l3 9m-3-9l-6-2m0-2v2m0 16V5m0 16H9m3 0h3"/></svg>
-          Pesaje
-        </a>
-        <a href="#" data-v4-tab="facturacion" class="nav-item flex items-center gap-3 px-3 py-2 rounded-lg text-sm">
-          <svg class="ico" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"/></svg>
-          Facturación
-        </a>
-        <a href="#" data-v4-tab="ops_diarias" class="nav-item flex items-center gap-3 px-3 py-2 rounded-lg text-sm">
-          <svg class="ico" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364-6.364l-.707.707M6.343 17.657l-.707.707m12.728 0l-.707-.707M6.343 6.343l-.707-.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
-          Operaciones Día
-        </a>
-        <a href="#" data-v4-tab="operativos" class="nav-item flex items-center gap-3 px-3 py-2 rounded-lg text-sm">
-          <svg class="ico" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg>
-          Operativos
-        </a>
-        <a href="#" data-v4-tab="dieguito" class="nav-item flex items-center gap-3 px-3 py-2 rounded-lg text-sm">
-          <svg class="ico" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"/></svg>
-          Dieguito
-        </a>
-        <a href="#" data-v4-tab="bandeja_dieg" class="nav-item flex items-center gap-3 px-3 py-2 rounded-lg text-sm">
-          <svg class="ico" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>
-          Bandeja Diego
-        </a>
-      </div>
-      <div>
-        <h3 class="px-3 mb-1 text-[10px] font-semibold text-slate-400 uppercase tracking-wider">Gestión</h3>
-        <a href="#" data-v4-tab="negocios" class="nav-item flex items-center gap-3 px-3 py-2 rounded-lg text-sm">
-          <svg class="ico" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 13.255A23.931 23.931 0 0112 15c-3.183 0-6.22-.62-9-1.745M16 6V4a2 2 0 00-2-2h-4a2 2 0 00-2 2v2m4 6h.01M5 20h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>
-          Negocios
-        </a>
-        <a href="#" data-v4-tab="cotizador" class="nav-item flex items-center gap-3 px-3 py-2 rounded-lg text-sm">
-          <svg class="ico" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"/></svg>
-          Cotizador
-        </a>
-        <a href="#" data-v4-tab="evolucion" class="nav-item flex items-center gap-3 px-3 py-2 rounded-lg text-sm">
-          <svg class="ico" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6"/></svg>
-          Evolución
-        </a>
-        <a href="#" data-v4-tab="rdo" class="nav-item flex items-center gap-3 px-3 py-2 rounded-lg text-sm">
-          <svg class="ico" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 17v-2m3 2v-4m3 4v-6m2 10H5a2 2 0 01-2-2V5a2 2 0 012-2h14a2 2 0 012 2v14a2 2 0 01-2 2z"/></svg>
-          RDO
-        </a>
-        <a href="#" data-v4-tab="precios" class="nav-item flex items-center gap-3 px-3 py-2 rounded-lg text-sm">
-          <svg class="ico" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
-          Precios
-        </a>
-        <a href="#" data-v4-tab="bandeja_precios" class="nav-item flex items-center gap-3 px-3 py-2 rounded-lg text-sm">
-          <svg class="ico" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>
-          Bandeja Precios
-        </a>
-        <a href="#" data-v4-tab="cierres" class="nav-item flex items-center gap-3 px-3 py-2 rounded-lg text-sm">
-          <svg class="ico" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"/></svg>
-          Cierre
-        </a>
-        <a href="#" data-v4-tab="cartera" class="nav-item flex items-center gap-3 px-3 py-2 rounded-lg text-sm">
-          <svg class="ico" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a4 4 0 00-3-3.87M9 20H4v-2a4 4 0 013-3.87m6-3a4 4 0 11-8 0 4 4 0 018 0zm6 0a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
-          Cartera
-        </a>
-        <a href="#" data-v4-tab="entregables" class="nav-item flex items-center gap-3 px-3 py-2 rounded-lg text-sm">
-          <svg class="ico" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 17v-2a4 4 0 014-4h4m-3-3l3 3m-3 3l3-3m0-9v6a2 2 0 002 2h6"/></svg>
-          Entregables
-        </a>
-        <a href="#" data-v4-tab="oportunidades" class="nav-item flex items-center gap-3 px-3 py-2 rounded-lg text-sm">
-          <svg class="ico" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6"/></svg>
-          Oportunidades
-        </a>
-        <a href="#" data-v4-tab="reconciliacion" class="nav-item flex items-center gap-3 px-3 py-2 rounded-lg text-sm" data-v4-tab-perfil="dusan,admin">
-          <svg class="ico" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4"/></svg>
-          Reconciliación
-        </a>
-      </div>
-      <div>
-        <h3 class="px-3 mb-1 text-[10px] font-semibold text-slate-400 uppercase tracking-wider">Equipo</h3>
-        <a href="#" data-v4-tab="comunicados" class="nav-item flex items-center gap-3 px-3 py-2 rounded-lg text-sm">
-          <svg class="ico" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5.882V19.24a1.76 1.76 0 01-3.417.592l-2.147-6.15M18 13a3 3 0 100-6M5.436 13.683A4 4 0 017 6h1.832c4.1 0 7.625-1.234 9.168-3v14c-1.543-1.766-5.067-3-9.168-3H7a3.988 3.988 0 01-1.564-.317z"/></svg>
-          Comunicados
-        </a>
-        <a href="#" data-v4-tab="manual" class="nav-item flex items-center gap-3 px-3 py-2 rounded-lg text-sm">
-          <svg class="ico" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"/></svg>
-          Manual
-        </a>
-        <a href="#" data-v4-tab="mi_memoria" class="nav-item flex items-center gap-3 px-3 py-2 rounded-lg text-sm">
-          <svg class="ico" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"/></svg>
-          Mi memoria
-        </a>
-      </div>
-      <div data-v4-group-perfil="dusan,admin">
-        <h3 class="px-3 mb-1 text-[10px] font-semibold text-slate-400 uppercase tracking-wider">Administración</h3>
-        <a href="#" data-v4-tab="admin" class="nav-item flex items-center gap-3 px-3 py-2 rounded-lg text-sm" data-v4-tab-perfil="dusan,admin">
-          <svg class="ico" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/></svg>
-          Admin
-        </a>
-        <a href="#" data-v4-tab="pcs_vivo" class="nav-item flex items-center gap-3 px-3 py-2 rounded-lg text-sm" data-v4-tab-perfil="dusan,admin">
-          <svg class="ico" fill="none" stroke="currentColor" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9" stroke="currentColor" stroke-width="2" fill="none"/><circle cx="12" cy="12" r="3" fill="currentColor"/></svg>
-          Estado vivo 4 PCs
-        </a>
-        <a href="#" data-v4-tab="plan_2026" class="nav-item flex items-center gap-3 px-3 py-2 rounded-lg text-sm" data-v4-tab-perfil="dusan,admin">
-          <svg class="ico" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"/></svg>
-          Plan 2026
-        </a>
-      </div>
+    <!-- [PC1-AUDIT REDISEÑO SIDEBAR V4] · Sesión rediseño 31-may
+         Cambios estructurales/visuales SIN romper data-v4-tab ni data-v4-tab-perfil:
+         - Buscador arriba (filtra items en cliente, sin backend)
+         - Sección Favoritos (placeholder; integrar con localStorage en v2)
+         - 6 categorías semánticas (Operaciones / Gestión / Herramientas Personales / Soporte / Administración)
+         - <details open> por categoría (acordeón soft, abierto por default)
+         - Breadcrumb dinámico arriba (Inicio / Tab actual — JS opcional)
+         - Íconos emoji semánticos (reemplazan los SVG genéricos)
+         - Conserva 100% de los data-v4-tab + data-v4-tab-perfil + handlers JS existentes
+    -->
+    <!-- Breadcrumb (placeholder; un JS chico puede actualizarlo al cambiar tab) -->
+    <div id="v4-breadcrumb" class="px-3 pt-2 pb-1 text-[11px] text-slate-500 truncate" aria-live="polite">
+      <span class="text-slate-400">Inicio</span>
+      <!-- TODO JS dinámico: agregar " / <nombre tab actual>" cuando cambia data-v4-tab activo -->
+    </div>
+
+    <!-- Buscador (filtra .nav-item por texto - JS abajo en este mismo bloque) -->
+    <div class="px-3 pt-1 pb-2">
+      <label for="v4-search" class="sr-only">Buscar en el menú</label>
+      <input id="v4-search" type="search" placeholder="🔍 Buscar..." class="w-full text-sm rounded-lg border border-slate-200 bg-slate-50 px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent" autocomplete="off">
+    </div>
+
+    <!-- Navegación reorganizada en 6 categorías con acordeón -->
+    <nav class="flex-1 overflow-y-auto px-2 py-2 space-y-2" aria-label="Atajos de pestañas">
+
+      <!-- ⭐ FAVORITOS (placeholder; v2 leer de localStorage 'v4-favoritos') -->
+      <details class="v4-cat" open>
+        <summary class="v4-cat-h px-3 py-1.5 cursor-pointer text-[10px] font-semibold text-slate-400 uppercase tracking-wider hover:text-slate-600 rounded-md">⭐ Favoritos</summary>
+        <div class="mt-1 space-y-0.5" id="v4-favoritos-list">
+          <p class="px-3 py-2 text-xs text-slate-400 italic">Sin favoritos aún. (Próximamente: click derecho en cualquier pestaña para marcarla.)</p>
+        </div>
+      </details>
+
+      <!-- 🏠 NAVEGACIÓN PRINCIPAL -->
+      <details class="v4-cat" open>
+        <summary class="v4-cat-h px-3 py-1.5 cursor-pointer text-[10px] font-semibold text-slate-400 uppercase tracking-wider hover:text-slate-600 rounded-md">🏠 Navegación principal</summary>
+        <div class="mt-1 space-y-0.5">
+          <a href="#" data-v4-tab="portada" class="nav-item active flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm">
+            <span class="v4-emoji" aria-hidden="true">🏡</span>
+            Portada
+          </a>
+        </div>
+      </details>
+
+      <!-- 📋 OPERACIONES -->
+      <details class="v4-cat" open>
+        <summary class="v4-cat-h px-3 py-1.5 cursor-pointer text-[10px] font-semibold text-slate-400 uppercase tracking-wider hover:text-slate-600 rounded-md">📋 Operaciones</summary>
+        <div class="mt-1 space-y-0.5">
+          <a href="#" data-v4-tab="pesaje" class="nav-item flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm">
+            <span class="v4-emoji" aria-hidden="true">⚖️</span>
+            Pesaje
+          </a>
+          <a href="#" data-v4-tab="facturacion" class="nav-item flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm">
+            <span class="v4-emoji" aria-hidden="true">🧾</span>
+            Facturación
+          </a>
+          <a href="#" data-v4-tab="ops_diarias" class="nav-item flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm">
+            <span class="v4-emoji" aria-hidden="true">🌅</span>
+            Operaciones Día
+          </a>
+          <a href="#" data-v4-tab="operativos" class="nav-item flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm">
+            <span class="v4-emoji" aria-hidden="true">📑</span>
+            Operativos
+          </a>
+        </div>
+      </details>
+
+      <!-- 👥 GESTIÓN (comercial + financiera) -->
+      <details class="v4-cat" open>
+        <summary class="v4-cat-h px-3 py-1.5 cursor-pointer text-[10px] font-semibold text-slate-400 uppercase tracking-wider hover:text-slate-600 rounded-md">👥 Gestión</summary>
+        <div class="mt-1 space-y-0.5">
+          <a href="#" data-v4-tab="cartera" class="nav-item flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm">
+            <span class="v4-emoji" aria-hidden="true">💳</span>
+            Cartera
+          </a>
+          <a href="#" data-v4-tab="oportunidades" class="nav-item flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm">
+            <span class="v4-emoji" aria-hidden="true">🎯</span>
+            Oportunidades
+          </a>
+          <a href="#" data-v4-tab="negocios" class="nav-item flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm">
+            <span class="v4-emoji" aria-hidden="true">💼</span>
+            Negocios
+          </a>
+          <a href="#" data-v4-tab="cotizador" class="nav-item flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm">
+            <span class="v4-emoji" aria-hidden="true">💱</span>
+            Cotizador
+          </a>
+          <a href="#" data-v4-tab="precios" class="nav-item flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm">
+            <span class="v4-emoji" aria-hidden="true">💲</span>
+            Precios
+          </a>
+          <a href="#" data-v4-tab="bandeja_precios" class="nav-item flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm">
+            <span class="v4-emoji" aria-hidden="true">📨</span>
+            Bandeja Precios
+          </a>
+          <a href="#" data-v4-tab="entregables" class="nav-item flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm">
+            <span class="v4-emoji" aria-hidden="true">📤</span>
+            Entregables
+          </a>
+          <a href="#" data-v4-tab="cierres" class="nav-item flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm">
+            <span class="v4-emoji" aria-hidden="true">🔒</span>
+            Cierre
+          </a>
+          <a href="#" data-v4-tab="reconciliacion" class="nav-item flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm" data-v4-tab-perfil="dusan,admin">
+            <span class="v4-emoji" aria-hidden="true">🔗</span>
+            Reconciliación
+          </a>
+          <a href="#" data-v4-tab="evolucion" class="nav-item flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm">
+            <span class="v4-emoji" aria-hidden="true">📈</span>
+            Evolución
+          </a>
+          <a href="#" data-v4-tab="rdo" class="nav-item flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm">
+            <span class="v4-emoji" aria-hidden="true">📊</span>
+            RDO
+          </a>
+        </div>
+      </details>
+
+      <!-- 🔧 HERRAMIENTAS PERSONALES -->
+      <details class="v4-cat" open>
+        <summary class="v4-cat-h px-3 py-1.5 cursor-pointer text-[10px] font-semibold text-slate-400 uppercase tracking-wider hover:text-slate-600 rounded-md">🔧 Herramientas personales</summary>
+        <div class="mt-1 space-y-0.5">
+          <a href="#" data-v4-tab="dieguito" class="nav-item flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm">
+            <span class="v4-emoji" aria-hidden="true">📎</span>
+            Dieguito
+          </a>
+          <a href="#" data-v4-tab="bandeja_dieg" class="nav-item flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm">
+            <span class="v4-emoji" aria-hidden="true">📥</span>
+            Bandeja Diego
+          </a>
+          <a href="#" data-v4-tab="mi_memoria" class="nav-item flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm">
+            <span class="v4-emoji" aria-hidden="true">🧠</span>
+            Mi memoria
+          </a>
+        </div>
+      </details>
+
+      <!-- 📚 SOPORTE -->
+      <details class="v4-cat" open>
+        <summary class="v4-cat-h px-3 py-1.5 cursor-pointer text-[10px] font-semibold text-slate-400 uppercase tracking-wider hover:text-slate-600 rounded-md">📚 Soporte</summary>
+        <div class="mt-1 space-y-0.5">
+          <a href="#" data-v4-tab="manual" class="nav-item flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm">
+            <span class="v4-emoji" aria-hidden="true">📖</span>
+            Manual
+          </a>
+          <a href="#" data-v4-tab="comunicados" class="nav-item flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm">
+            <span class="v4-emoji" aria-hidden="true">🎧</span>
+            Comunicados
+          </a>
+        </div>
+      </details>
+
+      <!-- ⚙️ ADMINISTRACIÓN (solo dusan/admin) -->
+      <details class="v4-cat" open data-v4-group-perfil="dusan,admin">
+        <summary class="v4-cat-h px-3 py-1.5 cursor-pointer text-[10px] font-semibold text-slate-400 uppercase tracking-wider hover:text-slate-600 rounded-md">⚙️ Administración</summary>
+        <div class="mt-1 space-y-0.5">
+          <a href="#" data-v4-tab="admin" class="nav-item flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm" data-v4-tab-perfil="dusan,admin">
+            <span class="v4-emoji" aria-hidden="true">⚙️</span>
+            Admin
+          </a>
+          <a href="#" data-v4-tab="pcs_vivo" class="nav-item flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm" data-v4-tab-perfil="dusan,admin">
+            <span class="v4-emoji" aria-hidden="true">🟢</span>
+            Estado vivo 4 PCs
+          </a>
+          <a href="#" data-v4-tab="plan_2026" class="nav-item flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm" data-v4-tab-perfil="dusan,admin">
+            <span class="v4-emoji" aria-hidden="true">🗳️</span>
+            Plan 2026
+          </a>
+        </div>
+      </details>
     </nav>
+
+    <!-- [PC1-AUDIT REDISEÑO] estilos + JS específicos del sidebar nuevo -->
+    <style>
+      /* Categorías acordeón (details/summary) */
+      .v4-cat > summary { list-style: none; user-select: none; }
+      .v4-cat > summary::-webkit-details-marker { display: none; }
+      .v4-cat > summary::after {
+        content: "▾"; float: right; transition: transform 0.2s ease; color: #cbd5e1; font-size: 11px;
+      }
+      .v4-cat:not([open]) > summary::after { transform: rotate(-90deg); }
+      .v4-cat[open] > summary { color: #475569; }
+      .v4-emoji { font-size: 15px; line-height: 1; width: 18px; text-align: center; flex-shrink: 0; }
+      /* Hover suave en items con emoji */
+      .nav-item:hover .v4-emoji { transform: scale(1.1); transition: transform 0.15s ease; }
+    </style>
+    <script>
+      (function () {
+        // Filtro buscador (cliente, sin backend)
+        var inp = document.getElementById('v4-search');
+        if (inp) {
+          inp.addEventListener('input', function (e) {
+            var q = (e.target.value || '').toLowerCase().trim();
+            document.querySelectorAll('#v4-sidebar .nav-item').forEach(function (a) {
+              var txt = a.textContent.toLowerCase();
+              var match = !q || txt.indexOf(q) !== -1;
+              a.style.display = match ? '' : 'none';
+            });
+            // Si hay query, abre todas las categorías para mostrar matches
+            if (q) {
+              document.querySelectorAll('#v4-sidebar .v4-cat').forEach(function (d) { d.open = true; });
+            }
+          });
+        }
+        // Breadcrumb dinámico (best-effort: lee el tab activo)
+        function actualizarBreadcrumb() {
+          var crumb = document.getElementById('v4-breadcrumb');
+          if (!crumb) return;
+          var active = document.querySelector('#v4-sidebar .nav-item.active');
+          var nombre = active ? (active.textContent || '').trim() : 'Portada';
+          crumb.innerHTML = '<span class="text-slate-400">Inicio</span> <span class="text-slate-300">/</span> <span class="text-slate-600 font-medium">' + nombre + '</span>';
+        }
+        actualizarBreadcrumb();
+        // Re-actualiza al click en cualquier nav-item
+        document.querySelectorAll('#v4-sidebar .nav-item').forEach(function (a) {
+          a.addEventListener('click', function () { setTimeout(actualizarBreadcrumb, 50); });
+        });
+      })();
+    </script>
 
     <!-- Footer usuario -->
     <div class="border-t border-slate-100 p-3">

--- a/public/panel-rdo.html
+++ b/public/panel-rdo.html
@@ -642,6 +642,10 @@
             <span class="v4-emoji" aria-hidden="true">⚖️</span>
             Pesaje
           </a>
+          <a href="#" data-v4-tab="vales_portal" class="nav-item flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm">
+            <span class="v4-emoji" aria-hidden="true">📊</span>
+            Vales portal
+          </a>
           <a href="#" data-v4-tab="facturacion" class="nav-item flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm">
             <span class="v4-emoji" aria-hidden="true">🧾</span>
             Facturación
@@ -1005,6 +1009,7 @@
         <button data-tab="firmas_pend" class="tab-btn py-3 px-3 text-stone-600"          role="tab" aria-selected="false" aria-controls="tabFirmasPend">📝 Firmas pendientes</button>
         <button data-tab="tarifas_ext" class="tab-btn py-3 px-3 text-stone-600"          role="tab" aria-selected="false" aria-controls="tabTarifasExt">💰 Tarifas externas</button>
         <button data-tab="cumplimiento" class="tab-btn py-3 px-3 text-stone-600"         role="tab" aria-selected="false" aria-controls="tabCumplimiento">⚖️ Cumplimiento</button>
+        <button data-tab="vales_portal" class="tab-btn py-3 px-3 text-stone-600"         role="tab" aria-selected="false" aria-controls="tabValesPortal">📊 Vales portal</button>
         <button data-tab="piloto_pwa"  class="tab-btn py-3 px-3 text-stone-600"          role="tab" aria-selected="false" aria-controls="tabPilotoPwa">📲 Piloto PWA</button>
         <button data-tab="mis_archivos" class="tab-btn py-3 px-3 text-stone-600"        role="tab" aria-selected="false" aria-controls="tabMisArchivos">📦 Mis archivos</button>
         <button data-tab="rdo"         class="tab-btn py-3 px-3 text-stone-600"        role="tab" aria-selected="false" aria-controls="tabRdo">📈 RDO Resumen</button>
@@ -3816,6 +3821,112 @@
       <div id="cump_lista" class="space-y-2"></div>
     </section>
 
+    <!-- Tab Vales portal · G42 · D-PESAJES-DIARIA-001 · PC2 Pablo 03-jun PM -->
+    <section id="tabValesPortal" class="tab-content hidden">
+      <div class="flex items-center justify-between mb-3 flex-wrap gap-2">
+        <div>
+          <h2 class="text-xl font-bold text-stone-800">📊 Vales portal pesajes</h2>
+          <p class="text-xs text-stone-500 mt-0.5">Ingesta vales detallados desde plataforma-virtual.com. Sincroniza 3x/día L-V + 1x/día S-D.</p>
+        </div>
+        <div class="flex gap-2 items-center flex-wrap">
+          <span id="vp_estado_pipeline" class="text-xs text-stone-500"></span>
+          <button id="vp_refresh" class="px-3 py-1 bg-emerald-600 text-white rounded text-xs hover:bg-emerald-700">↻ Actualizar</button>
+        </div>
+      </div>
+
+      <!-- Banner si no hay datos -->
+      <div id="vp_banner_sin_datos" class="hidden bg-amber-50 border border-amber-300 rounded p-3 mb-3 text-sm text-amber-900">
+        <strong>⏳ Pendiente clave Vault.</strong> La infraestructura está lista (tablas + EF + 4 crons), pero la clave del portal aún no se cargó al Vault Supabase. Dusan dicta la clave verbal a Pablo · Pablo ejecuta <code class="bg-amber-100 px-1 rounded">SELECT vault.create_secret('plataforma_virtual_pesajes_password', ...);</code> · luego se activan los 4 crons.
+      </div>
+
+      <!-- KPIs -->
+      <div class="grid grid-cols-2 md:grid-cols-4 gap-2 mb-3">
+        <div class="bg-white border border-stone-200 rounded p-2">
+          <div class="text-2xl font-bold text-stone-700" id="vp_kpi_vales">0</div>
+          <div class="text-xs text-stone-500">Vales totales</div>
+        </div>
+        <div class="bg-white border border-stone-200 rounded p-2">
+          <div class="text-2xl font-bold text-emerald-700" id="vp_kpi_saldo">$0</div>
+          <div class="text-xs text-stone-500">💰 Saldo pendiente</div>
+        </div>
+        <div class="bg-white border border-stone-200 rounded p-2">
+          <div class="text-2xl font-bold text-stone-700" id="vp_kpi_clientes">0</div>
+          <div class="text-xs text-stone-500">👥 Generadores pendientes</div>
+        </div>
+        <div class="bg-white border border-stone-200 rounded p-2">
+          <div class="text-2xl font-bold text-stone-700" id="vp_kpi_ultimo">—</div>
+          <div class="text-xs text-stone-500">📅 Último vale</div>
+        </div>
+      </div>
+
+      <!-- Resumen sucursal -->
+      <div class="bg-white border border-stone-200 rounded mb-3">
+        <div class="px-3 py-2 border-b border-stone-200 text-sm font-semibold text-stone-700">🏢 Resumen por sucursal</div>
+        <div class="overflow-x-auto">
+          <table class="w-full text-sm">
+            <thead class="bg-stone-50 text-xs text-stone-500 uppercase">
+              <tr>
+                <th class="text-left px-3 py-2">Sucursal</th>
+                <th class="text-right px-3 py-2">Vales</th>
+                <th class="text-right px-3 py-2">Clientes</th>
+                <th class="text-right px-3 py-2">Kg total</th>
+                <th class="text-right px-3 py-2">CLP total</th>
+                <th class="text-right px-3 py-2">Saldo pendiente</th>
+                <th class="text-right px-3 py-2">Último vale</th>
+              </tr>
+            </thead>
+            <tbody id="vp_sucursal_body"><tr><td colspan="7" class="text-center text-stone-400 py-4">Cargando...</td></tr></tbody>
+          </table>
+        </div>
+      </div>
+
+      <!-- Cuentas pagar generadores -->
+      <div class="bg-white border border-stone-200 rounded mb-3">
+        <div class="px-3 py-2 border-b border-stone-200 text-sm font-semibold text-stone-700 flex items-center justify-between">
+          <span>💸 Cuentas por pagar (generadores con saldo &gt; 0)</span>
+          <input id="vp_filtro_generador" type="search" placeholder="Buscar razón social o RUT..." class="px-2 py-0.5 border border-stone-300 rounded text-xs">
+        </div>
+        <div class="overflow-x-auto max-h-96 overflow-y-auto">
+          <table class="w-full text-sm">
+            <thead class="bg-stone-50 text-xs text-stone-500 uppercase sticky top-0">
+              <tr>
+                <th class="text-left px-3 py-2">Razón social</th>
+                <th class="text-left px-3 py-2">RUT</th>
+                <th class="text-left px-3 py-2">Banco</th>
+                <th class="text-right px-3 py-2">Vales</th>
+                <th class="text-right px-3 py-2">Saldo CLP</th>
+                <th class="text-left px-3 py-2">Último vale</th>
+              </tr>
+            </thead>
+            <tbody id="vp_pagar_body"><tr><td colspan="6" class="text-center text-stone-400 py-4">Cargando...</td></tr></tbody>
+          </table>
+        </div>
+      </div>
+
+      <!-- Últimos 50 vales -->
+      <div class="bg-white border border-stone-200 rounded">
+        <div class="px-3 py-2 border-b border-stone-200 text-sm font-semibold text-stone-700">📋 Últimos 50 vales</div>
+        <div class="overflow-x-auto">
+          <table class="w-full text-sm">
+            <thead class="bg-stone-50 text-xs text-stone-500 uppercase">
+              <tr>
+                <th class="text-left px-3 py-2">Folio</th>
+                <th class="text-left px-3 py-2">Fecha</th>
+                <th class="text-left px-3 py-2">Sucursal</th>
+                <th class="text-left px-3 py-2">Razón social</th>
+                <th class="text-left px-3 py-2">Tipo</th>
+                <th class="text-right px-3 py-2">Kg final</th>
+                <th class="text-right px-3 py-2">CLP total</th>
+                <th class="text-right px-3 py-2">Saldo</th>
+                <th class="text-left px-3 py-2">Estado</th>
+              </tr>
+            </thead>
+            <tbody id="vp_recientes_body"><tr><td colspan="9" class="text-center text-stone-400 py-4">Cargando...</td></tr></tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+
     <!-- Tab Piloto PWA (mig 195 backend · Pablo 02-jun PM) -->
     <section id="tabPilotoPwa" class="tab-content hidden">
       <div class="flex items-center justify-between mb-3 flex-wrap gap-2">
@@ -4917,6 +5028,7 @@ const TAB_SECTION_MAP = {
   firmas_pend: 'tabFirmasPend',
   tarifas_ext: 'tabTarifasExt',
   cumplimiento: 'tabCumplimiento',
+  vales_portal: 'tabValesPortal',
   piloto_pwa: 'tabPilotoPwa',
   mis_archivos: 'tabMisArchivos',
   diego_coord: 'tabDiegoCoord',
@@ -14822,6 +14934,146 @@ document.addEventListener('DOMContentLoaded', () => {
       var btn = e.target.closest('.cump-editar');
       if (btn) abrirFormEditar(btn.dataset.id);
     });
+  }
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init); else init();
+})();
+
+// Tab Vales Portal · G42 · D-PESAJES-DIARIA-001 · PC2 Pablo 03-jun PM
+(function () {
+  let _vpPagar = [];
+  function $$(id) { return document.getElementById(id); }
+  function esc(s) { return String(s == null ? '' : s).replace(/[&<>"']/g, function (c) { return ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c]; }); }
+  function fmtCLP(n) { if (n == null || isNaN(n)) return '—'; return '$' + Number(n).toLocaleString('es-CL', { maximumFractionDigits: 0 }); }
+  function fmtKg(n) { if (n == null || isNaN(n)) return '—'; return Number(n).toLocaleString('es-CL', { maximumFractionDigits: 1 }) + ' kg'; }
+  function fmtFecha(s) { if (!s) return '—'; try { return new Date(s).toLocaleDateString('es-CL'); } catch (e) { return s; } }
+  function badgeEstadoVale(estado) {
+    var n = Number(estado);
+    if (n === 1) return '<span class="bg-amber-100 text-amber-800 px-2 py-0.5 rounded text-xs">🟡 Pendiente</span>';
+    if (n === 2) return '<span class="bg-emerald-100 text-emerald-800 px-2 py-0.5 rounded text-xs">✅ Cerrado</span>';
+    if (n === 9) return '<span class="bg-red-100 text-red-800 px-2 py-0.5 rounded text-xs">❌ Anulado</span>';
+    return '<span class="bg-stone-100 text-stone-600 px-2 py-0.5 rounded text-xs">—</span>';
+  }
+
+  async function loadVales() {
+    if (!window.sb) return;
+    var estado = $$('vp_estado_pipeline');
+    if (estado) estado.textContent = 'Cargando...';
+
+    try {
+      var sucP = sb.schema('panel').from('v_pesajes_resumen_sucursal').select('*');
+      var pagarP = sb.schema('panel').from('v_cuentas_pagar_generadores').select('*').limit(500);
+      var recientesP = sb.schema('curated').from('vales_portal_externo').select('folio,fecha,sucursal,razon_social,tipo_servicio,peso_final,total_vale,saldo_vale,estado').order('fecha', { ascending: false }).order('folio', { ascending: false }).limit(50);
+
+      var [sucR, pagarR, recR] = await Promise.all([sucP, pagarP, recientesP]);
+
+      if (sucR.error) throw sucR.error;
+      if (pagarR.error) throw pagarR.error;
+      if (recR.error) throw recR.error;
+
+      var sucRows = sucR.data || [];
+      _vpPagar = pagarR.data || [];
+      var recRows = recR.data || [];
+
+      var totalVales = sucRows.reduce(function (a, r) { return a + (Number(r.vales) || 0); }, 0);
+      var totalSaldo = _vpPagar.reduce(function (a, r) { return a + (Number(r.saldo_clp) || 0); }, 0);
+      var ultimoVale = sucRows.reduce(function (max, r) {
+        if (!r.ultimo_vale) return max;
+        if (!max || new Date(r.ultimo_vale) > new Date(max)) return r.ultimo_vale;
+        return max;
+      }, null);
+
+      if ($$('vp_kpi_vales')) $$('vp_kpi_vales').textContent = totalVales.toLocaleString('es-CL');
+      if ($$('vp_kpi_saldo')) $$('vp_kpi_saldo').textContent = fmtCLP(totalSaldo);
+      if ($$('vp_kpi_clientes')) $$('vp_kpi_clientes').textContent = _vpPagar.length.toLocaleString('es-CL');
+      if ($$('vp_kpi_ultimo')) $$('vp_kpi_ultimo').textContent = fmtFecha(ultimoVale);
+
+      if (totalVales === 0) {
+        $$('vp_banner_sin_datos')?.classList.remove('hidden');
+      } else {
+        $$('vp_banner_sin_datos')?.classList.add('hidden');
+      }
+
+      var sucBody = $$('vp_sucursal_body');
+      if (sucBody) {
+        if (sucRows.length === 0) {
+          sucBody.innerHTML = '<tr><td colspan="7" class="text-center text-stone-400 py-4">Sin datos · pipeline aún sin ejecutar</td></tr>';
+        } else {
+          sucBody.innerHTML = sucRows.map(function (r) {
+            return '<tr class="border-t border-stone-100 hover:bg-stone-50">' +
+              '<td class="px-3 py-2 font-semibold">' + esc(r.sucursal) + '</td>' +
+              '<td class="text-right px-3 py-2">' + (Number(r.vales) || 0).toLocaleString('es-CL') + '</td>' +
+              '<td class="text-right px-3 py-2">' + (Number(r.clientes_unicos) || 0).toLocaleString('es-CL') + '</td>' +
+              '<td class="text-right px-3 py-2">' + fmtKg(r.kg_total) + '</td>' +
+              '<td class="text-right px-3 py-2">' + fmtCLP(r.clp_total) + '</td>' +
+              '<td class="text-right px-3 py-2 text-emerald-700 font-semibold">' + fmtCLP(r.saldo_pendiente_clp) + '</td>' +
+              '<td class="text-right px-3 py-2 text-xs text-stone-500">' + fmtFecha(r.ultimo_vale) + '</td>' +
+              '</tr>';
+          }).join('');
+        }
+      }
+
+      renderPagar();
+
+      var recBody = $$('vp_recientes_body');
+      if (recBody) {
+        if (recRows.length === 0) {
+          recBody.innerHTML = '<tr><td colspan="9" class="text-center text-stone-400 py-4">Sin vales · cargá la clave portal para que la EF arranque</td></tr>';
+        } else {
+          recBody.innerHTML = recRows.map(function (r) {
+            return '<tr class="border-t border-stone-100 hover:bg-stone-50">' +
+              '<td class="px-3 py-2 font-mono text-xs">' + esc(r.folio) + '</td>' +
+              '<td class="px-3 py-2 text-xs">' + fmtFecha(r.fecha) + '</td>' +
+              '<td class="px-3 py-2 text-xs">' + esc(r.sucursal || '—') + '</td>' +
+              '<td class="px-3 py-2">' + esc(r.razon_social || '—') + '</td>' +
+              '<td class="px-3 py-2 text-xs">' + esc(r.tipo_servicio || '—') + '</td>' +
+              '<td class="text-right px-3 py-2">' + fmtKg(r.peso_final) + '</td>' +
+              '<td class="text-right px-3 py-2">' + fmtCLP(r.total_vale) + '</td>' +
+              '<td class="text-right px-3 py-2 font-semibold ' + (Number(r.saldo_vale) > 0 ? 'text-emerald-700' : 'text-stone-400') + '">' + fmtCLP(r.saldo_vale) + '</td>' +
+              '<td class="px-3 py-2">' + badgeEstadoVale(r.estado) + '</td>' +
+              '</tr>';
+          }).join('');
+        }
+      }
+
+      if (estado) estado.textContent = 'Última carga ' + new Date().toLocaleTimeString('es-CL');
+    } catch (e) {
+      if (estado) estado.textContent = 'Error: ' + (e && e.message ? e.message : e);
+      console.error('[vales_portal] error:', e);
+    }
+  }
+
+  function renderPagar() {
+    var body = $$('vp_pagar_body');
+    if (!body) return;
+    var filtro = ($$('vp_filtro_generador')?.value || '').toLowerCase().trim();
+    var rows = _vpPagar;
+    if (filtro) {
+      rows = rows.filter(function (r) {
+        return (r.razon_social || '').toLowerCase().includes(filtro) ||
+               String(r.rut || '').toLowerCase().includes(filtro);
+      });
+    }
+    if (rows.length === 0) {
+      body.innerHTML = '<tr><td colspan="6" class="text-center text-stone-400 py-4">' + (filtro ? 'Sin coincidencias' : 'Sin saldos pendientes') + '</td></tr>';
+      return;
+    }
+    body.innerHTML = rows.slice(0, 200).map(function (r) {
+      return '<tr class="border-t border-stone-100 hover:bg-stone-50">' +
+        '<td class="px-3 py-2 font-semibold">' + esc(r.razon_social || '—') + '</td>' +
+        '<td class="px-3 py-2 font-mono text-xs">' + esc(r.rut ? r.rut + (r.dv ? '-' + r.dv : '') : '—') + '</td>' +
+        '<td class="px-3 py-2 text-xs">' + esc(r.banco || '—') + '</td>' +
+        '<td class="text-right px-3 py-2">' + (Number(r.vales_pendientes) || 0).toLocaleString('es-CL') + '</td>' +
+        '<td class="text-right px-3 py-2 text-emerald-700 font-semibold">' + fmtCLP(r.saldo_clp) + '</td>' +
+        '<td class="px-3 py-2 text-xs text-stone-500">' + fmtFecha(r.ultimo_vale) + '</td>' +
+        '</tr>';
+    }).join('');
+  }
+
+  function init() {
+    document.querySelector('button[data-tab="vales_portal"]')?.addEventListener('click', function () { setTimeout(loadVales, 100); });
+    document.querySelector('a[data-v4-tab="vales_portal"]')?.addEventListener('click', function () { setTimeout(loadVales, 100); });
+    $$('vp_refresh')?.addEventListener('click', loadVales);
+    $$('vp_filtro_generador')?.addEventListener('input', renderPagar);
   }
   if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init); else init();
 })();

--- a/public/panel-rdo.html
+++ b/public/panel-rdo.html
@@ -15110,6 +15110,21 @@ document.addEventListener('DOMContentLoaded', () => {
     } catch (_) {}
     return '';
   }
+  // Vista CEO · 08-jun · si admin → ve todas las obligaciones del equipo (no solo las suyas).
+  // Cubre el caso: Jair ve sus 40 obligaciones pero Dusan (gerencia@) veía vacío.
+  function _esAdminCEO() {
+    try {
+      var rf = JSON.parse(localStorage.getItem('rf_session') || '{}');
+      var perfil = String(rf.perfil || rf.rol || '').toLowerCase();
+      if (perfil === 'admin' || perfil === 'ceo' || perfil === 'gerencia') return true;
+      if (String(rf.email || '').toLowerCase() === 'gerencia@gestionrepchile.cl') return true;
+    } catch (_) {}
+    return String(_sessionEmail || '').toLowerCase() === 'gerencia@gestionrepchile.cl';
+  }
+  function _esMia(r) {
+    if (_esAdminCEO()) return true;
+    return !!(r.responsable_email && String(r.responsable_email).toLowerCase() === _sessionEmail);
+  }
   function badgeEstado(estado) {
     var map = {
       pendiente: { cls: 'bg-amber-100 text-amber-800', emoji: '🟡' },
@@ -15152,7 +15167,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (!box || !listaMis) return;
     if (!_sessionEmail) { box.classList.add('hidden'); return; }
     var mias = _cumpRows.filter(function (r) {
-      return r.responsable_email && String(r.responsable_email).toLowerCase() === _sessionEmail
+      return _esMia(r)
              && r.estado !== 'cumplida' && r.estado !== 'no_aplica';
     });
     if (!mias.length) { box.classList.add('hidden'); return; }
@@ -15321,10 +15336,10 @@ document.addEventListener('DOMContentLoaded', () => {
       try {
         var rowDone = (_cumpRows || []).find(function (r) { return String(r.id) === String(obligacionId); }) || {};
         var nTotal = (_cumpRows || []).filter(function (r) {
-          return r.responsable_email && String(r.responsable_email).toLowerCase() === _sessionEmail;
+          return _esMia(r);
         }).length;
         var nConArchivos = (_cumpRows || []).filter(function (r) {
-          return r.responsable_email && String(r.responsable_email).toLowerCase() === _sessionEmail
+          return _esMia(r)
                  && (_archivosCache[r.id] || []).length > 0;
         }).length;
         var faltan = Math.max(0, nTotal - nConArchivos);
@@ -15453,7 +15468,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (avEl) avEl.textContent = _permisologiaNombreCorto();
 
         var mias = (_cumpRows || []).filter(function (r) {
-          return r.responsable_email && String(r.responsable_email).toLowerCase() === _sessionEmail
+          return _esMia(r)
                  && r.estado !== 'cumplida' && r.estado !== 'no_aplica';
         });
 
@@ -15473,7 +15488,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
         // Barra progreso
         var total = mias.length + (_cumpRows || []).filter(function (r) {
-          return r.responsable_email && String(r.responsable_email).toLowerCase() === _sessionEmail && r.estado === 'cumplida';
+          return _esMia(r) && r.estado === 'cumplida';
         }).length;
         var hechas = total - mias.length;
         if (total > 0) {

--- a/public/supervision-jair.html
+++ b/public/supervision-jair.html
@@ -1,0 +1,161 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Supervisión Jair · Dusan + Cesar + Dyana · Reciclean-Farex</title>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap" rel="stylesheet">
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+<style>
+:root{--primary:#059669;--dark:#064e3b;--bg:#f3f4f6;--text:#111827;--muted:#6b7280;--border:#e5e7eb;--amber:#d97706;--red:#dc2626;--blue:#2563eb}
+*{box-sizing:border-box}
+body{font-family:'Inter',sans-serif;margin:0;background:var(--bg);color:var(--text);line-height:1.5}
+.bar{background:#111827;color:#fff;padding:14px 24px;display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:12px;position:sticky;top:0;z-index:10}
+.bar h1{margin:0;font-size:16px;font-weight:800}
+.bar .sub{font-size:12px;color:#9ca3af}
+.bar button{background:#059669;color:#fff;border:none;padding:8px 14px;border-radius:6px;cursor:pointer;font-weight:600;font-size:13px}
+.bar button.secondary{background:transparent;border:1px solid #4b5563}
+.cont{max-width:1280px;margin:0 auto;padding:24px}
+
+.kpis{display:grid;grid-template-columns:repeat(5,1fr);gap:12px;margin-bottom:24px}
+.kpi{background:#fff;border:1px solid var(--border);border-radius:10px;padding:16px;text-align:center}
+.kpi .n{font-size:30px;font-weight:900;color:var(--dark);line-height:1}
+.kpi .lbl{font-size:11px;color:var(--muted);text-transform:uppercase;letter-spacing:.06em;margin-top:6px}
+.kpi.rojo .n{color:var(--red)}.kpi.amarillo .n{color:var(--amber)}.kpi.verde .n{color:#10b981}
+
+.grid{display:grid;grid-template-columns:1.5fr 1fr;gap:24px;margin-bottom:24px}
+.box{background:#fff;border:1px solid var(--border);border-radius:12px;overflow:hidden}
+.box h3{margin:0;padding:14px 20px;background:#f9fafb;border-bottom:1px solid var(--border);font-size:14px;font-weight:700;color:var(--dark);display:flex;justify-content:space-between;align-items:center}
+.box h3 .count{font-size:11px;background:#e5e7eb;color:#374151;padding:3px 10px;border-radius:10px}
+
+table{width:100%;border-collapse:collapse;font-size:13px}
+th{text-align:left;padding:10px 14px;background:#f9fafb;border-bottom:1px solid var(--border);font-size:10px;color:var(--muted);font-weight:700;text-transform:uppercase;letter-spacing:.06em}
+td{padding:10px 14px;border-bottom:1px solid var(--border);vertical-align:top}
+tr:last-child td{border-bottom:none}
+.pill{display:inline-block;padding:2px 8px;border-radius:10px;font-size:11px;font-weight:700}
+.pill.rojo{background:#fee2e2;color:#991b1b}.pill.amarillo{background:#fef3c7;color:#92400e}.pill.ok{background:#d1fae5;color:#065f46}.pill.gris{background:#e5e7eb;color:#6b7280}
+.bit-tipo{display:inline-block;font-size:10px;font-weight:700;padding:2px 7px;border-radius:4px;margin-right:6px;text-transform:uppercase}
+.bit-tipo.whatsapp{background:#25d366;color:#fff}.bit-tipo.correo{background:#2563eb;color:#fff}.bit-tipo.llamada{background:#7c3aed;color:#fff}.bit-tipo.visita{background:#ea580c;color:#fff}.bit-tipo.nota{background:#6b7280;color:#fff}.bit-tipo.reunion{background:#0891b2;color:#fff}.bit-tipo.solicitud_interna{background:#be185d;color:#fff}.bit-tipo.respuesta_autoridad{background:#064e3b;color:#fff}.bit-tipo.otro{background:#94a3b8;color:#fff}
+.timeline-item{padding:12px 16px;border-bottom:1px solid var(--border);font-size:12px}
+.timeline-item:last-child{border-bottom:none}
+.timeline-item .head{display:flex;justify-content:space-between;align-items:center;margin-bottom:4px}
+.timeline-item .meta{color:var(--muted);font-size:11px;margin-top:4px}
+.loading{padding:40px;text-align:center;color:var(--muted)}
+.error{padding:16px;background:#fee2e2;color:#991b1b;border-radius:8px;margin:16px;font-size:13px}
+.empty{padding:30px;text-align:center;color:var(--muted);font-style:italic;font-size:13px}
+.por-suc{display:grid;grid-template-columns:repeat(4,1fr);gap:10px;padding:14px}
+.suc-card{background:#f9fafb;padding:12px;border-radius:8px;text-align:center;border:1px solid var(--border)}
+.suc-card .n{font-size:22px;font-weight:800;color:var(--dark);line-height:1}
+.suc-card .lbl{font-size:11px;color:var(--muted);margin-top:4px;text-transform:capitalize}
+.titulo-tarea{font-weight:600;color:var(--text)}
+.descr-tarea{color:var(--muted);font-size:11px;margin-top:2px}
+@media (max-width:900px){.grid{grid-template-columns:1fr}.kpis{grid-template-columns:repeat(2,1fr)}.por-suc{grid-template-columns:repeat(2,1fr)}}
+</style>
+</head>
+<body>
+<div class="bar">
+  <div>
+    <h1>👁️ Supervisión Jair</h1>
+    <div class="sub">Vista compartida · Dusan + Cesar + Dyana</div>
+  </div>
+  <div>
+    <button class="secondary" onclick="window.location.href='/panel-rdo.html'">← Panel</button>
+    <button class="secondary" onclick="window.location.href='/expedientes/'">📂 Expedientes</button>
+    <button onclick="cargar()">🔄 Refrescar</button>
+  </div>
+</div>
+
+<div class="cont">
+  <div class="kpis">
+    <div class="kpi"><div class="n" id="k-total">—</div><div class="lbl">Pendientes</div></div>
+    <div class="kpi rojo"><div class="n" id="k-venc">—</div><div class="lbl">Vencidas</div></div>
+    <div class="kpi amarillo"><div class="n" id="k-sing">—</div><div class="lbl">Sin gestión 3+ días</div></div>
+    <div class="kpi verde"><div class="n" id="k-cerr">—</div><div class="lbl">Cerradas 7d</div></div>
+    <div class="kpi"><div class="n" id="k-gest">—</div><div class="lbl">Gestiones 7d</div></div>
+  </div>
+
+  <div class="box" style="margin-bottom:24px">
+    <h3>🏭 Distribución por sucursal</h3>
+    <div class="por-suc" id="por-suc"><div class="loading">...</div></div>
+  </div>
+
+  <div class="grid">
+    <div class="box">
+      <h3>⚠️ Tareas trabadas <span class="count" id="cnt-trab">—</span></h3>
+      <div id="trabadas"><div class="loading">Cargando...</div></div>
+    </div>
+    <div class="box">
+      <h3>💬 Últimas gestiones de Jair <span class="count" id="cnt-tl">—</span></h3>
+      <div id="timeline"><div class="loading">Cargando...</div></div>
+    </div>
+  </div>
+</div>
+
+<script>
+const SUPABASE_URL='https://eknmtsrtfkzroxnovfqn.supabase.co';
+const SUPABASE_ANON='eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImVrbm10c3J0Zmt6cm94bm92ZnFuIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzU0MDY2ODgsImV4cCI6MjA5MDk4MjY4OH0.8Y4N0lw3DFN3Y8-R6ID7t_LAfgHWDM5N-oa4Ji9bncg';
+const sb=supabase.createClient(SUPABASE_URL,SUPABASE_ANON);
+
+function esc(s){return String(s==null?'':s).replace(/[&<>"']/g,c=>({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;"}[c]));}
+function fmtFecha(d){if(!d)return '—';try{return new Date(d).toLocaleString('es-CL',{day:'2-digit',month:'short',hour:'2-digit',minute:'2-digit'});}catch(_){return String(d);}}
+function fmtDia(d){if(!d)return '—';try{return new Date(d).toLocaleDateString('es-CL');}catch(_){return String(d);}}
+function fmtAgo(d){if(!d)return 'nunca';const ms=Date.now()-new Date(d).getTime();const h=Math.floor(ms/3600000);if(h<1)return 'hace minutos';if(h<24)return 'hace '+h+'h';return 'hace '+Math.floor(h/24)+'d';}
+
+async function cargar(){
+  try{
+    const {data,error}=await sb.schema('panel').rpc('supervision_jair');
+    if(error) throw error;
+    const k=data.kpis||{};
+    document.getElementById('k-total').textContent=k.tareas_totales||0;
+    document.getElementById('k-venc').textContent=k.vencidas||0;
+    document.getElementById('k-sing').textContent=k.sin_gestiones_3d||0;
+    document.getElementById('k-cerr').textContent=k.cerradas_7d||0;
+    document.getElementById('k-gest').textContent=k.gestiones_7d||0;
+    renderPorSuc(data.por_sucursal||[]);
+    renderTrabadas(data.trabadas||[]);
+    renderTimeline(data.timeline_reciente||[]);
+  }catch(e){
+    document.body.insertAdjacentHTML('beforeend','<div class="error">'+esc(e.message||JSON.stringify(e))+'</div>');
+  }
+}
+
+function renderPorSuc(arr){
+  if(!arr.length){document.getElementById('por-suc').innerHTML='<div class="empty" style="grid-column:1/-1">Sin datos</div>';return;}
+  document.getElementById('por-suc').innerHTML=arr.map(s =>
+    '<div class="suc-card"><div class="n">'+s.pendientes+'</div><div class="lbl">'+esc(s.sucursal)+'</div></div>'
+  ).join('');
+}
+
+function renderTrabadas(arr){
+  document.getElementById('cnt-trab').textContent=arr.length;
+  if(!arr.length){document.getElementById('trabadas').innerHTML='<div class="empty">Todo fluye · ningún cuello de botella detectado</div>';return;}
+  const rows=arr.map(t=>{
+    const dias=t.dias_vencida;
+    const cls=dias!==null && dias>0 ? 'rojo' : (t.ultima_gestion ? 'amarillo' : 'gris');
+    const txt=dias!==null && dias>0 ? 'Vencida '+dias+'d' : (t.ultima_gestion ? 'Sin gestión '+fmtAgo(t.ultima_gestion) : 'Sin gestiones');
+    return '<tr>'
+      +'<td><div class="titulo-tarea">'+esc(t.titulo||'(sin título)')+'</div><div class="descr-tarea">'+esc(t.sucursal)+' · '+esc(t.ley)+' · a '+esc(t.origen_destinatario||'—')+'</div></td>'
+      +'<td><span class="pill '+cls+'">'+txt+'</span></td>'
+      +'<td>'+fmtDia(t.fecha_meta)+'</td>'
+      +'</tr>';
+  }).join('');
+  document.getElementById('trabadas').innerHTML='<table><thead><tr><th>Tarea</th><th>Estado</th><th>Plazo</th></tr></thead><tbody>'+rows+'</tbody></table>';
+}
+
+function renderTimeline(arr){
+  document.getElementById('cnt-tl').textContent=arr.length;
+  if(!arr.length){document.getElementById('timeline').innerHTML='<div class="empty">Sin gestiones registradas todavía. Cuando Jair use /mi-cola aparecen acá.</div>';return;}
+  document.getElementById('timeline').innerHTML=arr.map(b => ''
+    +'<div class="timeline-item">'
+    +'  <div class="head"><div><span class="bit-tipo '+esc(b.tipo_canal)+'">'+esc(b.tipo_canal)+'</span><strong>'+esc(b.titulo||'(sin título)')+'</strong></div><span class="meta">'+fmtFecha(b.cuando)+'</span></div>'
+    +'  <div>'+esc(b.texto)+'</div>'
+    +'  <div class="meta">'+esc(b.sucursal||'—')+' · '+esc(b.ley||'—')+(b.destinatario?' · a '+esc(b.destinatario):'')+'</div>'
+    +'</div>'
+  ).join('');
+}
+
+cargar();
+setInterval(cargar, 60000);
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Resumen

**Sistema de expedientes completo para Permisología** · matriz 4 sucursales × 5 tipos + gobernanza con bitácora de gestiones.

### BD (5 migraciones aplicadas en prod)
- mig 250 · panel.cumplim_evidencia_tareas + panel.expedientes
- mig 251 · RPC panel.expediente_get (SECURITY DEFINER, anon ok)
- mig 252 · panel.cumplim_evidencia_bitacora + RPC bitacora_registrar
- mig 253 · RPC panel.expedientes_listar
- + reclasificación de 40 obligaciones por familia legal real (12 continuos a silos nuevos, 28 trámites a expediente correcto)

### Frontend
- public/panel-rdo.html · vista CEO (admin ve todas las obligaciones, no solo las suyas)
- public/expedientes/expediente.html · expediente imprimible con mesa de control + bitácora + modal agregar gestión + auth check
- public/expedientes/index.html · navegador 20 expedientes con KPIs + filtros + semáforo

### Estado datos
- 20 expedientes activos · 8 con docs (talca-def 7 · talca-prov 1 · 4 sanitarias × 5 · 1 transporte × 5 · 1 calif × 3)
- 12 expedientes vacíos esperando info del equipo
- 50 tareas activas (D1-D7 Talca + reclasificación)
- Puerto Montt marcada NO operativa
- Test smoke RPC anon OK: expediente_get retorna data completa con joins

## Test plan
- [ ] Index navegable carga 20 expedientes con KPIs
- [ ] Click en fila abre expediente detalle
- [ ] Mesa de control con click navegable a puntos
- [ ] Sin login: banner "iniciá sesión" reemplaza botón Agregar gestión
- [ ] Con login: modal Agregar gestión + upload imagen WhatsApp + bitácora la muestra
- [ ] Imprimir todo genera PDF en 1 acto
- [ ] Vista CEO panel-rdo.html muestra todas las obligaciones del equipo (no solo gerencia@)

🤖 Generated with [Claude Code](https://claude.com/claude-code)