### PR TITLE
promote/main-to-prod 11-jun PM: bandejas Andrea + Decisor + PDFs + BUG#5 + Vista simulada

### DIFF
--- a/public/js/page-logger.js
+++ b/public/js/page-logger.js
@@ -10,7 +10,18 @@
     return null;
   }
 
+  // BUG#5 fix 11-jun PC2: si no hay user resuelto, NO disparamos el POST a curated.page_logs.
+  // El insert con usuario_id=null violaba constraint NOT NULL → 400 → supabase-js degrada
+  // la conexión HTTP/2 pool y aborta signinWithPassword con ERR_ABORTED.
+  // Política: log solo cuando hay user. Si no hay, encolamos y reintentamos post-login.
+  var _pending = [];
   function log(evento, seccion, metadata) {
+    var user = resolveUser();
+    if (!user) {
+      // Encolar para retry post-login (max 20 items para evitar memory leak)
+      if (_pending.length < 20) _pending.push({ evento: evento, seccion: seccion, metadata: metadata });
+      return;
+    }
     fetch(SUPA + '/rest/v1/page_logs', {
       method: 'POST',
       headers: {
@@ -23,7 +34,7 @@
       body: JSON.stringify({
         pagina: window.location.pathname,
         seccion: seccion || null,
-        usuario_id: resolveUser(),
+        usuario_id: user,
         evento: evento || 'pageview',
         metadata: metadata || null
       }),
@@ -31,8 +42,17 @@
     }).catch(function () {});
   }
 
-  window.pageLog = log;
+  function flushPending() {
+    if (!resolveUser() || _pending.length === 0) return;
+    var items = _pending.splice(0);
+    items.forEach(function (it) { log(it.evento, it.seccion, it.metadata); });
+  }
 
+  window.pageLog = log;
+  window.pageLogFlushPending = flushPending;
+
+  // pageview en DOMContentLoaded: solo si ya hay user resuelto (sesión persistente).
+  // Si es first-login, log('login') desde hydrateSessionAndEnter llamará flushPending.
   document.addEventListener('DOMContentLoaded', function () { log('pageview'); });
 
   window.addEventListener('error', function (e) {

--- a/public/panel-rdo.html
+++ b/public/panel-rdo.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- redeploy 2026-06-11 15:25 CLT · force Vercel CDN purge tras PR #273 + #274 -->
 <html lang="es-CL">
 <head>
   <meta charset="UTF-8">

--- a/public/panel-rdo.html
+++ b/public/panel-rdo.html
@@ -987,6 +987,17 @@
           <option value="">Cargando…</option>
         </select>
       </div>
+      <!-- PC2 11-jun PM · "Ver como X" cosmético admin/dusan -->
+      <div id="vistaSimContainer" class="hidden items-center gap-2">
+        <label class="text-sm text-stone-600 font-medium" title="Vista cosmética: cambia qué tabs y orden se ven, NO cambia datos ni RLS">Ver como:</label>
+        <select id="vistaSimSelector" class="border border-amber-400 rounded px-2 py-1 text-sm focus:border-amber-600 focus:outline-none bg-amber-50">
+          <option value="">— Mi vista —</option>
+          <option value="andrea">👩 Andrea (comercial · silo 01)</option>
+          <option value="jair">👨 Jair (admin · silo 05)</option>
+          <option value="ingrid">👩 Ingrid (admin · silo 02)</option>
+          <option value="operaciones">🛠️ Operaciones (operaciones · silo 06)</option>
+        </select>
+      </div>
       <!-- Iconos externos (Gmail / Outlook / WhatsApp) -->
       <a href="https://mail.google.com" target="_blank" rel="noopener" class="hidden md:inline-flex p-2 rounded-lg text-slate-500 hover:bg-slate-100 hover:text-slate-700 transition" title="Gmail" aria-label="Abrir Gmail">
         <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>
@@ -1018,6 +1029,12 @@
   <div id="newAudioNotification" class="hidden bg-amber-50 border-l-4 border-amber-500 p-3 mx-6 mt-4 rounded">
     🎙️ <span class="font-semibold">Nuevo mensaje de Dusan sin escuchar.</span>
     <a href="#" onclick="document.querySelector('button[data-tab=comunicados]').click(); return false;" class="underline text-amber-800 ml-2">Escuchar ahora</a>
+  </div>
+
+  <!-- PC2 11-jun PM · Banner vista simulada (admin) -->
+  <div id="vistaSimBanner" class="hidden bg-amber-100 border-l-4 border-amber-500 p-2 mx-6 mt-2 rounded text-sm flex items-center justify-between">
+    <span>🎭 <strong>Vista cosmética como <span id="vistaSimNombre">…</span></strong> · Los tabs y orden son los de este usuario · Los datos siguen siendo los tuyos (RLS no cambia).</span>
+    <button onclick="restaurarMiVista()" class="text-xs px-3 py-1 bg-amber-600 hover:bg-amber-700 text-white rounded">Volver a mi vista</button>
   </div>
 
   <!-- F6 Transparencia Datos · pie fijo con metadata de la tab activa (R-AUD-frescura) -->
@@ -3394,6 +3411,9 @@
                 </div>
                 <div id="cotClienteSugerencias" role="listbox" aria-label="Sugerencias de clientes"
                      class="hidden border border-stone-200 rounded mt-1 bg-white shadow-md z-10 max-h-40 overflow-y-auto"></div>
+                <button type="button" id="cotClienteCrearBtn" onclick="cotAbrirCrearCliente()" class="hidden mt-1 text-xs px-2 py-1 bg-emerald-50 hover:bg-emerald-100 border border-emerald-300 text-emerald-800 rounded">
+                  + Crear nuevo cliente con este nombre
+                </button>
                 <input type="hidden" id="cotClienteId">
                 <span id="cotClienteSeleccionado" class="text-xs text-green-700 font-semibold mt-1 block" aria-live="polite"></span>
               </div>
@@ -5466,6 +5486,7 @@ async function hydrateSessionAndEnter(authUser) {
   await loadConfigPanel();     // carga "cajas" de configuración (refactor 08-may)
   await loadSilos();           // carga silos visibles + monta selector
   applySiloTabs();             // filtra pestañas según silo + perfil
+  if (typeof window.setupVistaSimulada === 'function') window.setupVistaSimulada();
   loadAccesoRapido();          // tarjeta de acceso al ecosistema externo
   loadAudios();
   loadPortadaAudio();
@@ -5856,6 +5877,85 @@ function applySiloTabs() {
     document.querySelector('button[data-tab="portada"]').click();
   }
 }
+
+// PC2 11-jun PM · Vista simulada "Ver como X" (cosmética, admin/dusan only)
+// Cambia currentProfile + currentSilo en memoria + re-aplica applySiloTabs.
+// NO toca JWT ni RLS. Útil para ensayar guion + soporte UX.
+const VISTAS_SIMULADAS = {
+  andrea:      { perfil: 'comercial',  silo: '01', nombre: 'Andrea Rivera (Comercial)' },
+  jair:        { perfil: 'admin',      silo: '05', nombre: 'Jair Sanmartín (Cumplimiento)' },
+  ingrid:      { perfil: 'admin',      silo: '02', nombre: 'Ingrid Cancino (Talca)' },
+  operaciones: { perfil: 'operaciones',silo: '06', nombre: 'Operaciones (genérico)' },
+};
+window._vistaSimOriginal = null;
+
+window.setupVistaSimulada = function() {
+  // Mostrar selector solo si perfil real es admin o dusan
+  // También espejar profile/silo a window para que tests/extras puedan leerlos
+  window.currentProfile = currentProfile;
+  window.currentSilo = currentSilo;
+  const cont = document.getElementById('vistaSimContainer');
+  if (!cont) return;
+  if (currentProfile === 'admin' || currentProfile === 'dusan') {
+    cont.classList.remove('hidden');
+    cont.classList.add('flex');
+  } else {
+    cont.classList.add('hidden');
+    cont.classList.remove('flex');
+  }
+};
+
+window.cambiarVistaSimulada = function(presetKey) {
+  if (!presetKey) { restaurarMiVista(); return; }
+  const preset = VISTAS_SIMULADAS[presetKey];
+  if (!preset) return;
+  // Guardar originales (solo la primera vez para no perderlos)
+  if (!_vistaSimOriginal) {
+    _vistaSimOriginal = { perfil: currentProfile, silo: currentSilo, user: currentUser };
+  }
+  currentProfile = preset.perfil;
+  currentSilo = preset.silo;
+  // Espejo a window para que consumidores externos puedan leer
+  window.currentProfile = currentProfile;
+  window.currentSilo = currentSilo;
+  // Re-aplicar visibilidad de tabs
+  if (typeof applySiloTabs === 'function') applySiloTabs();
+  // Banner
+  const banner = document.getElementById('vistaSimBanner');
+  const nombreEl = document.getElementById('vistaSimNombre');
+  if (banner && nombreEl) {
+    nombreEl.textContent = preset.nombre;
+    banner.classList.remove('hidden');
+  }
+  // Cambiar display de perfil en topbar
+  const profDisp = document.getElementById('userProfileDisplay');
+  if (profDisp) {
+    profDisp.textContent = preset.perfil + ' (sim)';
+    profDisp.classList.remove('bg-emerald-100','text-emerald-800');
+    profDisp.classList.add('bg-amber-100','text-amber-800');
+  }
+};
+
+window.restaurarMiVista = function() {
+  if (!_vistaSimOriginal) return;
+  currentProfile = _vistaSimOriginal.perfil;
+  currentSilo = _vistaSimOriginal.silo;
+  window.currentProfile = currentProfile;
+  window.currentSilo = currentSilo;
+  _vistaSimOriginal = null;
+  if (typeof applySiloTabs === 'function') applySiloTabs();
+  document.getElementById('vistaSimBanner')?.classList.add('hidden');
+  const sel = document.getElementById('vistaSimSelector');
+  if (sel) sel.value = '';
+  const profDisp = document.getElementById('userProfileDisplay');
+  if (profDisp) {
+    profDisp.textContent = currentProfile;
+    profDisp.classList.remove('bg-amber-100','text-amber-800');
+    profDisp.classList.add('bg-emerald-100','text-emerald-800');
+  }
+};
+
+document.getElementById('vistaSimSelector')?.addEventListener('change', e => cambiarVistaSimulada(e.target.value));
 
 window.logout = async function() {
   try { await sb.auth.signOut(); } catch(e) { console.warn('[Panel RDO] signOut error:', e); }
@@ -8893,13 +8993,30 @@ let _cotClienteTimer = null;
 async function buscarClienteCotizador(val) {
   clearTimeout(_cotClienteTimer);
   const sug = document.getElementById('cotClienteSugerencias');
-  if (val.trim().length < 2) { sug.classList.add('hidden'); return; }
+  const crearBtn = document.getElementById('cotClienteCrearBtn');
+  // Resetear: si el usuario edita después de seleccionar, limpiar cliente_id
+  const hidden = document.getElementById('cotClienteId');
+  if (hidden && hidden.value) {
+    hidden.value = '';
+    document.getElementById('cotClienteSeleccionado').textContent = '';
+    if (typeof cotRefrescarEditarClienteBtn === 'function') cotRefrescarEditarClienteBtn();
+  }
+  if (val.trim().length < 2) {
+    sug.classList.add('hidden');
+    if (crearBtn) crearBtn.classList.add('hidden');
+    return;
+  }
   _cotClienteTimer = setTimeout(async () => {
     const { data } = await sb.schema('curated').from('clientes')
       .select('cliente_id, razon_social, rut')
       .or(`razon_social.ilike.%${val}%,rut.ilike.%${val}%`)
       .eq('activo', true).limit(8);
-    if (!data || data.length === 0) { sug.classList.add('hidden'); return; }
+    if (!data || data.length === 0) {
+      sug.classList.add('hidden');
+      if (crearBtn) crearBtn.classList.remove('hidden');
+      return;
+    }
+    if (crearBtn) crearBtn.classList.add('hidden');
     sug.innerHTML = data.map(c =>
       `<div class="px-3 py-2 hover:bg-green-50 cursor-pointer text-sm border-b border-stone-100 last:border-0"
             onclick="seleccionarClienteCot('${escapeHtml(c.cliente_id)}','${escapeHtml(c.razon_social.replace(/'/g,"&#39;"))}')">
@@ -8910,6 +9027,34 @@ async function buscarClienteCotizador(val) {
     sug.classList.remove('hidden');
   }, 300);
 }
+
+// PC2 11-jun PM · cierre deuda DeepSeek post-merge #273
+// Abre modal Cartera (carAbrirEditar con id=null) con razón social prellenada.
+// Tras guardar exitoso, evento 'cliente:created' autoselecciona en Cotizador.
+window.cotAbrirCrearCliente = function() {
+  const txt = document.getElementById('cotClienteBuscar')?.value?.trim() || '';
+  // Si no existe el modal en este perfil, fallback a alert
+  if (typeof window.carAbrirCrear !== 'function') {
+    alert('El editor de cliente no está cargado. Probá desde la pestaña Cartera y volvé.');
+    return;
+  }
+  window._cotEsperandoClienteNuevo = true;
+  window.carAbrirCrear(txt);
+};
+
+// Escucha evento emitido tras crear cliente exitoso desde el modal de Cartera
+window.addEventListener('cliente:created', (e) => {
+  if (!window._cotEsperandoClienteNuevo) return;
+  window._cotEsperandoClienteNuevo = false;
+  const { cliente_id, razon_social } = e.detail || {};
+  if (!cliente_id) return;
+  // Autoseleccionar en Cotizador
+  if (typeof window.seleccionarClienteCot === 'function') {
+    window.seleccionarClienteCot(cliente_id, razon_social || '');
+  }
+  // Ocultar botón crear
+  document.getElementById('cotClienteCrearBtn')?.classList.add('hidden');
+});
 
 function seleccionarClienteCot(id, nombre) {
   document.getElementById('cotClienteId').value = id;
@@ -9622,6 +9767,34 @@ window.carCerrarEditar = function() {
   _cliEditando = null;
 };
 
+// PC2 11-jun PM · entry point para crear cliente desde otras pestañas (Cotizador)
+// Abre el modal vacío, con razón social opcionalmente prellenada.
+// El modal vive originalmente dentro de tabCartera (que está hidden cuando estamos en Cotizador).
+// Lo movemos al body para que el `position:fixed` no quede ocluido por parent display:none.
+window.carAbrirCrear = function(razonSocialPrefill) {
+  _cliEditando = null;
+  document.getElementById('clienteEditModalTitulo').textContent = 'Crear nuevo cliente';
+  document.getElementById('clienteEditMsg').classList.add('hidden');
+  // Limpiar todos los campos
+  ['cliRazonSocial','cliRut','cliSucursal','cliClientePara','cliSegmento','cliResponsable','cliTags',
+   'cliTelefono','cliEmail','cliDireccion','cliCiudad','cliRegion','cliSitioWeb','cliComentarios',
+   'cliFormaPago','cliServRetiro','cliServRetiroGratis','cliServContenedor','cliServCert',
+   'cliServCertFecha','cliServSegregacion','cliCobroFrecuencia','cliCobroMaterial','cliCondicionesPago',
+   'cliCompraDonacion','cliDetalleEnvio','cliBanco','cliTipoCuenta','cliNroCuenta'
+  ].forEach(id => { const el = document.getElementById(id); if (el) el.value = ''; });
+  const activo = document.getElementById('cliActivo'); if (activo) activo.value = 'true';
+  if (razonSocialPrefill) {
+    const rs = document.getElementById('cliRazonSocial');
+    if (rs) rs.value = razonSocialPrefill;
+  }
+  const modal = document.getElementById('clienteEditModal');
+  // Mover al body si todavía está dentro de tabCartera u otro container hidden
+  if (modal && modal.parentElement !== document.body) {
+    document.body.appendChild(modal);
+  }
+  modal.classList.remove('hidden');
+};
+
 window.carGuardarCliente = async function() {
   const razonSocial = document.getElementById('cliRazonSocial').value.trim();
   if (!razonSocial) {
@@ -9697,9 +9870,17 @@ window.carGuardarCliente = async function() {
   msg.className = 'text-sm text-green-700 bg-green-50 px-3 py-1.5 rounded';
   msg.classList.remove('hidden');
 
+  // PC2 11-jun PM · evento para otros consumidores (Cotizador autoselecciona)
+  const wasCreating = !_cliEditando;
+  const savedId = _cliEditando || payload.cliente_id;
+  const savedRazon = payload.razon_social;
+  if (wasCreating) {
+    window.dispatchEvent(new CustomEvent('cliente:created', { detail: { cliente_id: savedId, razon_social: savedRazon } }));
+  }
+
   setTimeout(() => {
     carCerrarEditar();
-    loadCartera();
+    if (typeof loadCartera === 'function') loadCartera();
   }, 1200);
 };
 

--- a/public/panel-rdo.html
+++ b/public/panel-rdo.html
@@ -677,6 +677,35 @@
             <span class="v4-emoji" aria-hidden="true">📅</span>
             Mis Visitas
           </a>
+          <!-- PC2 11-jun · Trio bandejas Cliente Único Andrea + Comex -->
+          <a href="#" data-v4-tab="andrea_dup_clientes" class="nav-item flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm" data-v4-tab-perfil="dusan,admin,comercial">
+            <span class="v4-emoji" aria-hidden="true">🔀</span>
+            Duplicados clientes
+          </a>
+          <a href="#" data-v4-tab="andrea_drift_libre" class="nav-item flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm" data-v4-tab-perfil="dusan,admin,comercial">
+            <span class="v4-emoji" aria-hidden="true">📝</span>
+            Nombres oportunidades
+          </a>
+          <a href="#" data-v4-tab="andrea_ruts_invalidos" class="nav-item flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm" data-v4-tab-perfil="dusan,admin,comercial">
+            <span class="v4-emoji" aria-hidden="true">🆔</span>
+            RUTs a verificar
+          </a>
+          <a href="#" data-v4-tab="andrea_comex" class="nav-item flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm" data-v4-tab-perfil="dusan,admin,comercial">
+            <span class="v4-emoji" aria-hidden="true">🚢</span>
+            Comex
+          </a>
+          <a href="#" data-v4-tab="decisor_venta" class="nav-item flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm" data-v4-tab-perfil="dusan,admin,comercial">
+            <span class="v4-emoji" aria-hidden="true">💰</span>
+            Decisor venta
+          </a>
+          <a href="#" data-v4-tab="andrea_cobranza" class="nav-item flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm" data-v4-tab-perfil="dusan,admin,comercial">
+            <span class="v4-emoji" aria-hidden="true">💸</span>
+            Cobranza
+          </a>
+          <a href="#" data-v4-tab="andrea_actas" class="nav-item flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm" data-v4-tab-perfil="dusan,admin,comercial">
+            <span class="v4-emoji" aria-hidden="true">📝</span>
+            Actas
+          </a>
           <a href="#" data-v4-tab="comercial" class="nav-item flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm">
             <span class="v4-emoji" aria-hidden="true">💼</span>
             Comercial (CRM Impulsa)
@@ -1043,6 +1072,13 @@
         <button data-tab="piloto_pwa"  class="tab-btn py-3 px-3 text-stone-600"          role="tab" aria-selected="false" aria-controls="tabPilotoPwa">📲 Piloto PWA</button>
         <button data-tab="mis_archivos" class="tab-btn py-3 px-3 text-stone-600"        role="tab" aria-selected="false" aria-controls="tabMisArchivos">📦 Mis archivos</button>
         <button data-tab="rdo"         class="tab-btn py-3 px-3 text-stone-600"        role="tab" aria-selected="false" aria-controls="tabRdo">📈 RDO Resumen</button>
+        <button data-tab="andrea_dup_clientes" class="tab-btn py-3 px-3 text-stone-600" role="tab" aria-selected="false" aria-controls="tabAndreaDupClientes">🔀 Duplicados clientes</button>
+        <button data-tab="andrea_drift_libre" class="tab-btn py-3 px-3 text-stone-600" role="tab" aria-selected="false" aria-controls="tabAndreaDriftLibre">📝 Nombres opps</button>
+        <button data-tab="andrea_ruts_invalidos" class="tab-btn py-3 px-3 text-stone-600" role="tab" aria-selected="false" aria-controls="tabAndreaRutsInvalidos">🆔 RUTs a verificar</button>
+        <button data-tab="andrea_comex" class="tab-btn py-3 px-3 text-stone-600" role="tab" aria-selected="false" aria-controls="tabAndreaComex">🚢 Comex</button>
+        <button data-tab="decisor_venta" class="tab-btn py-3 px-3 text-stone-600" role="tab" aria-selected="false" aria-controls="tabDecisorVenta">💰 Decisor venta</button>
+        <button data-tab="andrea_cobranza" class="tab-btn py-3 px-3 text-stone-600" role="tab" aria-selected="false" aria-controls="tabAndreaCobranza">💸 Cobranza</button>
+        <button data-tab="andrea_actas" class="tab-btn py-3 px-3 text-stone-600" role="tab" aria-selected="false" aria-controls="tabAndreaActas">📝 Actas</button>
         <button data-tab="negocios"   class="tab-btn py-3 px-3 text-stone-600"         role="tab" aria-selected="false" aria-controls="tabNegocios">💼 Negocios</button>
         <button data-tab="cotizador"  class="tab-btn py-3 px-3 text-stone-600"         role="tab" aria-selected="false" aria-controls="tabCotizador">📋 Cotizador</button>
         <button data-tab="evolucion"  class="tab-btn py-3 px-3 text-stone-600"         role="tab" aria-selected="false" aria-controls="tabEvolucion">📈 Evolución</button>
@@ -4334,6 +4370,278 @@
       </div>
     </section>
 
+    <!-- ============================================================
+         PC2 11-jun · Trio bandejas Cliente Único (mig 292+293) + Comex (mig 295)
+         ============================================================ -->
+
+    <!-- BANDEJA 1 · Duplicados clientes pendientes -->
+    <section id="tabAndreaDupClientes" class="tab-content hidden">
+      <div class="flex items-center justify-between mb-3 flex-wrap gap-2">
+        <div>
+          <h2 class="text-xl font-bold text-stone-800">🔀 Duplicados clientes</h2>
+          <p class="text-xs text-stone-500 mt-0.5">Pares con al menos un cliente activo (oportunidad no-terminal último año). Decidí si son el mismo (mergear), distintos, o desestimar.</p>
+        </div>
+        <div class="flex items-center gap-2">
+          <label class="text-xs text-stone-600 flex items-center gap-1 cursor-pointer">
+            <input type="checkbox" id="adup_ver_historico"> Ver histórico
+          </label>
+          <button id="adup_refresh" class="px-3 py-1 bg-emerald-600 text-white rounded text-xs hover:bg-emerald-700">↻ Actualizar</button>
+        </div>
+      </div>
+      <div class="grid grid-cols-3 gap-2 mb-3">
+        <div class="bg-white border border-stone-200 rounded p-2">
+          <div class="text-2xl font-bold text-stone-700" id="adup_kpi_total">0</div>
+          <div class="text-xs text-stone-500">Pares pendientes</div>
+        </div>
+        <div class="bg-white border border-stone-200 rounded p-2">
+          <div class="text-2xl font-bold text-amber-700" id="adup_kpi_alta">0</div>
+          <div class="text-xs text-stone-500">Similitud ≥ 0.7</div>
+        </div>
+        <div class="bg-white border border-stone-200 rounded p-2">
+          <div class="text-2xl font-bold text-sky-700" id="adup_kpi_baja">0</div>
+          <div class="text-xs text-stone-500">Similitud &lt; 0.7</div>
+        </div>
+      </div>
+      <div id="adup_lista" class="space-y-2">
+        <div class="text-xs text-stone-400 italic py-4 text-center">Cargando...</div>
+      </div>
+    </section>
+
+    <!-- BANDEJA 2 · Drift cliente_nombre_libre en oportunidades -->
+    <section id="tabAndreaDriftLibre" class="tab-content hidden">
+      <div class="flex items-center justify-between mb-3 flex-wrap gap-2">
+        <div>
+          <h2 class="text-xl font-bold text-stone-800">📝 Nombres en oportunidades</h2>
+          <p class="text-xs text-stone-500 mt-0.5">Nombres libres con oportunidades activas en el último año. Asigná al cliente correcto, marcá sin match, o descartá.</p>
+        </div>
+        <div class="flex items-center gap-2">
+          <label class="text-xs text-stone-600 flex items-center gap-1 cursor-pointer">
+            <input type="checkbox" id="adrift_ver_historico"> Ver histórico (3-7 años atrás)
+          </label>
+          <button id="adrift_refresh" class="px-3 py-1 bg-emerald-600 text-white rounded text-xs hover:bg-emerald-700">↻ Actualizar</button>
+        </div>
+      </div>
+      <div class="grid grid-cols-3 gap-2 mb-3">
+        <div class="bg-white border border-stone-200 rounded p-2">
+          <div class="text-2xl font-bold text-stone-700" id="adrift_kpi_total">0</div>
+          <div class="text-xs text-stone-500">Nombres pendientes</div>
+        </div>
+        <div class="bg-white border border-stone-200 rounded p-2">
+          <div class="text-2xl font-bold text-amber-700" id="adrift_kpi_opps">0</div>
+          <div class="text-xs text-stone-500">Σ oportunidades afectadas</div>
+        </div>
+        <div class="bg-white border border-stone-200 rounded p-2">
+          <div class="text-2xl font-bold text-sky-700" id="adrift_kpi_top">—</div>
+          <div class="text-xs text-stone-500">Top con más opps</div>
+        </div>
+      </div>
+      <div id="adrift_lista" class="space-y-2">
+        <div class="text-xs text-stone-400 italic py-4 text-center">Cargando...</div>
+      </div>
+    </section>
+
+    <!-- BANDEJA 3 · RUTs inválidos master -->
+    <section id="tabAndreaRutsInvalidos" class="tab-content hidden">
+      <div class="flex items-center justify-between mb-3 flex-wrap gap-2">
+        <div>
+          <h2 class="text-xl font-bold text-stone-800">🆔 RUTs a verificar</h2>
+          <p class="text-xs text-stone-500 mt-0.5">Clientes activos con RUT que no pasa el módulo 11. Corregí con el RUT real verificado con el cliente.</p>
+        </div>
+        <div class="flex items-center gap-2">
+          <label class="text-xs text-stone-600 flex items-center gap-1 cursor-pointer">
+            <input type="checkbox" id="aruts_ver_historico"> Ver histórico
+          </label>
+          <button id="aruts_refresh" class="px-3 py-1 bg-emerald-600 text-white rounded text-xs hover:bg-emerald-700">↻ Actualizar</button>
+        </div>
+      </div>
+      <div class="grid grid-cols-2 gap-2 mb-3">
+        <div class="bg-white border border-stone-200 rounded p-2">
+          <div class="text-2xl font-bold text-stone-700" id="aruts_kpi_total">0</div>
+          <div class="text-xs text-stone-500">Clientes con RUT inválido</div>
+        </div>
+        <div class="bg-white border border-stone-200 rounded p-2">
+          <div class="text-2xl font-bold text-emerald-700" id="aruts_kpi_corregidos">0</div>
+          <div class="text-xs text-stone-500">Corregidos esta sesión</div>
+        </div>
+      </div>
+      <div id="aruts_lista" class="space-y-2">
+        <div class="text-xs text-stone-400 italic py-4 text-center">Cargando...</div>
+      </div>
+    </section>
+
+    <!-- TAB 4 · Comex (importaciones/exportaciones) -->
+    <section id="tabAndreaComex" class="tab-content hidden">
+      <div class="flex items-center justify-between mb-3 flex-wrap gap-2">
+        <div>
+          <h2 class="text-xl font-bold text-stone-800">🚢 Comex</h2>
+          <p class="text-xs text-stone-500 mt-0.5">Importaciones y exportaciones activas. Estados: iniciado → en_tránsito → llegado.</p>
+        </div>
+        <div class="flex gap-2">
+          <button id="acomex_nueva" class="px-3 py-1 bg-sky-600 text-white rounded text-xs hover:bg-sky-700">+ Nueva operación</button>
+          <button id="acomex_refresh" class="px-3 py-1 bg-emerald-600 text-white rounded text-xs hover:bg-emerald-700">↻ Actualizar</button>
+        </div>
+      </div>
+      <div class="grid grid-cols-4 gap-2 mb-3">
+        <div class="bg-white border border-stone-200 rounded p-2">
+          <div class="text-2xl font-bold text-stone-700" id="acomex_kpi_total">0</div>
+          <div class="text-xs text-stone-500">Operaciones activas</div>
+        </div>
+        <div class="bg-white border border-stone-200 rounded p-2">
+          <div class="text-2xl font-bold text-amber-700" id="acomex_kpi_iniciado">0</div>
+          <div class="text-xs text-stone-500">⏳ Iniciado</div>
+        </div>
+        <div class="bg-white border border-stone-200 rounded p-2">
+          <div class="text-2xl font-bold text-sky-700" id="acomex_kpi_transito">0</div>
+          <div class="text-xs text-stone-500">🛳️ En tránsito</div>
+        </div>
+        <div class="bg-white border border-stone-200 rounded p-2">
+          <div class="text-2xl font-bold text-emerald-700" id="acomex_kpi_llegado">0</div>
+          <div class="text-xs text-stone-500">✅ Llegados &lt;7d</div>
+        </div>
+      </div>
+      <div id="acomex_lista" class="space-y-2">
+        <div class="text-xs text-stone-400 italic py-4 text-center">Cargando...</div>
+      </div>
+      <!-- Form alta inline (oculto por default) -->
+      <div id="acomex_form" class="hidden mt-4 bg-white border border-sky-300 rounded p-3">
+        <h3 class="font-semibold mb-2 text-sm">Nueva operación Comex</h3>
+        <div class="grid grid-cols-2 gap-2 text-xs">
+          <label>Forwarder *<input id="acomex_f_forwarder" class="w-full border rounded px-2 py-1 mt-0.5"></label>
+          <label>Tipo *<select id="acomex_f_tipo" class="w-full border rounded px-2 py-1 mt-0.5"><option value="importacion">Importación</option><option value="exportacion">Exportación</option></select></label>
+          <label>Cliente master (cliente_id)<input id="acomex_f_cliente_id" class="w-full border rounded px-2 py-1 mt-0.5" placeholder="ej: 102422"></label>
+          <label>Cliente libre (si no está en master)<input id="acomex_f_cliente_libre" class="w-full border rounded px-2 py-1 mt-0.5"></label>
+          <label>BL<input id="acomex_f_bl" class="w-full border rounded px-2 py-1 mt-0.5"></label>
+          <label>Origen<input id="acomex_f_origen" class="w-full border rounded px-2 py-1 mt-0.5" placeholder="Shanghai"></label>
+          <label>Destino<input id="acomex_f_destino" class="w-full border rounded px-2 py-1 mt-0.5" placeholder="Valparaíso"></label>
+          <label>ETD<input type="date" id="acomex_f_etd" class="w-full border rounded px-2 py-1 mt-0.5"></label>
+          <label>ETA<input type="date" id="acomex_f_eta" class="w-full border rounded px-2 py-1 mt-0.5"></label>
+          <label class="col-span-2">Notas<textarea id="acomex_f_notas" rows="2" class="w-full border rounded px-2 py-1 mt-0.5"></textarea></label>
+        </div>
+        <div class="flex gap-2 mt-2">
+          <button id="acomex_f_guardar" class="px-3 py-1 bg-emerald-600 text-white rounded text-xs hover:bg-emerald-700">Guardar</button>
+          <button id="acomex_f_cancelar" class="px-3 py-1 bg-stone-300 text-stone-700 rounded text-xs hover:bg-stone-400">Cancelar</button>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============================================================
+         PC2 11-jun · Decisor Venta UI (mig 276+277 + 296 backend ya existía)
+         ============================================================ -->
+    <section id="tabDecisorVenta" class="tab-content hidden">
+      <div class="flex items-center justify-between mb-3 flex-wrap gap-2">
+        <div>
+          <h2 class="text-xl font-bold text-stone-800">💰 Decisor de Venta</h2>
+          <p class="text-xs text-stone-500 mt-0.5">Elegí material + kg disponibles. Te muestro los compradores ordenados por mejor precio, con bonos vigentes y precios viejos marcados. Registrás la venta con 1 click.</p>
+        </div>
+        <button id="dec_refresh" class="px-3 py-1 bg-emerald-600 text-white rounded text-xs hover:bg-emerald-700">↻ Actualizar</button>
+      </div>
+
+      <!-- Form selector -->
+      <div class="bg-white border border-stone-200 rounded p-3 mb-3">
+        <div class="grid grid-cols-1 md:grid-cols-4 gap-2 text-xs">
+          <label>Material *<select id="dec_material" class="w-full border rounded px-2 py-1 mt-0.5"><option value="">Elegí material…</option></select></label>
+          <label>Kg disponibles *<input id="dec_kg" type="number" min="1" step="1" class="w-full border rounded px-2 py-1 mt-0.5" placeholder="ej: 1000"></label>
+          <label>Sucursal origen *<select id="dec_sucursal" class="w-full border rounded px-2 py-1 mt-0.5"><option value="">Elegí sucursal…</option></select></label>
+          <label>Empresa<select id="dec_empresa" class="w-full border rounded px-2 py-1 mt-0.5"><option value="reciclean">Reciclean</option><option value="farex">Farex</option></select></label>
+        </div>
+        <p class="text-[10px] text-stone-400 mt-1">⚠️ Flete real con google-maps queda fuera por BUG#4 (key referrer-blocked, encolado a Dusan). Por ahora se compara solo por precio + bonos.</p>
+      </div>
+
+      <!-- KPIs -->
+      <div class="grid grid-cols-3 gap-2 mb-3">
+        <div class="bg-white border border-stone-200 rounded p-2">
+          <div class="text-2xl font-bold text-stone-700" id="dec_kpi_total">0</div>
+          <div class="text-xs text-stone-500">Compradores con precio</div>
+        </div>
+        <div class="bg-white border border-stone-200 rounded p-2">
+          <div class="text-2xl font-bold text-amber-700" id="dec_kpi_stale">0</div>
+          <div class="text-xs text-stone-500">⏰ Con precio &gt;7 días</div>
+        </div>
+        <div class="bg-white border border-stone-200 rounded p-2">
+          <div class="text-2xl font-bold text-emerald-700" id="dec_kpi_top">—</div>
+          <div class="text-xs text-stone-500">🏆 Mejor total estimado</div>
+        </div>
+      </div>
+
+      <div id="dec_lista" class="space-y-2">
+        <div class="text-xs text-stone-400 italic py-4 text-center">Elegí material + kg + sucursal para empezar.</div>
+      </div>
+    </section>
+
+    <!-- ============================================================
+         PC2 11-jun · Cobranza + Actas (PDFs) · DeepSeek #2
+         EFs cobranza-pdf-reporte + acta-pdf-render ya deployadas.
+         ============================================================ -->
+
+    <!-- Tab COBRANZA -->
+    <section id="tabAndreaCobranza" class="tab-content hidden">
+      <div class="flex items-center justify-between mb-3 flex-wrap gap-2">
+        <div>
+          <h2 class="text-xl font-bold text-stone-800">💸 Cobranza</h2>
+          <p class="text-xs text-stone-500 mt-0.5">Facturas pendientes de pago con buckets aging 0-30/31-60/60+. Generá el PDF mensual para Dusan.</p>
+        </div>
+        <div class="flex gap-2 flex-wrap">
+          <select id="cob_empresa" class="border rounded px-2 py-1 text-xs">
+            <option value="todas">Todas las empresas</option>
+            <option value="reciclean">Reciclean</option>
+            <option value="farex">Farex</option>
+          </select>
+          <input id="cob_mes" type="month" class="border rounded px-2 py-1 text-xs">
+          <button id="cob_refresh" class="px-3 py-1 bg-emerald-600 text-white rounded text-xs hover:bg-emerald-700">↻ Actualizar</button>
+          <button id="cob_pdf" class="px-3 py-1 bg-sky-600 text-white rounded text-xs hover:bg-sky-700">📄 Generar PDF</button>
+        </div>
+      </div>
+      <div class="grid grid-cols-4 gap-2 mb-3">
+        <div class="bg-white border border-stone-200 rounded p-2">
+          <div class="text-2xl font-bold text-stone-700" id="cob_kpi_clientes">0</div>
+          <div class="text-xs text-stone-500">Clientes morosos</div>
+        </div>
+        <div class="bg-white border border-stone-200 rounded p-2">
+          <div class="text-2xl font-bold text-stone-700" id="cob_kpi_facturas">0</div>
+          <div class="text-xs text-stone-500">N° facturas</div>
+        </div>
+        <div class="bg-white border border-stone-200 rounded p-2">
+          <div class="text-2xl font-bold text-stone-700" id="cob_kpi_total">$0</div>
+          <div class="text-xs text-stone-500">Total pendiente</div>
+        </div>
+        <div class="bg-white border border-stone-200 rounded p-2">
+          <div class="text-2xl font-bold text-red-700" id="cob_kpi_critico">0%</div>
+          <div class="text-xs text-stone-500">% crítico &gt;60d</div>
+        </div>
+      </div>
+      <div id="cob_lista" class="space-y-2">
+        <div class="text-xs text-stone-400 italic py-4 text-center">Cargando…</div>
+      </div>
+    </section>
+
+    <!-- Tab ACTAS -->
+    <section id="tabAndreaActas" class="tab-content hidden">
+      <div class="flex items-center justify-between mb-3 flex-wrap gap-2">
+        <div>
+          <h2 class="text-xl font-bold text-stone-800">📝 Actas</h2>
+          <p class="text-xs text-stone-500 mt-0.5">Tus actas (PDI / compras). Generá el PDF, firmá pendientes, descargá copia para el cliente.</p>
+        </div>
+        <button id="act_refresh" class="px-3 py-1 bg-emerald-600 text-white rounded text-xs hover:bg-emerald-700">↻ Actualizar</button>
+      </div>
+      <div class="grid grid-cols-3 gap-2 mb-3">
+        <div class="bg-white border border-stone-200 rounded p-2">
+          <div class="text-2xl font-bold text-stone-700" id="act_kpi_total">0</div>
+          <div class="text-xs text-stone-500">Total actas</div>
+        </div>
+        <div class="bg-white border border-stone-200 rounded p-2">
+          <div class="text-2xl font-bold text-amber-700" id="act_kpi_pendientes">0</div>
+          <div class="text-xs text-stone-500">⏳ Firma pendiente</div>
+        </div>
+        <div class="bg-white border border-stone-200 rounded p-2">
+          <div class="text-2xl font-bold text-emerald-700" id="act_kpi_con_pdf">0</div>
+          <div class="text-xs text-stone-500">📄 Con PDF</div>
+        </div>
+      </div>
+      <div id="act_lista" class="space-y-2">
+        <div class="text-xs text-stone-400 italic py-4 text-center">Cargando…</div>
+      </div>
+    </section>
+
     <!-- Tab Facturacion grupo · D-FACTURACION-ETAPA-1 FASE 6 · PC2 Pablo 06-jun -->
     <section id="tabFacturacionGrupo" class="tab-content hidden">
       <div class="flex items-center justify-between mb-3 flex-wrap gap-2">
@@ -4930,7 +5238,7 @@ let recordedUrl = null;
 //
 // FALLBACKS (defaults): si las consultas fallan (red/RLS/tabla vacía) el
 // HTML no se rompe — el navbar aparece como en versión hardcoded.
-const FALLBACK_TABS_GLOBALES   = ['portada', 'pesaje', 'facturacion', 'facturacion_grupo', 'herramientas_ext', 'dieguito', 'comunicados', 'manual', 'mi_memoria', 'rdo', 'negocios', 'cotizador', 'cierres', 'precios', 'bandeja_precios', 'operativos', 'reconciliacion', 'cartera', 'oportunidades', 'entregables', 'bandeja_dieg', 'ops_diarias', 'pcs_vivo', 'plan_2026', 'gantt', 'admin'];
+const FALLBACK_TABS_GLOBALES   = ['portada', 'pesaje', 'facturacion', 'facturacion_grupo', 'herramientas_ext', 'dieguito', 'comunicados', 'manual', 'mi_memoria', 'rdo', 'negocios', 'cotizador', 'cierres', 'precios', 'bandeja_precios', 'operativos', 'reconciliacion', 'cartera', 'oportunidades', 'entregables', 'bandeja_dieg', 'ops_diarias', 'pcs_vivo', 'plan_2026', 'gantt', 'admin', 'andrea_dup_clientes', 'andrea_drift_libre', 'andrea_ruts_invalidos', 'andrea_comex', 'decisor_venta', 'andrea_cobranza', 'andrea_actas'];
 const FALLBACK_TABS_TRANSVERSALES = ['portada', 'dieguito', 'comunicados', 'cierres', 'precios', 'operativos'];
 const FALLBACK_BYPASS_EMAILS = [
   'gerencia@gestionrepchile.cl',
@@ -5132,6 +5440,8 @@ async function hydrateSessionAndEnter(authUser) {
   currentProfile = data.perfil;
   console.log('[Panel RDO] Login OK:', { email: currentUser, profile: currentProfile });
   if (typeof window.pageLog === 'function') window.pageLog('login', null, { perfil: currentProfile });
+  // BUG#5 fix: flush logs encolados pre-login (page-logger.js los encoló porque no había user)
+  if (typeof window.pageLogFlushPending === 'function') window.pageLogFlushPending();
   document.getElementById('userEmailDisplay').innerText = data.nombre || data.email;
   document.getElementById('userProfileDisplay').innerText = currentProfile;
 
@@ -5593,7 +5903,15 @@ const TAB_SECTION_MAP = {
   // PC1 fix 31-may PM: tabs con `_` o dígito que rompen el auto-CamelCase
   // (pcs_vivo→tabPcs_vivo ❌ real=tabPcsVivo · plan_2026→tabPlan_2026 ❌ real=tabPlan2026)
   pcs_vivo: 'tabPcsVivo',
-  plan_2026: 'tabPlan2026'
+  plan_2026: 'tabPlan2026',
+  // PC2 11-jun · Trio bandejas CU Andrea + Comex
+  andrea_dup_clientes: 'tabAndreaDupClientes',
+  andrea_drift_libre: 'tabAndreaDriftLibre',
+  andrea_ruts_invalidos: 'tabAndreaRutsInvalidos',
+  andrea_comex: 'tabAndreaComex',
+  decisor_venta: 'tabDecisorVenta',
+  andrea_cobranza: 'tabAndreaCobranza',
+  andrea_actas: 'tabAndreaActas'
 };
 function setupTabs() {
   document.querySelectorAll('.tab-btn').forEach(btn => {
@@ -11834,6 +12152,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
   async function refreshBadge() {
     if (!ready()) return;
+    // BUG#5 fix: no query si no hay user (RLS rebota → degrada cliente HTTP/2).
+    if (typeof currentUser === 'undefined' || !currentUser) return;
     try {
       const { count } = await sb.schema('panel').from('diego_bandeja')
         .select('*', { count: 'exact', head: true })
@@ -11891,6 +12211,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function suscribir() {
     if (realtimeCh || !ready()) return;
+    // BUG#5 fix: realtime requiere JWT; sin user, skip.
+    if (typeof currentUser === 'undefined' || !currentUser) return;
     realtimeCh = sb.channel('diego_bandeja_fab_v6')
       .on('postgres_changes', { event: '*', schema: 'panel', table: 'diego_bandeja' }, () => refreshBadge())
       .subscribe();
@@ -12122,6 +12444,8 @@ document.addEventListener('DOMContentLoaded', () => {
   // Bell · cuenta items pendientes en panel.diego_bandeja
   async function loadBellCount() {
     if (typeof sb === 'undefined' || !sb?.schema) return;
+    // BUG#5 fix: no query sin user (RLS rebota y aborta otros fetches en HTTP/2 pool).
+    if (typeof currentUser === 'undefined' || !currentUser) return;
     try {
       const { count, error } = await sb.schema('panel').from('diego_bandeja')
         .select('*', { count: 'exact', head: true })
@@ -12157,6 +12481,8 @@ document.addEventListener('DOMContentLoaded', () => {
     async function updateBellDot() {
       try {
         if (typeof sb === 'undefined' || !sb) return;
+        // BUG#5 fix: no query sin user.
+        if (typeof currentUser === 'undefined' || !currentUser) return;
         const { count, error } = await sb.schema('panel').from('diego_bandeja')
           .select('id', { count: 'exact', head: true })
           .eq('estado', 'pendiente');
@@ -16717,6 +17043,544 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
   if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', initHextFg); else initHextFg();
+})();
+
+// ============================================================
+// PC2 11-jun · Trio bandejas CU Andrea + Comex
+// Migs 292+293+294+295. Backend RPCs: andrea_decidir_dup,
+// andrea_resolver_drift, andrea_corregir_rut, comex_alta,
+// comex_avanzar_estado. Vistas: v_andrea_dup_pendientes,
+// v_andrea_drift_libre, v_andrea_ruts_invalidos, v_andrea_comex_activos.
+// ============================================================
+(function () {
+  function $$(id) { return document.getElementById(id); }
+  function esc(s) { return String(s == null ? '' : s).replace(/[&<>"']/g, c => ({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;' })[c]); }
+  function fmtFecha(s) { if (!s) return '—'; try { return new Date(s).toLocaleDateString('es-CL'); } catch(e) { return s; } }
+  function fmtPct(n) { if (n == null) return '—'; return (Number(n) * 100).toFixed(0) + '%'; }
+  let _rutsCorregidos = 0;
+
+  // ------------------ BANDEJA 1 · Duplicados ------------------
+  async function loadDup() {
+    const lista = $$('adup_lista'); if (!lista) return;
+    lista.innerHTML = '<div class="text-xs text-stone-400 italic py-4 text-center">Cargando...</div>';
+    try {
+      const verHist = $$('adup_ver_historico')?.checked;
+      const vista = verHist ? 'v_andrea_dup_pendientes_historico' : 'v_andrea_dup_pendientes';
+      const { data, error } = await sb.schema('panel').from(vista).select('*');
+      if (error) throw error;
+      $$('adup_kpi_total').textContent = (data || []).length;
+      $$('adup_kpi_alta').textContent = (data || []).filter(r => (r.similitud_nombre || 0) >= 0.7).length;
+      $$('adup_kpi_baja').textContent = (data || []).filter(r => (r.similitud_nombre || 0) < 0.7).length;
+      if (!data || data.length === 0) {
+        lista.innerHTML = '<div class="text-sm text-emerald-700 bg-emerald-50 border border-emerald-200 rounded p-3">✓ No hay duplicados pendientes.</div>';
+        return;
+      }
+      lista.innerHTML = data.map(r => `
+        <div class="bg-white border border-stone-200 rounded p-3" data-dup-id="${esc(r.id)}">
+          <div class="flex items-start justify-between mb-2">
+            <div class="text-xs text-stone-500">Detectado ${fmtFecha(r.detectado_at)} · similitud ${fmtPct(r.similitud_nombre)} · RUT ${esc(r.rut || '—')}</div>
+          </div>
+          <div class="grid grid-cols-2 gap-3 mb-2">
+            <div class="border border-stone-200 rounded p-2 bg-stone-50">
+              <div class="text-xs text-stone-500">Cliente NUEVO (${esc(r.cliente_id_nuevo)})</div>
+              <div class="font-semibold text-sm">${esc(r.razon_social_nueva)}</div>
+              <div class="text-xs text-stone-500">Sucursal: ${esc(r.sucursal_nueva || '—')}</div>
+              <button class="adup-btn-mergear mt-1 px-2 py-0.5 bg-amber-600 text-white rounded text-xs hover:bg-amber-700" data-par-id="${esc(r.id)}" data-ganador="${esc(r.cliente_id_existente)}" data-perdedor="${esc(r.cliente_id_nuevo)}">Mergear ← (existente gana)</button>
+            </div>
+            <div class="border border-stone-200 rounded p-2 bg-stone-50">
+              <div class="text-xs text-stone-500">Cliente EXISTENTE (${esc(r.cliente_id_existente)})</div>
+              <div class="font-semibold text-sm">${esc(r.razon_social_existente)}</div>
+              <div class="text-xs text-stone-500">Sucursal: ${esc(r.sucursal_existente || '—')}</div>
+              <button class="adup-btn-mergear mt-1 px-2 py-0.5 bg-amber-600 text-white rounded text-xs hover:bg-amber-700" data-par-id="${esc(r.id)}" data-ganador="${esc(r.cliente_id_nuevo)}" data-perdedor="${esc(r.cliente_id_existente)}">Mergear → (nuevo gana)</button>
+            </div>
+          </div>
+          <div class="flex gap-2">
+            <button class="adup-btn-decision px-2 py-1 bg-emerald-600 text-white rounded text-xs hover:bg-emerald-700" data-par-id="${esc(r.id)}" data-decision="ambos_validos">Son clientes distintos</button>
+            <button class="adup-btn-decision px-2 py-1 bg-stone-400 text-white rounded text-xs hover:bg-stone-500" data-par-id="${esc(r.id)}" data-decision="no_mergear">Desestimar (revisar después)</button>
+          </div>
+        </div>`).join('');
+    } catch (e) {
+      lista.innerHTML = '<div class="text-sm text-red-700 bg-red-50 border border-red-200 rounded p-3">Error: ' + esc(e.message || String(e)) + '</div>';
+    }
+  }
+
+  async function decidirDup(parId, decision, ganador) {
+    if (!confirm('¿Confirmar decisión: ' + decision + (ganador ? ' (ganador=' + ganador + ')' : '') + '?')) return;
+    try {
+      const { data, error } = await sb.rpc('andrea_decidir_dup', { p_par_id: parId, p_decision: decision, p_ganador_cliente_id: ganador || null, p_notas: null });
+      if (error) throw error;
+      if (!data?.ok) throw new Error(data?.error || 'Error desconocido');
+      loadDup();
+    } catch (e) { alert('No se pudo registrar: ' + (e.message || e)); }
+  }
+
+  // ------------------ BANDEJA 2 · Drift libre ------------------
+  async function loadDrift() {
+    const lista = $$('adrift_lista'); if (!lista) return;
+    lista.innerHTML = '<div class="text-xs text-stone-400 italic py-4 text-center">Cargando...</div>';
+    try {
+      const verHist = $$('adrift_ver_historico')?.checked;
+      const vista = verHist ? 'v_andrea_drift_libre_historico' : 'v_andrea_drift_libre';
+      const { data, error } = await sb.schema('panel').from(vista).select('*').limit(50);
+      if (error) throw error;
+      $$('adrift_kpi_total').textContent = (data || []).length;
+      $$('adrift_kpi_opps').textContent = (data || []).reduce((a, r) => a + (r.opps_count || 0), 0);
+      const top = (data || []).slice().sort((a, b) => (b.opps_count || 0) - (a.opps_count || 0))[0];
+      $$('adrift_kpi_top').textContent = top ? top.cliente_nombre_libre + ' (' + top.opps_count + ')' : '—';
+      if (!data || data.length === 0) {
+        lista.innerHTML = '<div class="text-sm text-emerald-700 bg-emerald-50 border border-emerald-200 rounded p-3">✓ No hay nombres drift pendientes.</div>';
+        return;
+      }
+      lista.innerHTML = data.map(r => {
+        const cands = Array.isArray(r.candidatos) ? r.candidatos.slice(0, 3) : [];
+        const candHtml = cands.length ? cands.map(c => `
+          <button class="adrift-btn-asignar block w-full text-left px-2 py-1 mt-0.5 bg-emerald-50 border border-emerald-200 rounded text-xs hover:bg-emerald-100" data-drift-id="${esc(r.id)}" data-cliente-id="${esc(c.cliente_id)}">
+            → Asignar a <span class="font-semibold">${esc(c.razon_social || c.cliente_id)}</span> <span class="text-stone-500">(score ${(c.score || 0).toFixed(2)})</span>
+          </button>`).join('') : '<div class="text-xs text-stone-500 italic">Sin candidatos sugeridos.</div>';
+        return `
+        <div class="bg-white border border-stone-200 rounded p-3">
+          <div class="flex items-start justify-between mb-2">
+            <div>
+              <div class="font-semibold text-sm">${esc(r.cliente_nombre_libre)}</div>
+              <div class="text-xs text-stone-500">${r.opps_count || 0} oportunidades afectadas · detectado ${fmtFecha(r.detectado_at)}</div>
+            </div>
+          </div>
+          <div class="mb-2">${candHtml}</div>
+          <div class="flex gap-2 flex-wrap">
+            <input type="text" placeholder="O escribí cliente_id manualmente" class="adrift-input-cid flex-1 border rounded px-2 py-1 text-xs" data-drift-id="${esc(r.id)}">
+            <button class="adrift-btn-asignar-manual px-2 py-1 bg-sky-600 text-white rounded text-xs hover:bg-sky-700" data-drift-id="${esc(r.id)}">Asignar manual</button>
+            <button class="adrift-btn-decision px-2 py-1 bg-stone-400 text-white rounded text-xs hover:bg-stone-500" data-drift-id="${esc(r.id)}" data-decision="sin_match">Sin match</button>
+            <button class="adrift-btn-decision px-2 py-1 bg-stone-400 text-white rounded text-xs hover:bg-stone-500" data-drift-id="${esc(r.id)}" data-decision="descartar">Descartar</button>
+          </div>
+        </div>`;
+      }).join('');
+    } catch (e) {
+      lista.innerHTML = '<div class="text-sm text-red-700 bg-red-50 border border-red-200 rounded p-3">Error: ' + esc(e.message || String(e)) + '</div>';
+    }
+  }
+
+  async function resolverDrift(driftId, decision, clienteId) {
+    if (!confirm('¿Confirmar: ' + decision + (clienteId ? ' a cliente ' + clienteId : '') + '?')) return;
+    try {
+      const { data, error } = await sb.rpc('andrea_resolver_drift', { p_drift_id: driftId, p_cliente_id_elegido: clienteId || null, p_decision: decision, p_notas: null });
+      if (error) throw error;
+      if (!data?.ok) throw new Error(data?.error || 'Error desconocido');
+      alert('OK. Opps actualizadas: ' + (data.opps_actualizadas || 0));
+      loadDrift();
+    } catch (e) { alert('No se pudo registrar: ' + (e.message || e)); }
+  }
+
+  // ------------------ BANDEJA 3 · RUTs inválidos ------------------
+  async function loadRuts() {
+    const lista = $$('aruts_lista'); if (!lista) return;
+    lista.innerHTML = '<div class="text-xs text-stone-400 italic py-4 text-center">Cargando...</div>';
+    try {
+      const verHist = $$('aruts_ver_historico')?.checked;
+      const vista = verHist ? 'v_andrea_ruts_invalidos_historico' : 'v_andrea_ruts_invalidos';
+      const { data, error } = await sb.schema('panel').from(vista).select('*');
+      if (error) throw error;
+      $$('aruts_kpi_total').textContent = (data || []).length;
+      $$('aruts_kpi_corregidos').textContent = _rutsCorregidos;
+      if (!data || data.length === 0) {
+        lista.innerHTML = '<div class="text-sm text-emerald-700 bg-emerald-50 border border-emerald-200 rounded p-3">✓ No hay RUTs inválidos.</div>';
+        return;
+      }
+      lista.innerHTML = data.map(r => `
+        <div class="bg-white border border-stone-200 rounded p-3">
+          <div class="flex items-start justify-between mb-2">
+            <div>
+              <div class="font-semibold text-sm">${esc(r.razon_social || '—')}</div>
+              <div class="text-xs text-stone-500">cliente_id ${esc(r.cliente_id)} · RUT actual: <span class="font-mono">${esc(r.rut || '—')}</span> · motivo: ${esc(r.motivo || '—')}</div>
+            </div>
+          </div>
+          <div class="flex gap-2 flex-wrap items-center">
+            <input type="text" placeholder="RUT correcto (ej: 12345678-5)" class="aruts-input-rut flex-1 border rounded px-2 py-1 text-xs font-mono" data-cliente-id="${esc(r.cliente_id)}">
+            <button class="aruts-btn-corregir px-2 py-1 bg-emerald-600 text-white rounded text-xs hover:bg-emerald-700" data-cliente-id="${esc(r.cliente_id)}">Corregir RUT</button>
+          </div>
+        </div>`).join('');
+    } catch (e) {
+      lista.innerHTML = '<div class="text-sm text-red-700 bg-red-50 border border-red-200 rounded p-3">Error: ' + esc(e.message || String(e)) + '</div>';
+    }
+  }
+
+  async function corregirRut(clienteId, rutNuevo) {
+    if (!rutNuevo || rutNuevo.length < 3) { alert('Ingresá un RUT válido (con guión).'); return; }
+    if (!confirm('¿Aplicar RUT ' + rutNuevo + ' al cliente ' + clienteId + '?')) return;
+    try {
+      const { data, error } = await sb.rpc('andrea_corregir_rut', { p_cliente_id: clienteId, p_rut_nuevo: rutNuevo, p_notas: null });
+      if (error) throw error;
+      if (!data?.ok) throw new Error(data?.error || 'Error desconocido');
+      _rutsCorregidos++;
+      loadRuts();
+    } catch (e) { alert('No se pudo corregir: ' + (e.message || e)); }
+  }
+
+  // ------------------ TAB 4 · Comex ------------------
+  async function loadComex() {
+    const lista = $$('acomex_lista'); if (!lista) return;
+    lista.innerHTML = '<div class="text-xs text-stone-400 italic py-4 text-center">Cargando...</div>';
+    try {
+      const { data, error } = await sb.schema('panel').from('v_andrea_comex_activos').select('*');
+      if (error) throw error;
+      $$('acomex_kpi_total').textContent = (data || []).length;
+      $$('acomex_kpi_iniciado').textContent = (data || []).filter(r => r.estado === 'iniciado').length;
+      $$('acomex_kpi_transito').textContent = (data || []).filter(r => r.estado === 'en_transito').length;
+      $$('acomex_kpi_llegado').textContent = (data || []).filter(r => r.estado === 'llegado').length;
+      if (!data || data.length === 0) {
+        lista.innerHTML = '<div class="text-sm text-stone-500 bg-stone-50 border border-stone-200 rounded p-3">Sin operaciones activas. Creá una con + Nueva operación.</div>';
+        return;
+      }
+      const badge = (e) => e === 'iniciado' ? 'bg-amber-100 text-amber-800' : e === 'en_transito' ? 'bg-sky-100 text-sky-800' : 'bg-emerald-100 text-emerald-800';
+      const next = (e) => e === 'iniciado' ? 'en_transito' : e === 'en_transito' ? 'llegado' : null;
+      lista.innerHTML = data.map(r => `
+        <div class="bg-white border border-stone-200 rounded p-3">
+          <div class="flex items-start justify-between mb-2">
+            <div>
+              <div class="font-semibold text-sm">${esc(r.cliente || '—')} <span class="text-xs text-stone-500">· ${esc(r.tipo)}</span></div>
+              <div class="text-xs text-stone-500">${esc(r.forwarder)} · BL ${esc(r.numero_bl || '—')} · ${esc(r.origen || '—')} → ${esc(r.destino || '—')}</div>
+              <div class="text-xs text-stone-500">ETD ${fmtFecha(r.fecha_etd)} · ETA ${fmtFecha(r.fecha_eta)} ${r.dias_a_eta != null ? '(' + r.dias_a_eta + ' días)' : ''}</div>
+            </div>
+            <span class="text-xs px-2 py-0.5 rounded ${badge(r.estado)}">${esc(r.estado)}</span>
+          </div>
+          ${next(r.estado) ? `<button class="acomex-btn-avanzar px-2 py-1 bg-sky-600 text-white rounded text-xs hover:bg-sky-700" data-id="${esc(r.id)}" data-nuevo="${next(r.estado)}">Avanzar a ${next(r.estado)}</button>` : ''}
+          ${r.notas ? '<div class="mt-2 text-xs text-stone-600 whitespace-pre-line border-l-2 border-stone-300 pl-2">' + esc(r.notas) + '</div>' : ''}
+        </div>`).join('');
+    } catch (e) {
+      lista.innerHTML = '<div class="text-sm text-red-700 bg-red-50 border border-red-200 rounded p-3">Error: ' + esc(e.message || String(e)) + '</div>';
+    }
+  }
+
+  async function comexAvanzar(id, nuevo) {
+    const notas = prompt('Notas para este cambio (opcional):') || null;
+    try {
+      const { data, error } = await sb.rpc('comex_avanzar_estado', { p_id: id, p_nuevo_estado: nuevo, p_notas_adicionales: notas });
+      if (error) throw error;
+      if (!data?.ok) throw new Error(data?.error || 'Error desconocido');
+      loadComex();
+    } catch (e) { alert('No se pudo avanzar: ' + (e.message || e)); }
+  }
+
+  async function comexGuardar() {
+    const forwarder = $$('acomex_f_forwarder').value.trim();
+    const tipo = $$('acomex_f_tipo').value;
+    const cliente_id = $$('acomex_f_cliente_id').value.trim() || null;
+    const cliente_libre = $$('acomex_f_cliente_libre').value.trim() || null;
+    if (!forwarder) { alert('Forwarder es obligatorio.'); return; }
+    if (!cliente_id && !cliente_libre) { alert('Indicá cliente_id master o cliente_nombre_libre.'); return; }
+    try {
+      const { data, error } = await sb.rpc('comex_alta', {
+        p_forwarder: forwarder, p_tipo: tipo,
+        p_cliente_id: cliente_id, p_cliente_nombre_libre: cliente_libre,
+        p_numero_bl: $$('acomex_f_bl').value.trim() || null,
+        p_origen: $$('acomex_f_origen').value.trim() || null,
+        p_destino: $$('acomex_f_destino').value.trim() || null,
+        p_fecha_etd: $$('acomex_f_etd').value || null,
+        p_fecha_eta: $$('acomex_f_eta').value || null,
+        p_notas: $$('acomex_f_notas').value.trim() || null
+      });
+      if (error) throw error;
+      if (!data?.ok) throw new Error(data?.error || 'Error desconocido');
+      // Limpiar form + ocultar
+      ['forwarder','cliente_id','cliente_libre','bl','origen','destino','etd','eta','notas'].forEach(k => { const el = $$('acomex_f_' + k); if (el) el.value = ''; });
+      $$('acomex_form').classList.add('hidden');
+      loadComex();
+    } catch (e) { alert('No se pudo guardar: ' + (e.message || e)); }
+  }
+
+  // ------------------ TAB 5 · Decisor Venta ------------------
+  let _decMatCache = null, _decSucCache = null;
+  async function decBootstrap() {
+    // Cargar selects una sola vez
+    if (!_decMatCache) {
+      const { data: mats } = await sb.schema('curated').from('materiales').select('material_id, nombre, categoria').eq('activo', true).order('nombre');
+      _decMatCache = mats || [];
+      const sel = $$('dec_material');
+      if (sel) sel.innerHTML = '<option value="">Elegí material…</option>' + _decMatCache.map(m => `<option value="${esc(m.material_id)}">${esc(m.nombre)} <span>(${esc(m.categoria || '-')})</span></option>`).join('');
+    }
+    if (!_decSucCache) {
+      const { data: sucs } = await sb.schema('curated').from('sucursales').select('sucursal_id, nombre').order('nombre');
+      _decSucCache = sucs || [];
+      const sel = $$('dec_sucursal');
+      if (sel) sel.innerHTML = '<option value="">Elegí sucursal…</option>' + _decSucCache.map(s => `<option value="${esc(s.sucursal_id)}">${esc(s.nombre)}</option>`).join('');
+    }
+  }
+  async function loadDecisor() {
+    const lista = $$('dec_lista'); if (!lista) return;
+    await decBootstrap();
+    const matId = $$('dec_material').value;
+    const kg = parseFloat($$('dec_kg').value);
+    const suc = $$('dec_sucursal').value;
+    if (!matId || !kg || kg <= 0 || !suc) {
+      lista.innerHTML = '<div class="text-xs text-stone-400 italic py-4 text-center">Elegí material + kg + sucursal para empezar.</div>';
+      $$('dec_kpi_total').textContent = '0'; $$('dec_kpi_stale').textContent = '0'; $$('dec_kpi_top').textContent = '—';
+      return;
+    }
+    lista.innerHTML = '<div class="text-xs text-stone-400 italic py-4 text-center">Calculando…</div>';
+    try {
+      const { data, error } = await sb.schema('panel').from('v_matriz_precios_compradores')
+        .select('*').eq('material_id', matId).not('precio_clp_kg', 'is', null);
+      if (error) throw error;
+      const filas = (data || []).map(r => ({
+        ...r,
+        precio: Number(r.precio_clp_kg || 0),
+        total_clp: Math.round(Number(r.precio_clp_kg || 0) * kg),
+        stale: (r.dias_desde_actualizacion || 0) > 7,
+      })).sort((a, b) => b.total_clp - a.total_clp);
+
+      // Bonos: una llamada por comprador top 5 (no spamear)
+      const bonos = {};
+      for (const f of filas.slice(0, 5)) {
+        try {
+          const { data: bonos_data } = await sb.rpc('f_estado_bono', { p_comprador_id: f.comprador_id, p_material_id: matId });
+          if (bonos_data && bonos_data.length) bonos[f.comprador_id] = bonos_data;
+        } catch (e) { /* silencioso */ }
+      }
+
+      $$('dec_kpi_total').textContent = filas.length;
+      $$('dec_kpi_stale').textContent = filas.filter(f => f.stale).length;
+      $$('dec_kpi_top').textContent = filas[0] ? '$' + filas[0].total_clp.toLocaleString('es-CL') : '—';
+
+      if (filas.length === 0) {
+        lista.innerHTML = '<div class="text-sm text-amber-700 bg-amber-50 border border-amber-200 rounded p-3">Ningún comprador activo tiene precio cargado para este material. Cargá un precio en la Bandeja Precios o actualizá el comprador.</div>';
+        return;
+      }
+      lista.innerHTML = filas.map((f, i) => {
+        const podio = i === 0 ? '🥇' : i === 1 ? '🥈' : i === 2 ? '🥉' : '';
+        const bonoList = bonos[f.comprador_id] || [];
+        const bonoHtml = bonoList.length ? '<div class="mt-1 text-xs text-amber-700">' + bonoList.map(b => `🎁 ${esc(b.nombre_bono)}: ${Number(b.acumulado_kg||0).toLocaleString('es-CL')}/${Number(b.meta_kg||0).toLocaleString('es-CL')} kg (${(b.pct_avance||0).toFixed(0)}%) · faltan ${Number(b.faltante_kg||0).toLocaleString('es-CL')} kg`).join('<br>') + '</div>' : '';
+        return `
+        <div class="bg-white border ${i===0?'border-emerald-400':'border-stone-200'} rounded p-3">
+          <div class="flex items-start justify-between flex-wrap gap-2">
+            <div class="flex-1 min-w-0">
+              <div class="font-semibold text-sm">${podio} ${esc(f.comprador)} <span class="text-xs text-stone-500">${esc(f.comuna || f.region || '')}</span></div>
+              <div class="text-xs text-stone-500">$${f.precio.toLocaleString('es-CL')}/kg × ${kg.toLocaleString('es-CL')} kg ${f.stale ? '<span class="ml-1 px-1 bg-amber-100 text-amber-800 rounded">⏰ precio '+f.dias_desde_actualizacion+'d</span>' : ''} ${f.requiere_foto_previa ? '<span class="ml-1 px-1 bg-sky-100 text-sky-800 rounded">📷 foto previa</span>' : ''}</div>
+              ${f.condicion_texto ? '<div class="text-xs text-stone-500 italic">'+esc(f.condicion_texto)+'</div>' : ''}
+              ${bonoHtml}
+            </div>
+            <div class="text-right">
+              <div class="text-lg font-bold ${i===0?'text-emerald-700':'text-stone-700'}">$${f.total_clp.toLocaleString('es-CL')}</div>
+              <button class="dec-btn-vender mt-1 px-3 py-1 ${i===0?'bg-emerald-600 hover:bg-emerald-700':'bg-stone-500 hover:bg-stone-600'} text-white rounded text-xs"
+                data-comprador="${esc(f.comprador_id)}" data-material="${esc(matId)}" data-precio="${f.precio}" data-kg="${kg}" data-suc="${esc(suc)}">
+                Vender a este
+              </button>
+            </div>
+          </div>
+        </div>`;
+      }).join('');
+    } catch (e) {
+      lista.innerHTML = '<div class="text-sm text-red-700 bg-red-50 border border-red-200 rounded p-3">Error: ' + esc(e.message || String(e)) + '</div>';
+    }
+  }
+  async function decVender(comprador, material, precio, kg, sucursal) {
+    if (!confirm(`¿Registrar venta de ${kg} kg de ${material} a ${comprador} a $${precio}/kg?`)) return;
+    try {
+      const empresa = $$('dec_empresa').value;
+      const ctx = { source: 'decisor_venta_ui', material, kg, precio_kg: precio, sucursal };
+      const { data, error } = await sb.rpc('venta_material_capturar', {
+        p_comprador_id: comprador, p_material_id: material,
+        p_kg: kg, p_precio_clp_kg: precio,
+        p_sucursal_origen: sucursal, p_empresa: empresa,
+        p_fecha_venta: new Date().toISOString().slice(0,10),
+        p_guia_despacho: null, p_decision_context: ctx,
+        p_comentario: 'Capturada desde Decisor de Venta', p_estado: 'cotizada'
+      });
+      if (error) throw error;
+      if (!data?.ok) throw new Error(data?.error || 'Error');
+      const bonos = (data.estado_bonos || []).map(b => `${b.nombre_bono}: ${(b.pct_avance||0).toFixed(0)}%`).join(' · ');
+      alert('Venta registrada (estado cotizada). Total $' + Math.round(precio*kg).toLocaleString('es-CL') + (bonos ? '. Bonos: ' + bonos : ''));
+      loadDecisor();
+    } catch (e) { alert('No se pudo registrar: ' + (e.message || e)); }
+  }
+
+  // ------------------ TAB 6 · Cobranza ------------------
+  function fmtCLP(n) { if (n == null || isNaN(n)) return '$0'; return '$' + Number(n).toLocaleString('es-CL', { maximumFractionDigits: 0 }); }
+  async function loadCobranza() {
+    const lista = $$('cob_lista'); if (!lista) return;
+    lista.innerHTML = '<div class="text-xs text-stone-400 italic py-4 text-center">Cargando…</div>';
+    try {
+      const empresa = $$('cob_empresa').value;
+      let q = sb.schema('panel').from('v_andrea_cobranza').select('*');
+      if (empresa !== 'todas') q = q.eq('empresa', empresa);
+      const { data, error } = await q.order('monto_pendiente_total', { ascending: false });
+      if (error) throw error;
+      const filas = data || [];
+      const total = filas.reduce((a, f) => a + Number(f.monto_pendiente_total || 0), 0);
+      const totalFac = filas.reduce((a, f) => a + Number(f.n_facturas || 0), 0);
+      const total60 = filas.reduce((a, f) => a + Number(f.bucket_60_mas || 0), 0);
+      const pct = total > 0 ? Math.round(total60 / total * 100) : 0;
+      $$('cob_kpi_clientes').textContent = filas.length;
+      $$('cob_kpi_facturas').textContent = totalFac;
+      $$('cob_kpi_total').textContent = fmtCLP(total);
+      $$('cob_kpi_critico').textContent = pct + '%';
+      if (filas.length === 0) {
+        lista.innerHTML = '<div class="text-sm text-emerald-700 bg-emerald-50 border border-emerald-200 rounded p-3">✓ Sin morosos.</div>';
+        return;
+      }
+      lista.innerHTML = filas.slice(0, 30).map((f, i) => `
+        <div class="bg-white border border-stone-200 rounded p-3">
+          <div class="flex items-start justify-between flex-wrap gap-2">
+            <div class="flex-1 min-w-0">
+              <div class="font-semibold text-sm">${i+1}. ${esc(f.razon_social || '—')} <span class="text-xs text-stone-500">${esc(f.empresa || '')}</span></div>
+              <div class="text-xs text-stone-500">RUT ${esc(f.rut_proveedor || '—')} · ${f.n_facturas || 0} factura(s) · aging máx ${f.aging_mas_viejo || 0}d ${f.dias_sin_gestion != null ? '· sin gestión '+f.dias_sin_gestion+'d' : ''}</div>
+              <div class="text-xs mt-1">
+                <span class="bg-stone-100 px-1 rounded">0-30: ${fmtCLP(f.bucket_0_30)}</span>
+                <span class="bg-amber-100 px-1 rounded ml-1">31-60: ${fmtCLP(f.bucket_31_60)}</span>
+                <span class="bg-red-100 px-1 rounded ml-1">60+: ${fmtCLP(f.bucket_60_mas)}</span>
+              </div>
+            </div>
+            <div class="text-right">
+              <div class="text-lg font-bold text-stone-700">${fmtCLP(f.monto_pendiente_total)}</div>
+            </div>
+          </div>
+        </div>`).join('');
+    } catch (e) {
+      lista.innerHTML = '<div class="text-sm text-red-700 bg-red-50 border border-red-200 rounded p-3">Error: ' + esc(e.message || String(e)) + '</div>';
+    }
+  }
+  async function cobGenerarPdf() {
+    const btn = $$('cob_pdf'); if (!btn) return;
+    const empresa = $$('cob_empresa').value;
+    const mes = $$('cob_mes').value || new Date().toISOString().slice(0, 7);
+    const orig = btn.textContent; btn.disabled = true; btn.textContent = 'Generando…';
+    try {
+      const { data, error } = await sb.functions.invoke('cobranza-pdf-reporte', { body: { empresa, mes } });
+      if (error) throw error;
+      if (!data?.ok) throw new Error(data?.error || 'Error');
+      window.open(data.signed_url, '_blank');
+    } catch (e) {
+      alert('Error PDF: ' + (e.message || e));
+    } finally {
+      btn.disabled = false; btn.textContent = orig;
+    }
+  }
+
+  // ------------------ TAB 7 · Actas ------------------
+  async function loadActas() {
+    const lista = $$('act_lista'); if (!lista) return;
+    lista.innerHTML = '<div class="text-xs text-stone-400 italic py-4 text-center">Cargando…</div>';
+    try {
+      const { data, error } = await sb.schema('panel').from('v_andrea_actas').select('*').limit(50);
+      if (error) throw error;
+      const filas = data || [];
+      $$('act_kpi_total').textContent = filas.length;
+      $$('act_kpi_pendientes').textContent = filas.filter(a => a.firma_pendiente).length;
+      $$('act_kpi_con_pdf').textContent = filas.filter(a => a.tiene_pdf).length;
+      if (filas.length === 0) {
+        lista.innerHTML = '<div class="text-sm text-stone-500 bg-stone-50 border border-stone-200 rounded p-3">No tenés actas todavía. Las actas se crean desde otros flujos (PDI, compras).</div>';
+        return;
+      }
+      lista.innerHTML = filas.map(a => `
+        <div class="bg-white border border-stone-200 rounded p-3">
+          <div class="flex items-start justify-between flex-wrap gap-2">
+            <div class="flex-1 min-w-0">
+              <div class="font-semibold text-sm">📝 ${esc((a.tipo||'').toUpperCase())} · ${esc(a.cliente || '—')}</div>
+              <div class="text-xs text-stone-500">Fecha ${esc(a.fecha || '—')} · creada ${esc(new Date(a.created_at).toLocaleDateString('es-CL'))}</div>
+              ${a.firma_pendiente ? '<span class="text-xs px-1.5 py-0.5 bg-amber-100 text-amber-800 rounded">⏳ Firma pendiente</span>' : '<span class="text-xs px-1.5 py-0.5 bg-emerald-100 text-emerald-800 rounded">✓ Firmada '+esc(a.firmado_por || '')+'</span>'}
+              ${a.tiene_pdf ? '<span class="text-xs px-1.5 py-0.5 bg-sky-100 text-sky-800 rounded ml-1">📄 PDF generado</span>' : ''}
+              ${a.notas ? '<div class="text-xs text-stone-600 italic mt-1">'+esc(a.notas).slice(0,200)+'</div>' : ''}
+            </div>
+            <div class="flex flex-col gap-1">
+              <button class="act-btn-pdf px-2 py-1 bg-sky-600 text-white rounded text-xs hover:bg-sky-700" data-id="${esc(a.id)}">📄 Generar PDF</button>
+              ${a.firma_pendiente ? '<button class="act-btn-firmar px-2 py-1 bg-emerald-600 text-white rounded text-xs hover:bg-emerald-700" data-id="'+esc(a.id)+'">✍️ Firmar</button>' : ''}
+            </div>
+          </div>
+        </div>`).join('');
+    } catch (e) {
+      lista.innerHTML = '<div class="text-sm text-red-700 bg-red-50 border border-red-200 rounded p-3">Error: ' + esc(e.message || String(e)) + '</div>';
+    }
+  }
+  async function actGenerarPdf(actaId) {
+    try {
+      const { data, error } = await sb.functions.invoke('acta-pdf-render', { body: { acta_id: actaId } });
+      if (error) throw error;
+      if (!data?.ok) throw new Error(data?.error || 'Error');
+      window.open(data.signed_url, '_blank');
+      loadActas();
+    } catch (e) { alert('Error PDF: ' + (e.message || e)); }
+  }
+  async function actFirmar(actaId) {
+    const nombre = prompt('Nombre de quien firma:');
+    if (!nombre || nombre.trim().length < 2) return;
+    try {
+      const { data, error } = await sb.rpc('firmar_acta', { p_acta_id: actaId, p_firmado_por_nombre: nombre.trim() });
+      if (error) throw error;
+      if (!data?.ok) throw new Error(data?.error || 'Error');
+      loadActas();
+    } catch (e) { alert('Error firma: ' + (e.message || e)); }
+  }
+
+  // ------------------ Wiring ------------------
+  function init() {
+    // Loaders al click del tab (ambos navbars)
+    [['andrea_dup_clientes', loadDup], ['andrea_drift_libre', loadDrift], ['andrea_ruts_invalidos', loadRuts], ['andrea_comex', loadComex], ['decisor_venta', decBootstrap], ['andrea_cobranza', loadCobranza], ['andrea_actas', loadActas]].forEach(([code, fn]) => {
+      document.querySelector('button[data-tab="' + code + '"]')?.addEventListener('click', () => setTimeout(fn, 100));
+      document.querySelector('a[data-v4-tab="' + code + '"]')?.addEventListener('click', () => setTimeout(fn, 100));
+    });
+    $$('adup_refresh')?.addEventListener('click', loadDup);
+    $$('adrift_refresh')?.addEventListener('click', loadDrift);
+    $$('aruts_refresh')?.addEventListener('click', loadRuts);
+    $$('acomex_refresh')?.addEventListener('click', loadComex);
+    $$('adrift_ver_historico')?.addEventListener('change', loadDrift);
+    $$('adup_ver_historico')?.addEventListener('change', loadDup);
+    $$('aruts_ver_historico')?.addEventListener('change', loadRuts);
+
+    // Delegated handlers
+    $$('adup_lista')?.addEventListener('click', e => {
+      const m = e.target.closest('.adup-btn-mergear');
+      if (m) return decidirDup(m.dataset.parId, 'mergear', m.dataset.ganador);
+      const d = e.target.closest('.adup-btn-decision');
+      if (d) return decidirDup(d.dataset.parId, d.dataset.decision, null);
+    });
+    $$('adrift_lista')?.addEventListener('click', e => {
+      const a = e.target.closest('.adrift-btn-asignar');
+      if (a) return resolverDrift(a.dataset.driftId, 'asignado', a.dataset.clienteId);
+      const am = e.target.closest('.adrift-btn-asignar-manual');
+      if (am) {
+        const inp = $$('adrift_lista').querySelector('.adrift-input-cid[data-drift-id="' + am.dataset.driftId + '"]');
+        return resolverDrift(am.dataset.driftId, 'asignado', inp?.value.trim());
+      }
+      const dec = e.target.closest('.adrift-btn-decision');
+      if (dec) return resolverDrift(dec.dataset.driftId, dec.dataset.decision, null);
+    });
+    $$('aruts_lista')?.addEventListener('click', e => {
+      const c = e.target.closest('.aruts-btn-corregir');
+      if (c) {
+        const inp = $$('aruts_lista').querySelector('.aruts-input-rut[data-cliente-id="' + c.dataset.clienteId + '"]');
+        return corregirRut(c.dataset.clienteId, inp?.value.trim());
+      }
+    });
+    $$('acomex_lista')?.addEventListener('click', e => {
+      const a = e.target.closest('.acomex-btn-avanzar');
+      if (a) return comexAvanzar(a.dataset.id, a.dataset.nuevo);
+    });
+    $$('acomex_nueva')?.addEventListener('click', () => $$('acomex_form').classList.toggle('hidden'));
+    $$('acomex_f_cancelar')?.addEventListener('click', () => $$('acomex_form').classList.add('hidden'));
+    $$('acomex_f_guardar')?.addEventListener('click', comexGuardar);
+
+    // Cobranza wiring
+    $$('cob_refresh')?.addEventListener('click', loadCobranza);
+    $$('cob_empresa')?.addEventListener('change', loadCobranza);
+    $$('cob_pdf')?.addEventListener('click', cobGenerarPdf);
+    // Default mes = mes actual
+    const cobMes = $$('cob_mes'); if (cobMes && !cobMes.value) cobMes.value = new Date().toISOString().slice(0, 7);
+
+    // Actas wiring
+    $$('act_refresh')?.addEventListener('click', loadActas);
+    $$('act_lista')?.addEventListener('click', e => {
+      const p = e.target.closest('.act-btn-pdf'); if (p) return actGenerarPdf(p.dataset.id);
+      const f = e.target.closest('.act-btn-firmar'); if (f) return actFirmar(f.dataset.id);
+    });
+
+    // Decisor Venta wiring
+    $$('dec_refresh')?.addEventListener('click', loadDecisor);
+    ['dec_material','dec_kg','dec_sucursal'].forEach(id => $$(id)?.addEventListener('change', loadDecisor));
+    $$('dec_kg')?.addEventListener('input', () => { clearTimeout(window._decT); window._decT = setTimeout(loadDecisor, 600); });
+    $$('dec_lista')?.addEventListener('click', e => {
+      const b = e.target.closest('.dec-btn-vender');
+      if (b) return decVender(b.dataset.comprador, b.dataset.material, Number(b.dataset.precio), Number(b.dataset.kg), b.dataset.suc);
+    });
+  }
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init); else init();
 })();
 
 // Tab Vales Portal · G42 · D-PESAJES-DIARIA-001 · PC2 Pablo 03-jun PM

--- a/tests/andrea-bandejas-cu.spec.ts
+++ b/tests/andrea-bandejas-cu.spec.ts
@@ -1,0 +1,208 @@
+// E2E smoke · Bandejas Cliente Único Andrea + Comex
+// PC2 Pablo 2026-06-11 PM, gatillado por feedback DeepSeek "smoke con UI real"
+// Cubre las 4 tabs construidas en commits 33c7642/6d7a0b7/f7a0c7c
+// User: qa@reciclean.cl (Andrea simulada, área Comercial, silo 01)
+import { test, expect, Page } from '@playwright/test';
+
+const QA_EMAIL = process.env.QA_EMAIL || 'qa@reciclean.cl';
+const QA_PASSWORD = process.env.QA_PASSWORD || 'SmokeAndrea2026!';
+
+const consoleErrors: string[] = [];
+
+async function login(page: Page) {
+  // Capturar logs de consola desde antes del login
+  const logs: string[] = [];
+  page.on('console', m => logs.push(`[${m.type()}] ${m.text()}`));
+  page.on('pageerror', e => logs.push(`[pageerror] ${e.message}`));
+
+  await page.goto('/panel-rdo.html');
+  await page.waitForSelector('#loginEmail', { timeout: 10_000 });
+  await page.fill('#loginEmail', QA_EMAIL);
+  await page.fill('#loginPassword', QA_PASSWORD);
+  // Llamar window.login() directamente para evitar problemas de click
+  await page.evaluate(() => (window as any).login());
+  try {
+    await page.waitForFunction(() => {
+      const el = document.getElementById('appContainer');
+      return el && getComputedStyle(el).display !== 'none';
+    }, { timeout: 25_000 });
+  } catch (e) {
+    const errText = await page.locator('#loginError').textContent().catch(() => '');
+    const errVisible = await page.locator('#loginError:not(.hidden)').count();
+    throw new Error(`Login timeout. loginError visible=${errVisible} text="${errText}". Logs: ${JSON.stringify(logs.slice(-15))}`);
+  }
+}
+
+async function abrirTab(page: Page, codigo: string, sectionId: string) {
+  // Sidebar v4 prioritario; navbar viejo fallback
+  const sel = `a[data-v4-tab="${codigo}"], button[data-tab="${codigo}"]`;
+  await page.locator(sel).first().click();
+  await page.waitForSelector(`section#${sectionId}:not(.hidden)`, { timeout: 6_000 });
+}
+
+test.describe('Smoke Bandejas CU Andrea + Comex', () => {
+  test.skip(!QA_PASSWORD, 'QA_PASSWORD no seteado');
+  test.setTimeout(90_000);
+
+  test.beforeEach(async ({ page }) => {
+    consoleErrors.length = 0;
+    page.on('console', m => { if (m.type() === 'error') consoleErrors.push(m.text()); });
+    page.on('pageerror', e => consoleErrors.push('pageerror: ' + e.message));
+  });
+
+  test('Tab Duplicados clientes carga + muestra KPIs', async ({ page }) => {
+    await login(page);
+    await abrirTab(page, 'andrea_dup_clientes', 'tabAndreaDupClientes');
+    // Esperar a que cargue (loader sale)
+    await page.waitForSelector('#adup_lista', { timeout: 8_000 });
+    await page.waitForFunction(() => {
+      const el = document.querySelector('#adup_lista');
+      return el && !el.textContent?.includes('Cargando');
+    }, { timeout: 10_000 });
+    // KPIs deben tener números (no "0" si hay data; pero 0 también es válido si fue limpiado)
+    const total = await page.locator('#adup_kpi_total').textContent();
+    expect(total).toMatch(/^\d+$/);
+    // No debe haber error visible
+    const err = await page.locator('#adup_lista').textContent();
+    expect(err).not.toMatch(/Error:/i);
+    await page.screenshot({ path: 'test-results/dup-clientes.png', fullPage: true });
+  });
+
+  test('Tab Nombres opps carga + toggle histórico funciona', async ({ page }) => {
+    await login(page);
+    await abrirTab(page, 'andrea_drift_libre', 'tabAndreaDriftLibre');
+    await page.waitForFunction(() => {
+      const el = document.querySelector('#adrift_lista');
+      return el && !el.textContent?.includes('Cargando');
+    }, { timeout: 10_000 });
+    const totalActivo = parseInt(await page.locator('#adrift_kpi_total').textContent() || '0');
+    expect(totalActivo).toBeGreaterThanOrEqual(0);
+    // Toggle histórico
+    await page.locator('#adrift_ver_historico').check();
+    await page.waitForFunction(() => {
+      const el = document.querySelector('#adrift_lista');
+      return el && !el.textContent?.includes('Cargando');
+    }, { timeout: 10_000 });
+    const totalHist = parseInt(await page.locator('#adrift_kpi_total').textContent() || '0');
+    // Histórico debe ser >= activo (es el universo más amplio o igual)
+    expect(totalHist).toBeGreaterThanOrEqual(totalActivo);
+    await page.screenshot({ path: 'test-results/drift-libre.png', fullPage: true });
+  });
+
+  test('Tab RUTs a verificar carga sin error permission denied', async ({ page }) => {
+    await login(page);
+    await abrirTab(page, 'andrea_ruts_invalidos', 'tabAndreaRutsInvalidos');
+    await page.waitForFunction(() => {
+      const el = document.querySelector('#aruts_lista');
+      return el && !el.textContent?.includes('Cargando');
+    }, { timeout: 10_000 });
+    const err = await page.locator('#aruts_lista').textContent();
+    expect(err).not.toMatch(/permission denied|Could not find|42501/i);
+    await page.screenshot({ path: 'test-results/ruts-invalidos.png', fullPage: true });
+  });
+
+  test('Tab Comex carga vacío + form alta visible al clickear + cancelar oculta', async ({ page }) => {
+    await login(page);
+    await abrirTab(page, 'andrea_comex', 'tabAndreaComex');
+    await page.waitForFunction(() => {
+      const el = document.querySelector('#acomex_lista');
+      return el && !el.textContent?.includes('Cargando');
+    }, { timeout: 10_000 });
+    // Form arranca oculto
+    await expect(page.locator('#acomex_form')).toBeHidden();
+    // Click + Nueva → form visible
+    await page.locator('#acomex_nueva').click();
+    await expect(page.locator('#acomex_form')).toBeVisible();
+    // Click cancelar → vuelve a oculto
+    await page.locator('#acomex_f_cancelar').click();
+    await expect(page.locator('#acomex_form')).toBeHidden();
+    await page.screenshot({ path: 'test-results/comex.png', fullPage: true });
+  });
+
+  test('Tab Decisor Venta: selectores cargan + lista vacía hasta tener material+kg+sucursal', async ({ page }) => {
+    await login(page);
+    await abrirTab(page, 'decisor_venta', 'tabDecisorVenta');
+    // Selects pobladas via decBootstrap
+    await page.waitForFunction(() => {
+      const m = document.getElementById('dec_material') as HTMLSelectElement;
+      const s = document.getElementById('dec_sucursal') as HTMLSelectElement;
+      return m && s && m.options.length > 1 && s.options.length > 1;
+    }, { timeout: 10_000 });
+    // Lista debe mostrar mensaje "Elegí material…" porque faltan inputs
+    const listaTxt = await page.locator('#dec_lista').textContent();
+    expect(listaTxt).toMatch(/Elegí material|Calculando|comprador/i);
+    // Elegir el primer material que tenga precio cargado en v_matriz (no hardcoded a un nombre)
+    const matConPrecio = await page.evaluate(async () => {
+      const sb = (window as any).sb;
+      const { data } = await sb.schema('panel').from('v_matriz_precios_compradores')
+        .select('material_id').not('precio_clp_kg', 'is', null).limit(1);
+      return data?.[0]?.material_id || '';
+    });
+    expect(matConPrecio, 'No hay material con precio cargado en v_matriz_precios_compradores').not.toBe('');
+    await page.selectOption('#dec_material', matConPrecio);
+    await page.fill('#dec_kg', '500');
+    await page.selectOption('#dec_sucursal', 'cerrillos');
+    await page.waitForFunction(() => {
+      const el = document.querySelector('#dec_lista');
+      return el && !el.textContent?.includes('Calculando') && !el.textContent?.includes('Elegí material');
+    }, { timeout: 15_000 });
+    const total = parseInt(await page.locator('#dec_kpi_total').textContent() || '0');
+    expect(total).toBeGreaterThan(0);
+    // Top KPI debe tener formato $
+    const top = await page.locator('#dec_kpi_top').textContent() || '';
+    expect(top).toMatch(/^\$/);
+    await page.screenshot({ path: 'test-results/decisor-venta.png', fullPage: true });
+  });
+
+  test('Tab Cobranza: carga + selector empresa + KPIs', async ({ page }) => {
+    await login(page);
+    await abrirTab(page, 'andrea_cobranza', 'tabAndreaCobranza');
+    await page.waitForFunction(() => {
+      const el = document.querySelector('#cob_lista');
+      return el && !el.textContent?.includes('Cargando');
+    }, { timeout: 12_000 });
+    const clientes = parseInt(await page.locator('#cob_kpi_clientes').textContent() || '0');
+    expect(clientes).toBeGreaterThanOrEqual(0);
+    // Cambiar filtro empresa
+    await page.selectOption('#cob_empresa', 'reciclean');
+    await page.waitForFunction(() => {
+      const el = document.querySelector('#cob_lista');
+      return el && !el.textContent?.includes('Cargando');
+    }, { timeout: 12_000 });
+    await page.screenshot({ path: 'test-results/cobranza.png', fullPage: true });
+  });
+
+  test('Tab Actas: vista carga sin error y KPIs presentes', async ({ page }) => {
+    await login(page);
+    await abrirTab(page, 'andrea_actas', 'tabAndreaActas');
+    await page.waitForFunction(() => {
+      const el = document.querySelector('#act_lista');
+      return el && !el.textContent?.includes('Cargando');
+    }, { timeout: 10_000 });
+    const total = parseInt(await page.locator('#act_kpi_total').textContent() || '-1');
+    expect(total).toBeGreaterThanOrEqual(0);
+    const err = await page.locator('#act_lista').textContent();
+    expect(err).not.toMatch(/permission denied|Could not find/i);
+    await page.screenshot({ path: 'test-results/actas.png', fullPage: true });
+  });
+
+  test('Sin console errors críticos durante navegación 7 tabs', async ({ page }) => {
+    await login(page);
+    for (const [codigo, sec] of [
+      ['andrea_dup_clientes', 'tabAndreaDupClientes'],
+      ['andrea_drift_libre', 'tabAndreaDriftLibre'],
+      ['andrea_ruts_invalidos', 'tabAndreaRutsInvalidos'],
+      ['andrea_comex', 'tabAndreaComex'],
+      ['decisor_venta', 'tabDecisorVenta'],
+      ['andrea_cobranza', 'tabAndreaCobranza'],
+      ['andrea_actas', 'tabAndreaActas'],
+    ]) {
+      await abrirTab(page, codigo, sec);
+      await page.waitForTimeout(1500);
+    }
+    const criticos = consoleErrors.filter(e =>
+      /Could not find the function|permission denied|42501|TypeError|ReferenceError/i.test(e)
+    );
+    expect(criticos, `Console errors críticos: ${JSON.stringify(criticos)}`).toEqual([]);
+  });
+});

--- a/tests/audit-autocomplete.spec.ts
+++ b/tests/audit-autocomplete.spec.ts
@@ -1,0 +1,45 @@
+// Validación 2.3 DeepSeek: autocomplete cliente en Cotizador
+import { test, expect, Page } from '@playwright/test';
+
+const QA_EMAIL = 'qa@reciclean.cl';
+const QA_PASSWORD = 'SmokeAndrea2026!';
+
+async function loginAndCotizador(page: Page) {
+  await page.goto('/panel-rdo.html');
+  await page.fill('#loginEmail', QA_EMAIL);
+  await page.fill('#loginPassword', QA_PASSWORD);
+  await page.evaluate(() => (window as any).login());
+  await page.waitForFunction(() => {
+    const el = document.getElementById('appContainer');
+    return el && getComputedStyle(el).display !== 'none';
+  }, { timeout: 30_000 });
+  await page.locator('a[data-v4-tab="cotizador"], button[data-tab="cotizador"]').first().click();
+  await page.waitForSelector('#cotClienteBuscar', { timeout: 10_000 });
+}
+
+test.describe('Audit 2.3 autocomplete Cotizador', () => {
+  test.setTimeout(60_000);
+
+  test('Autocomplete Emerson: aparece dropdown con resultados', async ({ page }) => {
+    await loginAndCotizador(page);
+    await page.fill('#cotClienteBuscar', 'Emerson');
+    // Debounce 300ms + RPC; espero a que sugerencias dejen de ser hidden
+    await page.waitForFunction(() => {
+      const el = document.getElementById('cotClienteSugerencias');
+      return el && !el.classList.contains('hidden');
+    }, { timeout: 5_000 });
+    const items = await page.locator('#cotClienteSugerencias > div').count();
+    expect(items).toBeGreaterThan(0);
+    const textos = await page.locator('#cotClienteSugerencias > div').allTextContents();
+    expect(textos.some(t => /emerson/i.test(t))).toBeTruthy();
+    await page.screenshot({ path: 'test-results/audit-autocomplete-emerson.png', fullPage: true });
+  });
+
+  test('Autocomplete texto inexistente: dropdown queda oculto', async ({ page }) => {
+    await loginAndCotizador(page);
+    await page.fill('#cotClienteBuscar', 'ZZZ_CLIENTE_INEXISTENTE_XYZ_999');
+    await page.waitForTimeout(800); // debounce + RPC
+    const oculto = await page.locator('#cotClienteSugerencias').evaluate(el => el.classList.contains('hidden'));
+    expect(oculto).toBe(true);
+  });
+});

--- a/tests/audit-deepseek.spec.ts
+++ b/tests/audit-deepseek.spec.ts
@@ -1,0 +1,78 @@
+// Auditoría DeepSeek 11-jun PM. Bloques 2 (UI) + 7 (regresión tabs viejos).
+import { test, expect, Page } from '@playwright/test';
+
+const QA_EMAIL = 'qa@reciclean.cl';
+const QA_PASSWORD = 'SmokeAndrea2026!';
+
+async function loginFresh(page: Page) {
+  await page.goto('/panel-rdo.html');
+  await page.waitForSelector('#loginEmail');
+  await page.fill('#loginEmail', QA_EMAIL);
+  await page.fill('#loginPassword', QA_PASSWORD);
+  await page.evaluate(() => (window as any).login());
+  await page.waitForFunction(() => {
+    const el = document.getElementById('appContainer');
+    return el && getComputedStyle(el).display !== 'none';
+  }, { timeout: 30_000 });
+}
+
+test.describe('Audit DeepSeek', () => {
+  test.setTimeout(120_000);
+
+  test('2.2 BUG#5 ausente en sesión fresca (incógnito limpio)', async ({ browser }) => {
+    // Browser context aislado = localStorage limpio = sesión fresca
+    const ctx = await browser.newContext();
+    const page = await ctx.newPage();
+    const errs: string[] = [];
+    page.on('console', m => { if (m.type() === 'error') errs.push(m.text()); });
+    page.on('pageerror', e => errs.push('pageerror: ' + e.message));
+    page.on('requestfailed', r => { if (r.failure()?.errorText.includes('ERR_ABORTED')) errs.push('reqfail ABORT: '+r.url().slice(-60)); });
+    await loginFresh(page);
+    // Filtrar errores conocidos no críticos
+    const criticos = errs.filter(e => /Failed to fetch|ERR_ABORTED.*auth\/v1\/token|TypeError.*fetch/i.test(e));
+    expect(criticos, JSON.stringify(criticos)).toEqual([]);
+    await ctx.close();
+  });
+
+  test('2.1 + 7 los 7 tabs nuevos y los viejos críticos cargan sin error crítico', async ({ page }) => {
+    const errs: string[] = [];
+    page.on('console', m => { if (m.type() === 'error') errs.push(m.text()); });
+    page.on('pageerror', e => errs.push('pageerror: ' + e.message));
+    await loginFresh(page);
+    // Tabs nuevos
+    const nuevos = ['andrea_dup_clientes','andrea_drift_libre','andrea_ruts_invalidos','andrea_comex','decisor_venta','andrea_cobranza','andrea_actas'];
+    for (const t of nuevos) {
+      await page.locator(`a[data-v4-tab="${t}"], button[data-tab="${t}"]`).first().click();
+      await page.waitForTimeout(1200);
+    }
+    // Tabs viejos críticos (regresión)
+    const viejos = ['cotizador','bandeja_precios','cumplimiento','cartera','rdo'];
+    for (const t of viejos) {
+      const sel = `a[data-v4-tab="${t}"], button[data-tab="${t}"]`;
+      const visible = await page.locator(sel).first().isVisible().catch(()=>false);
+      if (visible) {
+        await page.locator(sel).first().click();
+        await page.waitForTimeout(1000);
+      }
+    }
+    const criticos = errs.filter(e => /Could not find the function|permission denied|42501|TypeError|ReferenceError/i.test(e));
+    expect(criticos, JSON.stringify(criticos)).toEqual([]);
+    await page.screenshot({ path: 'test-results/audit-regresion.png', fullPage: true });
+  });
+
+  test('2.3 + 2.4 autocomplete cotizador + crear cliente nuevo', async ({ page }) => {
+    await loginFresh(page);
+    await page.locator('a[data-v4-tab="cotizador"], button[data-tab="cotizador"]').first().click();
+    await page.waitForTimeout(2000);
+    // Buscar input cliente en cotizador (selectores comunes)
+    const inputs = await page.locator('input[placeholder*="liente" i], input[placeholder*="azón social" i], input[id*="liente" i]').all();
+    if (inputs.length === 0) {
+      test.skip(true, 'No encontré input cliente en Cotizador — selector no estándar');
+      return;
+    }
+    await inputs[0].fill('Emerson');
+    await page.waitForTimeout(1500);
+    // Capturar screenshot del estado (si hay autocomplete, debería verse)
+    await page.screenshot({ path: 'test-results/audit-cotizador-emerson.png', fullPage: true });
+  });
+});

--- a/tests/cotizador-crear-cliente.spec.ts
+++ b/tests/cotizador-crear-cliente.spec.ts
@@ -1,0 +1,69 @@
+// Smoke crear cliente desde Cotizador (deuda Fase 5 cerrada hoy)
+// Flujo: autocomplete vacío → click "Crear nuevo" → modal Cartera prefill → guardar → autoselecciona en Cotizador
+import { test, expect, Page } from '@playwright/test';
+
+const QA_EMAIL = 'qa@reciclean.cl';
+const QA_PASSWORD = 'SmokeAndrea2026!';
+const MARCADOR = 'SMOKE_COTIZADOR_CREATE_' + Date.now();
+
+async function loginAndCotizador(page: Page) {
+  await page.goto('/panel-rdo.html');
+  await page.fill('#loginEmail', QA_EMAIL);
+  await page.fill('#loginPassword', QA_PASSWORD);
+  await page.evaluate(() => (window as any).login());
+  await page.waitForFunction(() => {
+    const el = document.getElementById('appContainer');
+    return el && getComputedStyle(el).display !== 'none';
+  }, { timeout: 30_000 });
+  await page.locator('a[data-v4-tab="cotizador"], button[data-tab="cotizador"]').first().click();
+  await page.waitForSelector('#cotClienteBuscar', { timeout: 10_000 });
+}
+
+test.describe('Cotizador · crear cliente nuevo', () => {
+  test.setTimeout(90_000);
+
+  test('Flujo completo: autocomplete vacío → modal → guardar → autoseleccionado', async ({ page }) => {
+    page.on('console', m => console.log('[browser]', m.type(), m.text()));
+    page.on('pageerror', e => console.log('[pageerror]', e.message));
+    page.on('dialog', d => { console.log('[DIALOG]', d.message()); d.dismiss(); });
+    await loginAndCotizador(page);
+    // Tipear nombre inexistente
+    await page.fill('#cotClienteBuscar', MARCADOR);
+    // Esperar a que botón "+ Crear nuevo" aparezca (debounce 300ms + RPC)
+    await page.waitForFunction(() => {
+      const b = document.getElementById('cotClienteCrearBtn');
+      return b && !b.classList.contains('hidden');
+    }, { timeout: 5_000 });
+    // Verificar pre-condiciones
+    const tienen = await page.evaluate(() => ({
+      cotAbrir: typeof (window as any).cotAbrirCrearCliente,
+      carAbrir: typeof (window as any).carAbrirCrear,
+      modal: !!document.getElementById('clienteEditModal'),
+    }));
+    console.log('pre-click funcs:', JSON.stringify(tienen));
+    // Capturar alerts (si carAbrirCrear no existe, sale alert)
+    page.on('dialog', d => { console.log('DIALOG:', d.message()); d.dismiss(); });
+    // Click botón
+    await page.locator('#cotClienteCrearBtn').click();
+    // Modal abierto con razón social prellenada
+    await page.waitForSelector('#clienteEditModal:not(.hidden)', { timeout: 5_000 });
+    const razon = await page.locator('#cliRazonSocial').inputValue();
+    expect(razon).toBe(MARCADOR);
+    // Título del modal
+    const titulo = await page.locator('#clienteEditModalTitulo').textContent();
+    expect(titulo).toMatch(/Crear/i);
+    // Guardar
+    await page.locator('#clienteEditGuardarBtn').click();
+    // Esperar a que modal se cierre y cliente_id se setee
+    await page.waitForFunction(() => {
+      const h = document.getElementById('cotClienteId') as HTMLInputElement;
+      return h && h.value && h.value.length > 0;
+    }, { timeout: 10_000 });
+    const cliId = await page.locator('#cotClienteId').inputValue();
+    expect(cliId).toMatch(/^cli_\d+|^c\d+$/);
+    // Confirmación visible
+    const sel = await page.locator('#cotClienteSeleccionado').textContent();
+    expect(sel).toContain(MARCADOR);
+    await page.screenshot({ path: 'test-results/cotizador-crear-cliente.png', fullPage: true });
+  });
+});

--- a/tests/vista-simulada-admin.spec.ts
+++ b/tests/vista-simulada-admin.spec.ts
@@ -1,0 +1,51 @@
+// Vista simulada "Ver como X" cosmética (admin/dusan only)
+import { test, expect, Page } from '@playwright/test';
+
+const QA_EMAIL = 'qa@reciclean.cl';
+const QA_PASSWORD = 'SmokeAndrea2026!';
+
+async function login(page: Page) {
+  await page.goto('/panel-rdo.html');
+  await page.fill('#loginEmail', QA_EMAIL);
+  await page.fill('#loginPassword', QA_PASSWORD);
+  await page.evaluate(() => (window as any).login());
+  await page.waitForFunction(() => {
+    const el = document.getElementById('appContainer');
+    return el && getComputedStyle(el).display !== 'none';
+  }, { timeout: 30_000 });
+}
+
+test.describe('Vista simulada admin', () => {
+  test.setTimeout(60_000);
+
+  test('Como admin: selector visible, cambia a Andrea, banner aparece, restaura', async ({ page }) => {
+    await login(page);
+    // Esperar que setupVistaSimulada haya corrido
+    await page.waitForTimeout(1500);
+    // Selector debe estar visible (perfil admin)
+    await expect(page.locator('#vistaSimContainer')).toBeVisible();
+    // Banner default oculto
+    await expect(page.locator('#vistaSimBanner')).toBeHidden();
+    // Cambiar a Andrea
+    await page.selectOption('#vistaSimSelector', 'andrea');
+    // Banner visible
+    await expect(page.locator('#vistaSimBanner')).toBeVisible();
+    const nombre = await page.locator('#vistaSimNombre').textContent();
+    expect(nombre).toMatch(/Andrea/);
+    // currentProfile cambió a comercial
+    const prof = await page.evaluate(() => (window as any).currentProfile);
+    expect(prof).toBe('comercial');
+    // currentSilo cambió a 01
+    const silo = await page.evaluate(() => (window as any).currentSilo);
+    expect(silo).toBe('01');
+    // userProfileDisplay con badge amber
+    const badge = await page.locator('#userProfileDisplay').textContent();
+    expect(badge).toMatch(/sim/i);
+    // Click "Volver a mi vista"
+    await page.locator('#vistaSimBanner button').click();
+    await expect(page.locator('#vistaSimBanner')).toBeHidden();
+    // currentProfile restaurado
+    const profRestaurado = await page.evaluate(() => (window as any).currentProfile);
+    expect(profRestaurado).toBe('admin');
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -6,5 +6,13 @@
     { "source": "/ejemplos",         "destination": "/diego-ejemplos.html",     "permanent": false },
     { "source": "/dar-feedback",     "destination": "/diego-feedback.html",     "permanent": false },
     { "source": "/videos-diego",     "destination": "/diego-video-script.html", "permanent": false }
+  ],
+  "headers": [
+    {
+      "source": "/(.*\\.html)",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-store, no-cache, must-revalidate, max-age=0" }
+      ]
+    }
   ]
 }


### PR DESCRIPTION
## Promoción a prod · D12 firma delegada Pablo

**Autorización**: Pablo Tech Lead presente otorgó OK explícito bajo D12 (smoke E2E real + autorización verbal).

**Memoria**: `reference-d12-pablo-firma-main-prod` cubre exactamente este caso.

## Por qué cherry-pick en vez de main→prod directo

Diagnóstico encontrado a las 15:46 CLT: el flujo de este repo es feature→main→promote/X→prod. Hay 8 commits en main que nunca se promovieron a prod (precios vivos, sidebar fantasma, bandeja CEO, etc.). Si hacía main→prod directo, llevaba todo eso sin haberlo validado.

Estrategia A elegida por Pablo: rama nueva desde prod, cherry-pick **solo los 4 commits míos**, PR limpio.

## Commits cherry-pickeados (4)

- `f9ad06b` ← `9633972` feat: UI bandejas Andrea + Comex + Decisor + PDFs + fix BUG#5 (PR #273)
- `6ca80e7` ← `8bf0f26` feat(cotizador): botón "Crear nuevo cliente" (PR #274 commit 1)
- `f934d9d` ← `bee3819` chore: force CDN purge
- `e34a612` ← `6f0cdc0` config(vercel): no-cache headers en .html

## Conflicto resuelto

`public/panel-rdo.html` líneas 676-709: prod tenía nuevo tab `mis_visitas` (📅 Mis Visitas), main tenía mis 6 tabs Andrea. **Resolución: mantener ambos**. Verificado con `scripts/js-parse-check.mjs` ✓ 24 scripts OK.

## Smoke E2E real con JWT (requisito D12)

15/15 PASSED en local antes del cherry-pick:
- `andrea-bandejas-cu.spec.ts`: 8/8
- `audit-deepseek.spec.ts`: 3/3
- `audit-autocomplete.spec.ts`: 2/2
- `cotizador-crear-cliente.spec.ts`: 1/1
- `vista-simulada-admin.spec.ts`: 1/1

JWT real qa@reciclean.cl simulando Andrea (comercial, silo 01) + admin para vista simulada.

## Features que llegarán a producción

Silo 01 (Andrea):
- 🔀 Duplicados clientes con toggle activo/histórico
- 📝 Nombres opps con toggle activo/histórico
- 🆔 RUTs a verificar con toggle activo/histórico
- 🚢 Comex prototipo (3 estados)
- 💰 Decisor Venta (selector + podio compradores + bonos)
- 💸 Cobranza con generación PDF mensual
- 📝 Actas con generación PDF + firma

Para todos:
- Fix BUG#5: panel funciona en sesión fresca sin localStorage
- Cotizador: botón "Crear nuevo cliente" cuando autocomplete no encuentra
- vercel.json: no-cache headers en .html (cero stale futuro)

Para admin/dusan:
- Selector "Ver como X" en topbar (cosmético, no toca RLS)

## Migraciones Supabase (ya en producción)

Migs 290-301 aplicadas durante la jornada con verificación + smoke. Incluye BUG#3 resuelto (`mv_cartera_detalle` drift estados: 0/1942 → 344 clientes con opp visibles).

## Test plan post-merge

- [ ] Vercel deploy de prod genera ok (auto-trigger por push)
- [ ] Andrea silo 01: ve los 7 tabs nuevos en sidebar
- [ ] Pablo (admin): ve selector "Ver como X" amarillo en topbar
- [ ] Login fresco (modo incógnito) sin error consola
- [ ] PDF cobranza descarga válido desde UI
- [ ] Tab `mis_visitas` de prod sigue funcional (regresión)

🤖 Generated with [Claude Code](https://claude.com/claude-code)