### PR TITLE
fix(a11y): tarjetas onclick navegables por teclado (Enter/Espacio)

### DIFF
--- a/public/panel-rdo.html
+++ b/public/panel-rdo.html
@@ -9255,6 +9255,8 @@ function oppRenderCard(o) {
   const crmDot = esCrm ? '<span title="CRM Impulsa" class="inline-block w-2 h-2 rounded-full bg-purple-400 mr-1"></span>' : '';
   return `
     <div onclick="oppAbrirDrawer('${escapeHtml(o.oportunidad_id)}')"
+         role="button" tabindex="0"
+         onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}"
          draggable="true"
          ondragstart="oppDragStart(event,'${escapeHtml(o.oportunidad_id)}','${escapeHtml(o.origen || '')}')"
          data-entity-type="oportunidad" data-entity-id="${escapeHtml(o.oportunidad_id)}" data-entity-nombre="${escapeHtml(o.titulo || '')}"
@@ -13843,7 +13845,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const preguntasHtml = abierto ? `<div class="p26-preguntas">${g.preguntas.map(renderPregunta).join('')}</div>` : '';
       return `
         <div class="p26-bloque" data-bloque="${num}">
-          <div class="p26-bloque-header" onclick="plan2026ToggleBloque(${num})">
+          <div class="p26-bloque-header" role="button" tabindex="0" onclick="plan2026ToggleBloque(${num})" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}">
             <div class="flex items-center gap-2">
               <span class="text-stone-400">${chevron}</span>
               <span class="font-semibold text-stone-700">Bloque ${num}: ${esc(g.nombre)}</span>
@@ -13864,7 +13866,7 @@ document.addEventListener('DOMContentLoaded', () => {
       : '<span class="p26-badge-pendiente">PENDIENTE</span>';
     const corta = (r.pregunta || '').slice(0, 90) + ((r.pregunta || '').length > 90 ? '…' : '');
     return `
-      <div class="p26-pregunta" onclick="plan2026AbrirModal(${r.id})">
+      <div class="p26-pregunta" role="button" tabindex="0" onclick="plan2026AbrirModal(${r.id})" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}">
         ${badge}
         <div class="flex-1 text-sm text-stone-700">
           <div><span class="font-semibold">#${r.id}.</span> ${esc(corta)}</div>


### PR DESCRIPTION
## Qué

3 tarjetas del panel que abrían solo con click ahora funcionan también con teclado (Enter / Espacio):

- `oppRenderCard` — tarjeta de oportunidad (kanban Negocios) · línea ~9257
- `p26-bloque-header` — header colapsable Plan 2026 · línea ~13846
- `p26-pregunta` — pregunta Plan 2026 · línea ~13867

Fix: `role="button"` + `tabindex="0"` + `onkeydown` que reusa el `onclick` existente vía `this.click()`. Cero cambio de lógica.

## Por qué (eje funcional · R-AUD-070)

Hallazgo de la revisión contra **Web Interface Guidelines** (Vercel). Quien navega sin mouse (lectores de pantalla, teclado) no podía abrir el detalle de un negocio ni los bloques del Plan 2026 — quedaba afuera. Es el único hallazgo de la revisión que **bloqueaba uso real**.

## No agregar errores (eje 2 · R-AUD-070)

- ✅ Parse check canónico **R-AUD-064**: `node scripts/js-parse-check.mjs` → 39 scripts OK en panel-rdo.html.
- ✅ Cambio puramente aditivo (4 inserciones, 2 modificaciones de línea). No remueve ni altera comportamiento de mouse/drag existente.
- ✅ `draggable`/`ondragstart` de la tarjeta de oportunidad intactos.

## Robusto y sostenible (eje 3 · R-AUD-070)

- `this.click()` reusa el handler único existente → no duplica lógica, no se desincroniza si cambia el onclick.
- `preventDefault()` en Espacio evita scroll accidental.
- Patrón replicable para futuros `<div onclick>`.

## Pendiente del revisor

Smoke manual recomendado tras merge: Tab hasta una tarjeta de oportunidad → Enter abre el drawer → Espacio en header Plan 2026 colapsa/expande.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
