### PR TITLE
ui(shadow-trend): sparkline SHADOW v12 en Mesa Control · widget N

### DIFF
--- a/public/panel-rdo.html
+++ b/public/panel-rdo.html
@@ -4017,6 +4017,15 @@
         <div class="bg-white border border-amber-200 rounded p-3 cursor-pointer hover:border-emerald-300" data-mc-drill="firmas_reglas"><div class="text-[10px] text-amber-700 uppercase">Firmas pend</div><div class="text-lg font-semibold mt-1 text-amber-700" id="mcFirmasPend">—</div></div>
       </div>
 
+      <div class="bg-white border border-stone-200 rounded p-3 mb-4">
+        <div class="flex items-center justify-between mb-2">
+          <h3 class="text-sm font-semibold text-stone-700">📈 Trend SHADOW v12 · % sentenciadas</h3>
+          <span class="text-[10px] text-stone-400" id="mcTrendInfo">—</span>
+        </div>
+        <svg id="mcTrendSparkline" viewBox="0 0 600 80" preserveAspectRatio="none" class="w-full h-20" style="background:#fafaf5;border-radius:3px"></svg>
+        <div class="text-[10px] text-stone-400 mt-1">Min/Max últimas N corridas · meta SPEC 70% sentenciadas</div>
+      </div>
+
       <h3 class="text-sm font-semibold text-stone-700 mb-2">👥 Score individual por PC (SHADOW v12)</h3>
       <div class="bg-white border border-stone-200 rounded overflow-hidden mb-4">
         <table class="w-full text-xs">
@@ -16641,6 +16650,40 @@ document.addEventListener('DOMContentLoaded', () => {
       setText('mcShadowVerdes', (k.shadow_v12_verdes != null ? k.shadow_v12_verdes + ' (' + (k.shadow_v12_pct_sentenciadas || 0) + '%)' : '—'));
       setText('mcShadowFalsas', (k.shadow_v12_falsas != null ? k.shadow_v12_falsas : '—'));
       setText('mcFirmasPend', (k.firmas_pendientes_panel_alt3 != null ? k.firmas_pendientes_panel_alt3 : '—'));
+      // Trend SHADOW v12 sparkline (consume RPC public.shadow_v12_trend)
+      try {
+        var rTrend = await fetch(SUPA + '/rest/v1/rpc/shadow_v12_trend', { method: 'POST', headers: headers, body: JSON.stringify({ p_horas: 24 }) });
+        var trend = await rTrend.json();
+        if (Array.isArray(trend) && trend.length >= 2) {
+          var svg = document.getElementById('mcTrendSparkline');
+          if (svg) {
+            var W = 600, H = 80, P = 4;
+            var pcts = trend.map(function(p) { return parseFloat(p.pct) || 0; });
+            var minP = Math.min.apply(null, pcts), maxP = Math.max.apply(null, pcts);
+            var rangeP = Math.max(maxP - minP, 1);
+            var step = (W - 2*P) / Math.max(trend.length - 1, 1);
+            var pts = trend.map(function(p, i) {
+              var x = P + i * step;
+              var y = P + (H - 2*P) * (1 - (parseFloat(p.pct) - minP) / rangeP);
+              return x + ',' + y;
+            }).join(' ');
+            var dotsHtml = trend.map(function(p, i) {
+              var x = P + i * step;
+              var y = P + (H - 2*P) * (1 - (parseFloat(p.pct) - minP) / rangeP);
+              var color = parseFloat(p.pct) === maxP ? '#059669' : parseFloat(p.pct) === minP ? '#dc2626' : '#78716c';
+              return '<circle cx="' + x.toFixed(1) + '" cy="' + y.toFixed(1) + '" r="2.5" fill="' + color + '"><title>' + (p.version || '') + ': ' + p.pct + '% (' + p.verdes + ' verdes / ' + p.rojas + ' falsas)</title></circle>';
+            }).join('');
+            var metaY = P + (H - 2*P) * (1 - (70 - minP) / rangeP);
+            var metaLine = (70 >= minP && 70 <= maxP) ? '<line x1="' + P + '" y1="' + metaY + '" x2="' + (W - P) + '" y2="' + metaY + '" stroke="#d97706" stroke-dasharray="3,3" stroke-width="0.5"><title>Meta SPEC 70%</title></line>' : '';
+            svg.innerHTML = metaLine
+              + '<polyline points="' + pts + '" fill="none" stroke="#059669" stroke-width="1.5"></polyline>'
+              + dotsHtml;
+            setText('mcTrendInfo', trend.length + ' puntos · ' + minP.toFixed(1) + '% → ' + maxP.toFixed(1) + '%');
+          }
+        } else {
+          setText('mcTrendInfo', 'esperando 2+ snapshots');
+        }
+      } catch (errT) { /* silent */ }
       // Widget H · Score por PC
       var pcRows = (Array.isArray(pcScore) ? pcScore : []).map(function(pc) {
         var pctFalso = parseFloat(pc.shadow_pct_falso_real) || 0;


### PR DESCRIPTION
## Sparkline SVG inline en Mesa Control

Trend del % sentenciadas SHADOW v12 mostrado como gráfico SVG inline (sin librerías externas).

## Componentes
- SVG 600x80 viewbox preserveAspectRatio
- Polyline con auto-scale min/max sobre los datos
- Dots con tooltip: version + verdes + falsas
- Línea dashed amber para meta SPEC 70%

## Backend
RPC `public.shadow_v12_trend(p_horas DEFAULT 12)` devuelve JSON array de puntos desde `panel.shadow_v12_snapshots`.

11 snapshots históricos del día ya cargados (v12.0 → v12.9).

## Smokes
- R-AUD-064 parse JS pass
- Vercel preview deploy pendiente

🤖 Generated with [Claude Code](https://claude.com/claude-code)