### PR TITLE
Capa 2b · Drawer extendido + filtros owner + bucket archivos

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "vite": "^8.0.3"
       },
       "devDependencies": {
+        "@playwright/test": "^1.48.0",
         "tailwindcss": "^3.4.17"
       }
     },
@@ -164,6 +165,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -1337,6 +1354,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/public/panel-rdo.html
+++ b/public/panel-rdo.html
@@ -2596,8 +2596,18 @@
         </div>
       </div>
 
-      <!-- Filtros Kanban — origen CRM/RDO + cerrados + búsqueda -->
+      <!-- Filtros Kanban — alcance owner + origen + cerrados + búsqueda -->
       <div class="bg-white p-3 rounded shadow-sm mb-4 flex flex-wrap gap-3 items-end">
+        <!-- Capa 2b · filtro alcance "Mías / Mi sucursal / Todo el silo" -->
+        <div>
+          <label for="oppFiltroAlcance" class="block text-xs text-stone-500 mb-1">Mostrar</label>
+          <select id="oppFiltroAlcance" onchange="loadOportunidadesKanban()"
+                  class="border border-stone-300 rounded px-2 py-1.5 text-sm focus:border-green-700 focus:outline-none">
+            <option value="mias">👤 Mías</option>
+            <option value="sucursal">🏢 Mi sucursal</option>
+            <option value="todo" selected>🌐 Todo el silo</option>
+          </select>
+        </div>
         <div>
           <label for="oppFiltroOrigen" class="block text-xs text-stone-500 mb-1">Origen</label>
           <select id="oppFiltroOrigen" onchange="loadOportunidadesKanban()"
@@ -2664,16 +2674,23 @@
             <div class="text-xs text-stone-500 mb-1">Estado actual</div>
             <div id="oppDrawerEstadoActual" class="font-medium text-stone-800 mb-2">—</div>
             <label for="oppDrawerEstadoSelect" class="block text-xs text-stone-500 mb-1">Cambiar a:</label>
+            <!-- Capa 2b · 11 estados nuevos del Embudo Comercial Antifrágil -->
             <select id="oppDrawerEstadoSelect"
                     class="w-full border border-stone-300 rounded px-2 py-1.5 text-sm focus:border-green-700 focus:outline-none mb-2">
-              <option value="recibida">Recibida</option>
-              <option value="en_evaluacion">En evaluación</option>
-              <option value="activada">Activada</option>
-              <option value="monitoreo">Monitoreo</option>
-              <option value="respondida">Respondida</option>
-              <option value="ganada">Ganada</option>
-              <option value="perdida">Perdida</option>
+              <option value="prospeccion">🛂 Prospección</option>
+              <option value="cotizacion">📋 Cotización</option>
+              <option value="negociando">🤝 Negociando</option>
+              <option value="coord_retiro">🚚 Coord. Retiro</option>
+              <option value="retirado">✅ Retirado</option>
+              <option value="facturar">📄 FACTURAR (elige DTE)</option>
+              <option value="cobranza">💸 Cobranza (rama venta)</option>
+              <option value="ganada">🏆 Ganada</option>
+              <option value="esperando_pago">⏳ Esperando Pago (rama compra)</option>
+              <option value="pagado">💰 Pagado</option>
+              <option value="perdida">✗ Perdida</option>
             </select>
+            <!-- Bifurcación V/C visible cuando ya hay DTE asignado -->
+            <div id="oppDrawerDteBadge" class="hidden mb-2 text-xs px-2 py-1 rounded"></div>
             <button id="oppDrawerMoverBtn" onclick="oppMoverEstado()"
                     class="w-full bg-green-700 hover:bg-green-800 text-white text-sm py-1.5 rounded">
               Mover
@@ -2711,10 +2728,23 @@
             </dl>
           </div>
 
-          <!-- Adjuntos -->
-          <div id="oppDrawerAdjuntosSection" class="hidden mt-4 pt-3 border-t border-stone-200">
-            <div class="text-xs font-semibold text-stone-600 mb-2">Documentos adjuntos</div>
-            <div id="oppDrawerAdjuntos" class="space-y-1 text-sm text-stone-600"></div>
+          <!-- Adjuntos (Capa 2b · panel.opp_archivos + bucket opp-files) -->
+          <div class="mt-4 pt-3 border-t border-stone-200">
+            <div class="flex justify-between items-center mb-2">
+              <div class="text-xs font-semibold text-stone-700">📎 Documentos adjuntos</div>
+              <label class="text-xs text-green-700 hover:underline cursor-pointer">
+                <input type="file" id="oppDrawerSubirInput" class="hidden" onchange="oppSubirArchivo(event)">
+                ⬆ Subir
+              </label>
+            </div>
+            <div id="oppDrawerAdjuntos" class="space-y-1 text-xs text-stone-600">—</div>
+            <div id="oppDrawerSubirMsg" class="hidden mt-1 text-xs"></div>
+          </div>
+
+          <!-- Historial movimientos (Capa 2b · panel.opp_seguimiento) -->
+          <div class="mt-4 pt-3 border-t border-stone-200">
+            <div class="text-xs font-semibold text-stone-700 mb-2">📜 Historial de movimientos</div>
+            <div id="oppDrawerAudit" class="space-y-1 text-xs text-stone-600 max-h-48 overflow-y-auto">—</div>
           </div>
         </div>
       </div>
@@ -5249,6 +5279,11 @@ async function hydrateSessionAndEnter(authUser) {
   currentUser = data.email;
   currentProfile = data.perfil;
   console.log('[Panel RDO] Login OK:', { email: currentUser, profile: currentProfile });
+  // Capa 2b · cachear sucursal_id del usuario para filtro "Mi sucursal" del kanban
+  try {
+    const { data: dot } = await sb.schema('panel').from('dotacion').select('sucursal').eq('email', currentUser).maybeSingle();
+    window._miSucursalId = dot?.sucursal || null;
+  } catch(_) { window._miSucursalId = null; }
   if (typeof window.pageLog === 'function') window.pageLog('login', null, { perfil: currentProfile });
   // BUG#5 fix: flush logs encolados pre-login (page-logger.js los encoló porque no había user)
   if (typeof window.pageLogFlushPending === 'function') window.pageLogFlushPending();
@@ -9863,12 +9898,22 @@ async function loadOportunidadesKanban() {
   const embudoFiltro    = document.getElementById('oppFiltroEmbudo')?.value ?? '';
   const mostrarCerrados = document.getElementById('oppMostrarCerrados')?.checked ?? false;
   const buscar = (document.getElementById('oppFiltroBuscar')?.value || '').trim();
+  // Capa 2b · filtro alcance owner (mias / sucursal / todo)
+  const alcanceFiltro = document.getElementById('oppFiltroAlcance')?.value ?? 'todo';
 
   // Capa 1 · usa la vista v2 (11 estados nuevos + flags metadata + rama V/C inferida)
   let q = sb.schema('panel').from('v_oportunidades_kanban_v2').select('*').order('fecha_recepcion', { ascending: false });
   if (origenFiltro === 'rdo') q = q.neq('origen', 'crm_impulsa');
   else if (origenFiltro === 'crm') q = q.eq('origen', 'crm_impulsa');
   if (!mostrarCerrados) q = q.not('estado', 'in', '("ganada","perdida","pagado")');
+
+  // Capa 2b · filtro por responsable o por sucursal del usuario logueado
+  if (alcanceFiltro === 'mias' && typeof currentUser === 'string' && currentUser) {
+    q = q.eq('responsable', currentUser);
+  } else if (alcanceFiltro === 'sucursal') {
+    const miSuc = window._miSucursalId;
+    if (miSuc) q = q.eq('sucursal_id', miSuc);
+  }
   if (buscar) {
     const s = buscar.replace(/'/g, "''");
     q = q.or(`titulo.ilike.%${s}%,cliente_nombre.ilike.%${s}%`);
@@ -10087,7 +10132,7 @@ window.oppAbrirDrawer = async function(oppId) {
   resetIds.forEach(id => { const el = document.getElementById(id); if (el) el.textContent = '—'; });
   document.getElementById('oppDrawerTags').innerHTML = '';
 
-  const { data: o, error } = await sb.schema('curated').from('vw_oportunidades_kanban').select('*').eq('oportunidad_id', oppId).maybeSingle();
+  const { data: o, error } = await sb.schema('panel').from('v_oportunidades_kanban_v2').select('*').eq('oportunidad_id', oppId).maybeSingle();
   if (error || !o) {
     document.getElementById('oppDrawerTitulo').textContent = 'Error cargando oportunidad';
     return;
@@ -10145,23 +10190,122 @@ window.oppAbrirDrawer = async function(oppId) {
     } else { razonRow.classList.add('hidden'); }
   } else if (impulsaSection) { impulsaSection.classList.add('hidden'); }
 
-  const adjSection = document.getElementById('oppDrawerAdjuntosSection');
+  // Capa 2b · Badge DTE bifurcación V/C
+  const dteBadge = document.getElementById('oppDrawerDteBadge');
+  if (dteBadge) {
+    if (o.dte_codigo === '33') {
+      dteBadge.className = 'mb-2 text-xs px-2 py-1 rounded bg-sky-100 text-sky-800 font-semibold';
+      dteBadge.textContent = '🌊 Rama VENTA · DTE 33 emitido';
+      dteBadge.classList.remove('hidden');
+    } else if (o.dte_codigo === '46') {
+      dteBadge.className = 'mb-2 text-xs px-2 py-1 rounded bg-amber-100 text-amber-900 font-semibold';
+      dteBadge.textContent = '🏭 Rama COMPRA · DTE 46 emitido (cambio de sujeto IVA)';
+      dteBadge.classList.remove('hidden');
+    } else {
+      dteBadge.classList.add('hidden');
+    }
+  }
+
+  // Capa 2b · Adjuntos canónicos (panel.opp_archivos) — histórico Impulsa + nuevos
   const adjDiv = document.getElementById('oppDrawerAdjuntos');
-  if (o.external_crm_id && adjSection && adjDiv) {
-    const { data: adjs } = await sb.schema('curated').from('oportunidades_adjuntos')
-      .select('nombre_archivo, extension, ruta_local')
-      .eq('external_crm_id', o.external_crm_id)
-      .limit(50);
+  if (adjDiv) {
+    let q = sb.schema('panel').from('opp_archivos').select('*');
+    if (o.cliente_id) {
+      q = q.or(`oportunidad_id.eq.${oppId},cliente_id.eq.${escapeHtml(o.cliente_id)}`);
+    } else {
+      q = q.eq('oportunidad_id', oppId);
+    }
+    const { data: adjs } = await q.order('fecha_subida', { ascending: false }).limit(50);
     if (adjs && adjs.length > 0) {
-      adjSection.classList.remove('hidden');
-      adjDiv.innerHTML = adjs.map(a =>
-        `<div class="flex items-center gap-2 text-xs text-stone-600 py-0.5">
-          <span class="text-stone-400">${escapeHtml(a.extension || '📄')}</span>
-          <span class="truncate">${escapeHtml(a.nombre_archivo)}</span>
-        </div>`
-      ).join('');
-    } else { adjSection.classList.add('hidden'); }
-  } else if (adjSection) { adjSection.classList.add('hidden'); }
+      adjDiv.innerHTML = adjs.map(a => {
+        const ts = a.fecha_subida ? new Date(a.fecha_subida).toLocaleDateString('es-CL') : '';
+        const badge = a.origen === 'impulsa'
+          ? '<span class="text-[10px] px-1 bg-purple-100 text-purple-700 rounded">Impulsa</span>'
+          : '<span class="text-[10px] px-1 bg-green-100 text-green-700 rounded">Nuevo</span>';
+        return `<div class="flex items-center justify-between gap-2 py-1 border-b border-stone-100">
+          <div class="flex items-center gap-2 min-w-0 flex-1">
+            <span>📄</span>
+            <span class="truncate" title="${escapeHtml(a.nombre)}">${escapeHtml(a.nombre || a.archivo_path)}</span>
+          </div>
+          <div class="flex items-center gap-1 whitespace-nowrap">
+            ${badge}
+            <span class="text-[10px] text-stone-400">${ts}</span>
+          </div>
+        </div>`;
+      }).join('');
+    } else {
+      adjDiv.innerHTML = '<div class="text-stone-400 italic">Sin archivos aún</div>';
+    }
+  }
+
+  // Capa 2b · Historial de movimientos (panel.opp_seguimiento)
+  const auditDiv = document.getElementById('oppDrawerAudit');
+  if (auditDiv && !esCrm) {
+    const { data: hist } = await sb.schema('panel').from('opp_seguimiento')
+      .select('*').eq('oportunidad_id', oppId).order('creado_en', { ascending: false }).limit(20);
+    if (hist && hist.length > 0) {
+      auditDiv.innerHTML = hist.map(h => {
+        const ts = h.creado_en ? new Date(h.creado_en).toLocaleString('es-CL') : '';
+        const okIcon = h.resultado === 'ok' ? '✓' : '✗';
+        const okColor = h.resultado === 'ok' ? 'text-green-700' : 'text-red-600';
+        const dte = h.dte_codigo ? ` · DTE ${h.dte_codigo}` : '';
+        return `<div class="flex items-start gap-2 py-1 border-b border-stone-100">
+          <span class="${okColor} font-mono">${okIcon}</span>
+          <div class="flex-1 min-w-0">
+            <div><strong>${escapeHtml(h.estado_anterior || '—')}</strong> → <strong>${escapeHtml(h.estado_nuevo)}</strong>${dte}</div>
+            <div class="text-[10px] text-stone-500">${ts} · ${escapeHtml(h.actor || '')}</div>
+            ${h.motivo ? `<div class="text-[10px] text-stone-600 italic">${escapeHtml(h.motivo)}</div>` : ''}
+          </div>
+        </div>`;
+      }).join('');
+    } else {
+      auditDiv.innerHTML = '<div class="text-stone-400 italic">Sin movimientos registrados aún</div>';
+    }
+  } else if (auditDiv) {
+    auditDiv.innerHTML = '<div class="text-stone-400 italic">CRM Impulsa · sin audit local</div>';
+  }
+};
+
+// Capa 2b · Subida real al bucket opp-files
+window.oppSubirArchivo = async function(event) {
+  const file = event.target.files?.[0];
+  if (!file || !_oppDrawerId) return;
+  const msg = document.getElementById('oppDrawerSubirMsg');
+  msg.className = 'mt-1 text-xs text-blue-700';
+  msg.textContent = `Subiendo ${file.name}…`;
+  msg.classList.remove('hidden');
+
+  const path = `${_oppDrawerId}/${Date.now()}_${file.name}`;
+  const up = await sb.storage.from('opp-files').upload(path, file, { upsert: false });
+  if (up.error) {
+    msg.className = 'mt-1 text-xs text-red-700';
+    msg.textContent = 'Error: ' + up.error.message;
+    return;
+  }
+
+  // Registrar en panel.opp_archivos
+  const cli = document.getElementById('oppDrawerCliente')?.dataset?.cliId || null;
+  const ins = await sb.schema('panel').from('opp_archivos').insert({
+    oportunidad_id: _oppDrawerId,
+    cliente_id: cli,
+    archivo_path: path,
+    nombre: file.name,
+    tipo: file.type || (file.name.split('.').pop() || ''),
+    tamano_bytes: file.size,
+    origen: 'nuevo',
+    bucket: 'opp-files',
+    subido_por: (typeof currentUser === 'string' ? currentUser : null)
+  });
+  if (ins.error) {
+    msg.className = 'mt-1 text-xs text-amber-700';
+    msg.textContent = 'Subido al bucket pero error al registrar: ' + ins.error.message;
+    return;
+  }
+  msg.className = 'mt-1 text-xs text-green-700';
+  msg.textContent = `✓ ${file.name} subido`;
+  event.target.value = '';
+  // Recargar adjuntos
+  if (_oppDrawerId) await oppAbrirDrawer(_oppDrawerId);
 };
 
 window.oppCerrarDrawer = function() {
@@ -10178,11 +10322,21 @@ window.oppMoverEstado = async function() {
   const msg = document.getElementById('oppDrawerMsg');
   const btn = document.getElementById('oppDrawerMoverBtn');
   msg.classList.add('hidden');
-  btn.disabled = true; btn.textContent = 'Moviendo…';
 
-  const { error } = await sb.schema('curated').from('oportunidades')
-    .update({ estado: nuevoEstado, updated_by: (currentUser || 'desconocido') })
-    .eq('oportunidad_id', _oppDrawerId);
+  // Capa 2b · pasar por RPC canónica con DTE selector en FACTURAR
+  let dte = null;
+  if (nuevoEstado === 'facturar' && typeof _oppPickDte === 'function') {
+    dte = await _oppPickDte();
+    if (!dte) return;
+  }
+
+  btn.disabled = true; btn.textContent = 'Moviendo…';
+  const { data, error } = await sb.rpc('mover_oportunidad', {
+    p_opp_id: _oppDrawerId,
+    p_nuevo_estado: nuevoEstado,
+    p_motivo: 'drawer manual',
+    p_dte_codigo: dte
+  });
   btn.disabled = false; btn.textContent = 'Mover';
 
   if (error) {
@@ -10191,8 +10345,14 @@ window.oppMoverEstado = async function() {
     msg.classList.remove('hidden');
     return;
   }
+  if (data && data.ok === false) {
+    msg.className = 'mt-2 text-xs p-2 rounded bg-red-50 text-red-700';
+    msg.textContent = 'Rechazado: ' + (data.error || '');
+    msg.classList.remove('hidden');
+    return;
+  }
   msg.className = 'mt-2 text-xs p-2 rounded bg-green-50 text-green-700';
-  msg.textContent = 'Estado actualizado.';
+  msg.textContent = `Estado actualizado a ${nuevoEstado}` + (dte ? ` · DTE ${dte}` : '');
   msg.classList.remove('hidden');
   await loadOportunidadesKanban();
   if (_oppDrawerId) await oppAbrirDrawer(_oppDrawerId);


### PR DESCRIPTION
## Resumen

Capa 2b del Embudo Comercial Antifrágil. Construye sobre Capa 2 (PR #277).

### Drawer de oportunidad ampliado
- Selector estado actualizado a los 11 estados nuevos del embudo.
- \`oppMoverEstado\`: pasa por RPC \`mover_oportunidad\` (audit + validación + bifurcación V/C).
- Modal DTE 33/46 al elegir FACTURAR desde el selector.
- Badge bifurcación V/C visible: sky (33 venta) / amber (46 compra).
- **Sección Documentos**: lee \`panel.opp_archivos\` con badges Impulsa/Nuevo + botón ⬆ Subir.
- **Sección Historial**: lee \`panel.opp_seguimiento\` con los últimos 20 movimientos (anterior → nuevo, DTE, actor, motivo, resultado).

### Subida real de archivos
- Bucket \`opp-files\` con estructura \`{opp_id}/{timestamp}_nombre\`.
- INSERT automático en \`panel.opp_archivos\` con origen='nuevo'.
- Recarga del drawer al terminar.

### Filtros kanban nuevo selector \"Mostrar\"
- 👤 **Mías**: filtra por \`responsable = currentUser\`.
- 🏢 **Mi sucursal**: filtra por \`sucursal_id\` del usuario (cacheado en login desde \`panel.dotacion.sucursal\`).
- 🌐 **Todo el silo** (default).

## Dependencias backend (ya en producción)
- \`panel.opp_archivos\` (Capa 1)
- \`panel.opp_seguimiento\` (Capa 1)
- \`public.mover_oportunidad\` (Capa 1)
- Bucket Storage \`opp-files\` (Capa 1)

## Pendiente para sub-PR siguiente
- Fix del bug preexistente \`tg_negocios_notif_descartar_viejas\` (paquete SQL aparte para firma Dusan)

## Test plan
- [ ] Abrir drawer de opp → ver badge DTE si está bifurcada
- [ ] Documentos: para opp de un cliente con histórico Impulsa, ver archivos badge violeta
- [ ] Subir archivo → bucket privado lo acepta, aparece en lista
- [ ] Historial: ver los movimientos del smoke 20/20 + drawer manual
- [ ] Filtro \"Mías\" (Andrea): solo las suyas
- [ ] Filtro \"Mi sucursal\": las de su sucursal
- [ ] Selector estado → mover a FACTURAR abre modal DTE
- [ ] Rechazo legible: mover a esperando_pago sin DTE 46 → toast claro

🤖 Generated with [Claude Code](https://claude.com/claude-code)