### PR TITLE
Capa 2 · Embudo Comercial Antifrágil · kanban 11 cols + Mi Día + sidebar 6 tabs

### DIFF
--- a/public/panel-rdo.html
+++ b/public/panel-rdo.html
@@ -9697,14 +9697,21 @@ window.carAplicarCategoria = async function() {
 // ============================================================
 // TAB OPORTUNIDADES KANBAN (D-OP-12) — v2 con Impulsa CRM
 // ============================================================
+// Capa 1 · Embudo Comercial Antifrágil · 11 estados canónicos
+// Migración 12-jun-2026: nombres en español, secuenciados según el flujo real.
+// La bifurcación V/C después de FACTURAR se decide por metadata.dte_codigo (33=venta, 46=compra).
 const OPP_ESTADOS = [
-  { id: 'recibida',      nombre: 'Recibida',      color: 'bg-stone-100' },
-  { id: 'en_evaluacion', nombre: 'En evaluación', color: 'bg-amber-50' },
-  { id: 'activada',      nombre: 'Activada',      color: 'bg-blue-50' },
-  { id: 'monitoreo',     nombre: 'Monitoreo',     color: 'bg-purple-50' },
-  { id: 'respondida',    nombre: 'Respondida',    color: 'bg-cyan-50' },
-  { id: 'ganada',        nombre: 'Ganada',        color: 'bg-green-50' },
-  { id: 'perdida',       nombre: 'Perdida',       color: 'bg-red-50' },
+  { id: 'prospeccion',     nombre: '🛂 Prospección',     color: 'bg-stone-100', emoji: '🛂' },
+  { id: 'cotizacion',      nombre: '📋 Cotización',      color: 'bg-amber-50',  emoji: '📋' },
+  { id: 'negociando',      nombre: '🤝 Negociando',      color: 'bg-cyan-50',   emoji: '🤝' },
+  { id: 'coord_retiro',    nombre: '🚚 Coord. Retiro',   color: 'bg-blue-50',   emoji: '🚚' },
+  { id: 'retirado',        nombre: '✅ Retirado',        color: 'bg-emerald-50', emoji: '✅' },
+  { id: 'facturar',        nombre: '📄 FACTURAR',        color: 'bg-violet-50', emoji: '📄' },
+  { id: 'cobranza',        nombre: '💸 Cobranza',        color: 'bg-sky-50',    emoji: '💸', rama: 'venta' },
+  { id: 'ganada',          nombre: '🏆 Ganada',          color: 'bg-green-100', emoji: '🏆', rama: 'venta' },
+  { id: 'esperando_pago',  nombre: '⏳ Esperando Pago',  color: 'bg-yellow-50', emoji: '⏳', rama: 'compra' },
+  { id: 'pagado',          nombre: '💰 Pagado',          color: 'bg-lime-100',  emoji: '💰', rama: 'compra' },
+  { id: 'perdida',         nombre: '✗ Perdida',          color: 'bg-red-50',    emoji: '✗' },
 ];
 let _oppDrawerId   = null;
 let _oppDrawerOrig = null;
@@ -9754,10 +9761,11 @@ async function loadOportunidadesKanban() {
   const mostrarCerrados = document.getElementById('oppMostrarCerrados')?.checked ?? false;
   const buscar = (document.getElementById('oppFiltroBuscar')?.value || '').trim();
 
-  let q = sb.schema('curated').from('vw_oportunidades_kanban').select('*').order('fecha_recepcion', { ascending: false });
+  // Capa 1 · usa la vista v2 (11 estados nuevos + flags metadata + rama V/C inferida)
+  let q = sb.schema('panel').from('v_oportunidades_kanban_v2').select('*').order('fecha_recepcion', { ascending: false });
   if (origenFiltro === 'rdo') q = q.neq('origen', 'crm_impulsa');
   else if (origenFiltro === 'crm') q = q.eq('origen', 'crm_impulsa');
-  if (!mostrarCerrados) q = q.not('estado', 'in', '("ganada","perdida","estandarizada","descartada")');
+  if (!mostrarCerrados) q = q.not('estado', 'in', '("ganada","perdida","pagado")');
   if (buscar) {
     const s = buscar.replace(/'/g, "''");
     q = q.or(`titulo.ilike.%${s}%,cliente_nombre.ilike.%${s}%`);
@@ -9799,11 +9807,16 @@ async function loadOportunidadesKanban() {
     porEstado[o.estado].push(o);
   });
 
-  const estadosVisibles = mostrarCerrados ? OPP_ESTADOS : OPP_ESTADOS.filter(e => !['ganada','perdida'].includes(e.id));
+  const estadosVisibles = mostrarCerrados ? OPP_ESTADOS : OPP_ESTADOS.filter(e => !['ganada','perdida','pagado'].includes(e.id));
   const kpisMap = new Map((kpis || []).map(k => [k.estado, k]));
-  const nCols = estadosVisibles.length;
-  const colsCls = nCols <= 4 ? 'xl:grid-cols-4' : 'xl:grid-cols-5';
-  cont.className = `grid grid-cols-1 md:grid-cols-2 ${colsCls} gap-3`;
+  // Capa 2 · layout flex con scroll horizontal para 10 columnas
+  cont.className = 'flex gap-2 overflow-x-auto pb-2 snap-x';
+
+  // Cajón espera factura: tarjetas con metadata.cajon_espera_factura=true se separan dentro de FACTURAR
+  const opsFacturar = porEstado['facturar'] || [];
+  const facturarCajon = opsFacturar.filter(o => o.cajon_espera_factura === true);
+  const facturarMain  = opsFacturar.filter(o => !o.cajon_espera_factura);
+  porEstado['facturar'] = facturarMain;
 
   cont.innerHTML = estadosVisibles.map(e => {
     const k = kpisMap.get(e.id);
@@ -9813,16 +9826,28 @@ async function loadOportunidadesKanban() {
     const visible = todos.slice(0, LIMIT_PER_COL);
     const resto = todos.length - visible.length;
     const cards = visible.map(oppRenderCard).join('');
-    const masBtn = resto > 0 ? `<div class="text-xs text-stone-400 italic py-2 text-center">+${resto.toLocaleString('es-CL')} más — usa búsqueda para filtrar</div>` : '';
+    const masBtn = resto > 0 ? `<div class="text-xs text-stone-400 italic py-2 text-center">+${resto.toLocaleString('es-CL')} más — usa búsqueda</div>` : '';
     const emptyMsg = todos.length === 0 ? '<div class="text-xs text-stone-400 italic py-3 text-center">Sin oportunidades</div>' : '';
+
+    // Sub-zona cajón espera solo en columna FACTURAR
+    const cajonZone = (e.id === 'facturar' && facturarCajon.length > 0) ? `
+      <div class="mt-2 p-2 rounded border border-dashed border-amber-400 bg-amber-50">
+        <div class="text-[10px] font-bold uppercase text-amber-800 mb-1">⏳ Espera factura proveedor (${facturarCajon.length})</div>
+        <div class="space-y-1">${facturarCajon.map(oppRenderCard).join('')}</div>
+      </div>` : '';
+
+    const ramaBorder = e.rama === 'venta' ? 'border-l-4 border-l-sky-400'
+                     : e.rama === 'compra' ? 'border-l-4 border-l-amber-400' : '';
+
     return `
-      <div class="${e.color} rounded-lg p-3 min-h-[200px]"
+      <div class="${e.color} ${ramaBorder} rounded-lg p-2 min-w-[200px] max-w-[230px] flex-shrink-0 snap-start"
            ondragover="event.preventDefault()" ondrop="oppDrop(event,'${e.id}')">
-        <div class="flex justify-between items-baseline mb-2 pb-2 border-b border-stone-200">
-          <h3 class="font-semibold text-stone-800">${escapeHtml(e.nombre)}</h3>
-          <div class="text-xs text-stone-500">${cant.toLocaleString('es-CL')} · ${uf.toLocaleString('es-CL', { maximumFractionDigits: 1 })} UF</div>
+        <div class="flex justify-between items-baseline mb-2 pb-1.5 border-b border-stone-200">
+          <h3 class="font-semibold text-sm text-stone-800 truncate" title="${escapeHtml(e.nombre)}">${escapeHtml(e.nombre)}</h3>
+          <div class="text-[10px] text-stone-500 whitespace-nowrap ml-1">${cant.toLocaleString('es-CL')}${uf>0?' · '+uf.toLocaleString('es-CL',{maximumFractionDigits:1})+' UF':''}</div>
         </div>
-        <div class="space-y-2">${cards}${masBtn}${emptyMsg}</div>
+        <div class="space-y-1.5">${cards}${masBtn}${emptyMsg}</div>
+        ${cajonZone}
       </div>`;
   }).join('');
 }
@@ -9866,6 +9891,46 @@ window.oppDragStart = function(event, oppId, origen) {
   event.dataTransfer.setData('text/plain', oppId);
 };
 
+// Helper · selector DTE para columna FACTURAR (33 venta · 46 compra · SII Chile Res 86/2016)
+function _oppPickDte() {
+  return new Promise(resolve => {
+    const back = document.createElement('div');
+    back.className = 'fixed inset-0 bg-black/50 z-[10000] flex items-center justify-center';
+    back.innerHTML = `
+      <div class="bg-white rounded-xl p-5 max-w-md w-full mx-4 shadow-2xl">
+        <h3 class="text-lg font-bold text-stone-800 mb-1">📄 Tipo de factura SII</h3>
+        <p class="text-sm text-stone-600 mb-4">Esta oportunidad pasa a FACTURAR. ¿Qué DTE corresponde emitir?</p>
+        <div class="space-y-2">
+          <button data-dte="33" class="w-full text-left p-3 rounded-lg border-2 border-sky-200 hover:bg-sky-50 hover:border-sky-400 transition">
+            <div class="font-bold text-sky-700">33 · Factura de Venta</div>
+            <div class="text-xs text-stone-600 mt-0.5">Cliente compra a Reciclean (rama Venta → Cobranza → Ganada)</div>
+          </button>
+          <button data-dte="46" class="w-full text-left p-3 rounded-lg border-2 border-amber-200 hover:bg-amber-50 hover:border-amber-400 transition">
+            <div class="font-bold text-amber-700">46 · Factura de Compra</div>
+            <div class="text-xs text-stone-600 mt-0.5">Reciclean compra a proveedor sin DTE (rama Compra → Esperando Pago → Pagado)</div>
+          </button>
+        </div>
+        <button data-cancel class="mt-4 w-full py-2 text-sm text-stone-500 hover:text-stone-800">Cancelar</button>
+      </div>`;
+    document.body.appendChild(back);
+    back.querySelectorAll('button[data-dte]').forEach(b => {
+      b.addEventListener('click', () => { back.remove(); resolve(b.dataset.dte); });
+    });
+    back.querySelector('button[data-cancel]').addEventListener('click', () => { back.remove(); resolve(null); });
+    back.addEventListener('click', e => { if (e.target === back) { back.remove(); resolve(null); } });
+  });
+}
+
+// Helper para mostrar toast
+function _oppToast(msg, type = 'info') {
+  const colors = { ok: 'bg-green-100 text-green-800', err: 'bg-red-100 text-red-800', info: 'bg-blue-100 text-blue-800', warn: 'bg-amber-100 text-amber-900' };
+  const tmp = document.createElement('div');
+  tmp.className = `fixed top-4 right-4 ${colors[type] || colors.info} text-sm px-4 py-2 rounded shadow-lg z-50 max-w-sm`;
+  tmp.textContent = msg;
+  document.body.appendChild(tmp);
+  setTimeout(() => tmp.remove(), 4000);
+}
+
 window.oppDrop = async function(event, estadoDestino) {
   event.preventDefault();
   const oppId = _oppDragId;
@@ -9874,18 +9939,35 @@ window.oppDrop = async function(event, estadoDestino) {
   if (!oppId) return;
 
   if (origen === 'crm_impulsa') {
-    const tmp = document.createElement('div');
-    tmp.className = 'fixed top-4 right-4 bg-purple-100 text-purple-800 text-sm px-4 py-2 rounded shadow z-50';
-    tmp.textContent = 'CRM Impulsa — solo lectura. El estado no se puede cambiar desde el panel.';
-    document.body.appendChild(tmp);
-    setTimeout(() => tmp.remove(), 3000);
+    _oppToast('CRM Impulsa — solo lectura. El estado no se puede cambiar desde el panel.', 'warn');
     return;
   }
 
-  const { error } = await sb.schema('curated').from('oportunidades')
-    .update({ estado: estadoDestino, updated_by: (currentUser || 'desconocido') })
-    .eq('oportunidad_id', oppId);
-  if (!error) await loadOportunidadesKanban();
+  // Capa 2 · si destino es FACTURAR, pedir DTE (33 venta o 46 compra) antes de mover
+  let dte = null;
+  if (estadoDestino === 'facturar') {
+    dte = await _oppPickDte();
+    if (!dte) return; // canceló
+  }
+
+  // Capa 1 · usa RPC canónica con validaciones de permisos, salto, bifurcación V/C, audit
+  const { data, error } = await sb.rpc('mover_oportunidad', {
+    p_opp_id: oppId,
+    p_nuevo_estado: estadoDestino,
+    p_motivo: 'drag&drop kanban',
+    p_dte_codigo: dte
+  });
+
+  if (error) {
+    _oppToast('Error: ' + error.message, 'err');
+    return;
+  }
+  if (data && data.ok === false) {
+    _oppToast('No se pudo mover: ' + (data.error || 'razón desconocida'), 'err');
+    return;
+  }
+  _oppToast(`Movida a ${estadoDestino}` + (dte ? ` · DTE ${dte}` : ''), 'ok');
+  await loadOportunidadesKanban();
 };
 
 // ── Drawer ───────────────────────────────────────────────────

--- a/public/panel-rdo.html
+++ b/public/panel-rdo.html
@@ -666,6 +666,12 @@
       <details class="v4-cat" open>
         <summary class="v4-cat-h px-3 py-1.5 cursor-pointer text-[10px] font-semibold text-slate-400 uppercase tracking-wider hover:text-slate-600 rounded-md">👥 Gestión</summary>
         <div class="mt-1 space-y-0.5">
+          <!-- Capa 2 · Mi Día (bandeja personal del usuario logueado) -->
+          <a href="#" data-v4-tab="mi_dia" class="nav-item flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm">
+            <span class="v4-emoji" aria-hidden="true">📅</span>
+            Mi Día
+            <span id="miDiaBadge" class="ml-auto bg-amber-500 text-white text-[10px] px-1.5 py-0.5 rounded-full hidden">0</span>
+          </a>
           <a href="#" data-v4-tab="cartera" class="nav-item flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm">
             <span class="v4-emoji" aria-hidden="true">💳</span>
             Cartera
@@ -1076,6 +1082,7 @@
         <button data-tab="andrea_ruts_invalidos" class="tab-btn py-3 px-3 text-stone-600" role="tab" aria-selected="false" aria-controls="tabAndreaRutsInvalidos">🆔 RUTs a verificar</button>
         <button data-tab="andrea_comex" class="tab-btn py-3 px-3 text-stone-600" role="tab" aria-selected="false" aria-controls="tabAndreaComex">🚢 Comex</button>
         <button data-tab="decisor_venta" class="tab-btn py-3 px-3 text-stone-600" role="tab" aria-selected="false" aria-controls="tabDecisorVenta">💰 Decisor venta</button>
+        <button data-tab="mi_dia" class="tab-btn py-3 px-3 text-stone-600" role="tab" aria-selected="false" aria-controls="tabMiDia">📅 Mi Día</button>
         <button data-tab="andrea_cobranza" class="tab-btn py-3 px-3 text-stone-600" role="tab" aria-selected="false" aria-controls="tabAndreaCobranza">💸 Cobranza</button>
         <button data-tab="andrea_actas" class="tab-btn py-3 px-3 text-stone-600" role="tab" aria-selected="false" aria-controls="tabAndreaActas">📝 Actas</button>
         <button data-tab="negocios"   class="tab-btn py-3 px-3 text-stone-600"         role="tab" aria-selected="false" aria-controls="tabNegocios">💼 Negocios</button>
@@ -2131,6 +2138,29 @@
             <button onclick="recCerrarMatchModal()" class="px-3 py-1.5 bg-stone-200 rounded hover:bg-stone-300 text-sm">Cancelar</button>
           </div>
         </div>
+      </div>
+    </section>
+
+    <!-- ═══════════════════════════════════════════════════════════
+         PESTAÑA MI DÍA — Capa 2 · Bandeja personal del usuario
+    ═══════════════════════════════════════════════════════════ -->
+    <section id="tabMiDia" class="tab-content hidden">
+      <div class="flex justify-between items-center mb-4 flex-wrap gap-2">
+        <div>
+          <h2 class="text-xl font-bold text-stone-800">📅 Mi Día</h2>
+          <p class="text-xs text-stone-500 mt-0.5">Tus oportunidades estancadas y visitas de hoy · Capa 1 Embudo Comercial</p>
+        </div>
+        <button onclick="loadMiDia()" class="text-sm text-green-700 hover:underline">↺ Recargar</button>
+      </div>
+      <!-- KPIs Mi Día -->
+      <div id="miDiaKpis" class="grid grid-cols-2 md:grid-cols-4 gap-3 mb-4"></div>
+      <!-- Lista de items pendientes -->
+      <div id="miDiaItems" class="space-y-2">
+        <div class="skeleton" aria-busy="true"></div>
+      </div>
+      <!-- Empty state -->
+      <div id="miDiaEmpty" class="hidden p-8 text-center text-stone-500 text-sm bg-white rounded-lg border border-stone-200">
+        🎉 Tu bandeja está al día. No hay oportunidades estancadas ni visitas agendadas para hoy.
       </div>
     </section>
 
@@ -5802,6 +5832,7 @@ function setupTabs() {
       if (tabId === 'reconciliacion') initReconciliacion();
       if (tabId === 'cartera')   initCartera();
       if (tabId === 'oportunidades') initOportunidadesKanban();
+      if (tabId === 'mi_dia')    loadMiDia();
       if (tabId === 'entregables') initEntregables();
       if (tabId === 'bandeja_dieg') initBandejaDiego();
       if (tabId === 'bandeja_precios') initBandejaPrecios();
@@ -9750,6 +9781,78 @@ async function initOportunidadesKanban() {
     _oppSucursalesMap = new Map((sucs || []).map(s => [s.sucursal_id, s.nombre]));
   }
   await loadOportunidadesKanban();
+}
+
+// Capa 2 · Mi Día · bandeja personal del usuario logueado (panel.v_mi_dia)
+async function loadMiDia() {
+  const cont   = document.getElementById('miDiaItems');
+  const empty  = document.getElementById('miDiaEmpty');
+  const kpis   = document.getElementById('miDiaKpis');
+  const badge  = document.getElementById('miDiaBadge');
+  if (!cont) return;
+
+  cont.innerHTML = '<div class="skeleton" aria-busy="true"></div>';
+  empty?.classList.add('hidden');
+
+  const { data, error } = await sb.schema('panel').from('v_mi_dia').select('*');
+  if (error) {
+    cont.innerHTML = `<div class="text-red-600">Error: ${escapeHtml(error.message)}</div>`;
+    return;
+  }
+  const items = data || [];
+
+  // KPIs por tipo
+  const nOpps    = items.filter(i => i.tipo === 'opp_pendiente').length;
+  const nVisitas = items.filter(i => i.tipo === 'visita_hoy').length;
+  const nUrgentes = items.filter(i => Number(i.dias) > 7).length;
+  if (kpis) {
+    kpis.innerHTML = `
+      <div class="bg-amber-50 border border-amber-200 rounded-lg p-3 text-center">
+        <div class="text-2xl font-bold text-amber-700">${nOpps}</div>
+        <div class="text-xs text-amber-800">Opps estancadas</div>
+      </div>
+      <div class="bg-blue-50 border border-blue-200 rounded-lg p-3 text-center">
+        <div class="text-2xl font-bold text-blue-700">${nVisitas}</div>
+        <div class="text-xs text-blue-800">Visitas hoy</div>
+      </div>
+      <div class="bg-red-50 border border-red-200 rounded-lg p-3 text-center">
+        <div class="text-2xl font-bold text-red-700">${nUrgentes}</div>
+        <div class="text-xs text-red-800">+7 días sin tocar</div>
+      </div>
+      <div class="bg-green-50 border border-green-200 rounded-lg p-3 text-center">
+        <div class="text-2xl font-bold text-green-700">${items.length}</div>
+        <div class="text-xs text-green-800">Total pendientes</div>
+      </div>`;
+  }
+
+  // Badge sidebar
+  if (badge) {
+    if (items.length > 0) { badge.textContent = items.length; badge.classList.remove('hidden'); }
+    else                  { badge.classList.add('hidden'); }
+  }
+
+  if (items.length === 0) {
+    cont.innerHTML = '';
+    empty?.classList.remove('hidden');
+    return;
+  }
+
+  cont.innerHTML = items.map(i => {
+    const icon = i.tipo === 'opp_pendiente' ? '🎯' : '📅';
+    const urgClass = Number(i.dias) > 7 ? 'border-l-red-500 bg-red-50' : 'border-l-amber-400 bg-white';
+    const dias = i.tipo === 'opp_pendiente' ? `${Math.floor(Number(i.dias||0))}d sin tocar` : '';
+    const click = i.tipo === 'opp_pendiente' ? `onclick="oppAbrirDrawer('${escapeHtml(i.ref_id)}')"` : '';
+    return `
+      <div class="${urgClass} border-l-4 rounded-lg p-3 shadow-sm hover:shadow-md transition cursor-pointer" ${click}>
+        <div class="flex justify-between items-start gap-3">
+          <div class="flex-1 min-w-0">
+            <div class="font-semibold text-stone-800 text-sm">${icon} ${escapeHtml(i.titulo || '—')}</div>
+            <div class="text-xs text-stone-600 mt-0.5">Estado: <strong>${escapeHtml(i.detalle || '')}</strong></div>
+          </div>
+          <div class="text-xs text-stone-500 whitespace-nowrap">${dias}</div>
+        </div>
+      </div>`;
+  }).join('');
 }
 
 async function loadOportunidadesKanban() {


### PR DESCRIPTION
## Resumen

Frontend de la **Capa 2 del Embudo Comercial Antifrágil**. Conecta el panel-rdo con el backend de Capa 1 firmado por Dusan el 12-jun-2026.

### Cambios en `public/panel-rdo.html`

**Kanban Oportunidades**
- `OPP_ESTADOS`: 7 estados viejos → **11 estados canónicos** (prospeccion, cotizacion, negociando, coord_retiro, retirado, facturar, cobranza, ganada, esperando_pago, pagado, perdida) con emojis y campo \`rama\` (venta/compra) para colorear bordes.
- Layout: \`grid 4 cols\` → \`flex horizontal scrollable\` con \`min-width: 200px\` por columna.
- Fuente datos: \`curated.vw_oportunidades_kanban\` → \`panel.v_oportunidades_kanban_v2\` (incluye flags de metadata jsonb).
- **Cajón espera factura**: sub-zona dentro de FACTURAR para opps con \`metadata.cajon_espera_factura=true\`.
- **Bordes de rama**: sky (venta) y amber (compra) sobre las columnas post-FACTURAR.

**Drag & drop**
- Reemplaza UPDATE directo por la RPC canónica \`public.mover_oportunidad\` con audit en \`panel.opp_seguimiento\`.
- **Modal selector DTE** al arrastrar a FACTURAR: 33 (Factura Venta) o 46 (Factura Compra) según SII Res 86/2016.
- Toast claro con motivo de OK / rechazo.

**Sidebar silo Comercial**
- De **18 → 6 entradas** vía DELETE en \`panel.silo_pestanas\` (13 pestañas huérfanas eliminadas: facturacion, facturacion_grupo, herramientas_ext, negocios, reconciliacion, entregables, bandeja_precios, mis_visitas, decisor_venta, 3 bandejas CU, comex).
- Nueva: 📅 **Mi Día** con badge dinámico contador.

**Tab Mi Día**
- KPIs: Opps estancadas, Visitas hoy, +7d sin tocar, total pendientes.
- Lista con click → drawer de oportunidad existente.
- Empty state amigable.
- Fuente: \`panel.v_mi_dia\` (filtrada por JWT del usuario).

## Backend dependencias (ya en producción · firma Dusan 12-jun-2026)

- ALTER CHECK constraint \`oportunidades_estado_check\` (11 estados)
- UPDATE migración 10.256 opps
- RPC \`public.mover_oportunidad\` (11 validaciones + bifurcación V/C por DTE)
- Trigger \`trg_pesaje_a_oportunidad\` (vales → opps automático)
- Tabla \`panel.opp_seguimiento\` (audit log)
- Vista \`panel.v_oportunidades_kanban_v2\`, \`v_mi_dia\`, \`v_dashboard_anomalias\`
- Bucket Storage \`opp-files\` (privado)

## Test plan

- [ ] Andrea entra al silo Comercial y ve 6 tabs (Mi Día + Cartera + Oportunidades + Cotizador + Cobranza + Actas)
- [ ] Kanban Oportunidades muestra las 9 columnas activas (sin ganada/perdida/pagado por default)
- [ ] Drag de tarjeta a FACTURAR abre modal DTE 33/46
- [ ] Drop a Esperando Pago sin DTE 46 → toast de rechazo claro
- [ ] Click en Mi Día con bandeja vacía → empty state
- [ ] Badge contador en sidebar refleja items pendientes
- [ ] Cajón espera factura aparece como sub-zona en FACTURAR cuando hay opps con flag
- [ ] No-Andrea (Dusan) sigue viendo el selector "Ver como X" y todas las opps

## Pendiente para sub-PR siguiente (Capa 2b)

- Drawer extendido: secciones de archivos (panel.opp_archivos) + historial (panel.opp_seguimiento) + botones bifurcación V/C manual.
- Filtros "Mías / Mi sucursal / Todo el silo" (reemplazo de origen+embudo).
- Subida real de archivos al bucket opp-files.
- Fix del bug preexistente \`tg_negocios_notif_descartar_viejas\` (usa \`o.id\` cuando es \`oportunidad_id\`) → requiere firma Dusan, paquete aparte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)